### PR TITLE
fix(emails): fix code display and redesign all email templates

### DIFF
--- a/templates/emails/_base.html.twig
+++ b/templates/emails/_base.html.twig
@@ -19,7 +19,6 @@
 </head>
 <body style="margin:0;padding:0;background-color:#f0f0f0;font-family:Arial,Helvetica,sans-serif;-webkit-font-smoothing:antialiased;">
 
-    <!-- Pre-header invisible text -->
     <div style="display:none;max-height:0;overflow:hidden;mso-hide:all;font-size:1px;color:#f0f0f0;line-height:1px;">
         {% block preheader %}{% endblock %}&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;
     </div>
@@ -29,20 +28,20 @@
             <td align="center" style="padding:32px 10px;">
                 <!--[if mso]><table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" align="center"><tr><td><![endif]-->
                 <table role="presentation" class="email-container" width="600" cellpadding="0" cellspacing="0" border="0"
-                       style="background-color:#ffffff;max-width:600px;width:100%;border-collapse:collapse;">
+                       style="background-color:#ffffff;max-width:600px;width:100%;border-collapse:collapse;border-radius:8px;overflow:hidden;">
 
-                    <!-- TOP ACCENT STRIP -->
+                    <!-- DARK HEADER -->
                     <tr>
-                        <td style="background-color:{% block accent_color %}#AF0101{% endblock %};height:5px;font-size:1px;line-height:5px;">&nbsp;</td>
+                        <td align="center" style="background-color:#1e2a3a;padding:18px 40px;">
+                            {% block brand_header %}{% endblock %}
+                        </td>
                     </tr>
 
                     <!-- LOGO AREA -->
-                    <tr>
-                        <td align="center" class="mob-pad"
-                            style="padding:28px 40px 24px 40px;background-color:#ffffff;border-bottom:1px solid #ebebeb;">
-                            {% block logo %}{% endblock %}
-                        </td>
-                    </tr>
+                    {% block logo_area %}{% endblock %}
+
+                    <!-- COLORED BANNER (title + subtitle) -->
+                    {% block banner %}{% endblock %}
 
                     <!-- BODY CONTENT -->
                     <tr>
@@ -51,9 +50,9 @@
                         </td>
                     </tr>
 
-                    <!-- FOOTER -->
+                    <!-- DARK FOOTER -->
                     <tr>
-                        <td style="background-color:{% block footer_bg_color %}#AF0101{% endblock %};padding:24px 40px;">
+                        <td style="background-color:#1e2a3a;padding:20px 40px;">
                             {% block footer %}{% endblock %}
                         </td>
                     </tr>

--- a/templates/emails/balance/balance.comremit.html.twig
+++ b/templates/emails/balance/balance.comremit.html.twig
@@ -1,38 +1,42 @@
 {% extends 'emails/_base.html.twig' %}
 
-{% set brand   = '#E30613' %}
 {% set alert_bg = status_en == 'CRITICAL' ? '#E30613' : '#D97706' %}
 
 {% block title %}Alerta de saldo — Comremit{% endblock %}
 
-{% block preheader %}⚠ Saldo {{ status_es }} en {{ platform }} — {{ balance|round(2, 'floor') }} {{ currency }}{% endblock %}
+{% block preheader %}&#9888; Saldo {{ status_es }} en {{ platform }} — {{ balance|round(2, 'floor') }} {{ currency }}{% endblock %}
 
-{% block accent_color %}#E30613{% endblock %}
-{% block footer_bg_color %}#E30613{% endblock %}
+{% block brand_header %}
+<span style="font-size:20px;font-weight:bold;color:#ffffff;font-family:Arial,Helvetica,sans-serif;letter-spacing:0.5px;">
+    Comremit
+</span>
+{% endblock %}
 
-{% block logo %}
-    <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1ODEuNjggMTQwLjYxIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UzMDYxMzt9LmNscy0ye2ZpbGw6IzNjM2MzYjt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPkNvbXJlbWl0X2xvZ28gY29sb3I8L3RpdGxlPjxnIGlkPSJDYXBhXzIiIGRhdGEtbmFtZT0iQ2FwYSAyIj48ZyBpZD0iQ2FwYV8xLTIiIGRhdGEtbmFtZT0iQ2FwYSAxIj48ZWxsaXBzZSBjbGFzcz0iY2xzLTEiIGN4PSIxMTMuNyIgY3k9IjQwLjQiIHJ4PSIxNS4wMiIgcnk9IjE1LjQ2Ii8+PHBhdGggY2xhc3M9ImNscy0yIiBkPSJNMTQ4LjU3LDgxLjUxYTQuNzksNC43OSwwLDAsMS0xLjQ5LS4yNGwtMTUtNWEyLDIsMCwwLDAtMS41Ni4xNCw0MC40NCw0MC40NCwwLDEsMSwxNy42Ni0xNy41OCwyLDIsMCwwLDAtLjE1LDEuNTZsNSwxNWE0LjY5LDQuNjksMCwwLDEtNC40Miw2LjE2Wm0tMTcuMTQtOGE0LjczLDQuNzMsMCwwLDEsMS40NC4yNGwxNSw1YTIsMiwwLDAsMCwyLjEyLS41LDIsMiwwLDAsMCwuNDktMi4xMWwtNS0xNWE0LjYxLDQuNjEsMCwwLDEsLjI5LTMuNTgsMzcuNzcsMzcuNzcsMCwxLDAtNzAuNjctOS45MWgwQTM3Ljc0LDM3Ljc0LDAsMCwwLDEyOS4zLDc0LjA2LDQuNzgsNC43OCwwLDAsMSwxMzEuNDMsNzMuNTRaIi8+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNMCw0Mi4xMnYtLjIxQzAsMjAuNjcsMTYuMzUsNCwzOC40MSw0YzE0Ljg5LDAsMjQuNDcsNi4yNSwzMC45MiwxNS4yTDU0LjEzLDMxYy00LjE2LTUuMi05LTguNTQtMTUuOTItOC41NC0xMC4yLDAtMTcuMzksOC42NS0xNy4zOSwxOS4yNnYuMjFjMCwxMC45Myw3LjE5LDE5LjQ3LDE3LjM5LDE5LjQ3LDcuNiwwLDEyLjA3LTMuNTQsMTYuNDUtOC44NUw2OS44NSw2My4zNkM2Myw3Mi44Myw1My43Miw3OS44MSwzNy41OCw3OS44MSwxNi43Niw3OS44MSwwLDYzLjg4LDAsNDIuMTJaIi8+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNMTYyLjg3LDUuNDhoMjEuMzVMMjAxLjYsMzMuNjksMjE5LDUuNDhoMjEuMzRWNzguMzVoLTIwLjFWMzYuNUwyMDEuNiw2NWgtLjQyTDE4Mi42NiwzNi43MVY3OC4zNUgxNjIuODdaIi8+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNMjUzLjIxLDUuNDhoMzQuNDZjMTEuMTQsMCwxOC44NCwyLjkxLDIzLjczLDcuOTEsNC4yNyw0LjE2LDYuNDYsOS43OCw2LjQ2LDE3di4yYzAsMTEuMTQtNS45MywxOC41NC0xNSwyMi4zOWwxNy4zOCwyNS40SDI5Ni45M0wyODIuMjUsNTYuMjhoLTguODRWNzguMzVoLTIwLjJabTMzLjUyLDM1YzYuODcsMCwxMC44My0zLjMzLDEwLjgzLTguNjR2LS4yYzAtNS43My00LjE3LTguNjQtMTAuOTMtOC42NEgyNzMuNDFWNDAuNDVaIi8+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNMzI4LDUuNDhoNTguNjJWMjIuNjVIMzQ4djExaDM1VjQ5LjYySDM0OFY2MS4xN2gzOS4xNVY3OC4zNUgzMjhaIi8+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNMzk3LjQ1LDUuNDhoMjEuMzRsMTcuMzksMjguMjFMNDUzLjU2LDUuNDhINDc0LjlWNzguMzVINDU0LjgxVjM2LjVMNDM2LjE4LDY1aC0uNDJMNDE3LjIzLDM2LjcxVjc4LjM1SDM5Ny40NVoiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik00ODguMiw1LjJoMjAuM1Y3OC4zNUg0ODguMloiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik01MzkuNjIsMjMuMTdINTE3Ljc2VjUuNDhoNjMuOTJWMjMuMTdINTU5LjgyVjc4LjM1aC0yMC4yWiIvPjxwYXRoIGNsYXNzPSJjbHMtMiIgZD0iTTE2Mi4zNSwxMzYuMTlsMS41Mi0yLjY0YTIwLjA3LDIwLjA3LDAsMCwwLDEyLjQsNC4xNWM3LjI2LDAsMTAuMTctMi41NywxMC4xNy02LjQ2LDAtMTAtMjIuODMtMi42NC0yMi44My0xNi4xNywwLTUuMjEsNC4zNS05LjQzLDEzLjA2LTkuNDMsNC4zNiwwLDkuMTEsMS4zMiwxMS44MSwzLjM3TDE4NywxMTEuNjVhMTcuNjcsMTcuNjcsMCwwLDAtMTAuMzUtMy4xMWMtNi43NCwwLTkuNywyLjc3LTkuNyw2LjQ3LDAsMTAuMzYsMjIuODIsMywyMi44MiwxNi4xNiwwLDUuNjEtNC44MSw5LjQ0LTEzLjU5LDkuNDRDMTcwLjQ3LDE0MC42MSwxNjUuMDUsMTM4LjY5LDE2Mi4zNSwxMzYuMTlaIi8+PHBhdGggY2xhc3M9ImNscy0yIiBkPSJNMjA4LjM4LDEyMy4xMmMwLTEwLjIyLDcuMzMtMTcuNDgsMTcuMjItMTcuNDhzMTcuMjMsNy4yNiwxNy4yMywxNy40OC03LjMzLDE3LjQ5LTE3LjIzLDE3LjQ5UzIwOC4zOCwxMzMuMzUsMjA4LjM4LDEyMy4xMlptMzEuMDgsMGMwLTguNjQtNS45NC0xNC41MS0xMy44Ni0xNC41MXMtMTMuODUsNS44Ny0xMy44NSwxNC41MSw1LjkzLDE0LjUyLDEzLjg1LDE0LjUyUzIzOS40NiwxMzEuNzcsMjM5LjQ2LDEyMy4xMloiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik0yNjYuMjIsMTMxLjMxVjkxLjM5aDMuM3YzOS41MmMwLDQuNDIsMiw2Ljg2LDYuMDcsNi44NmE4LjgyLDguODIsMCwwLDAsMy4zLS42NmwuMjYsMi43N2ExMS40LDExLjQsMCwwLDEtNCwuNzNDMjY5LjMyLDE0MC42MSwyNjYuMjIsMTM3LjA1LDI2Ni4yMiwxMzEuMzFaIi8+PHBhdGggY2xhc3M9ImNscy0yIiBkPSJNMzI5LjIyLDEwNS45djM0LjQ0aC0zLjE3VjEzM2MtMi4yNCw0LjgyLTYuOTMsNy42Ni0xMyw3LjY2LTguNzcsMC0xNC4zOS01LTE0LjM5LTE0LjU5VjEwNS45SDMwMnYxOS44N2MwLDcuNzgsNC4xNiwxMS44NywxMS4zNSwxMS44Nyw3Ljc5LDAsMTIuNjEtNS4yMSwxMi42MS0xMy4zOVYxMDUuOVoiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik0zNzIuNCwxMzguMTdhMTAuNDMsMTAuNDMsMCwwLDEtNy4wNiwyLjQ0Yy02LjA3LDAtOS4zNy0zLjU2LTkuMzctOS4zN1Y5OC4zOGgzLjN2Ny41MmgxMXYyLjg0aC0xMXYyMi4xN2MwLDQuNDIsMi4xOCw2Ljg2LDYuNCw2Ljg2YTgsOCwwLDAsMCw1LjM1LTEuOTFaIi8+PHBhdGggY2xhc3M9ImNscy0yIiBkPSJNMzkzLjY5LDk0Ljg5YTIuNzMsMi43MywwLDAsMSwyLjcxLTIuNzEsMi42OCwyLjY4LDAsMSwxLTIuNzEsMi43MVptMS4wNiwxMWgzLjN2MzQuNDRoLTMuM1oiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik00MjEuMzksMTIzLjEyYzAtMTAuMjIsNy4zMi0xNy40OCwxNy4yMi0xNy40OHMxNy4yMiw3LjI2LDE3LjIyLDE3LjQ4LTcuMzIsMTcuNDktMTcuMjIsMTcuNDlTNDIxLjM5LDEzMy4zNSw0MjEuMzksMTIzLjEyWm0zMS4wOCwwYzAtOC42NC01Ljk0LTE0LjUxLTEzLjg2LTE0LjUxcy0xMy44NSw1Ljg3LTEzLjg1LDE0LjUxLDUuOTMsMTQuNTIsMTMuODUsMTQuNTJTNDUyLjQ3LDEzMS43Nyw0NTIuNDcsMTIzLjEyWiIvPjxwYXRoIGNsYXNzPSJjbHMtMiIgZD0iTTUxMCwxMjAuMjJ2MjAuMTJoLTMuM1YxMjAuNDhjMC03Ljc4LTQuMTYtMTEuODctMTEuMTUtMTEuODctOC4xMiwwLTEzLjA3LDUuMjEtMTMuMDcsMTMuMzl2MTguMzRoLTMuMjlWMTA1LjloMy4xN3Y3LjQ2YzIuMy00LjgyLDcuMTItNy43MiwxMy42NS03LjcyQzUwNC40MywxMDUuNjQsNTEwLDExMC41OSw1MTAsMTIwLjIyWiIvPjxwYXRoIGNsYXNzPSJjbHMtMiIgZD0iTTUzMS43MSwxMzYuMTlsMS41Mi0yLjY0YTIwLjA4LDIwLjA4LDAsMCwwLDEyLjQxLDQuMTVjNy4yNSwwLDEwLjE2LTIuNTcsMTAuMTYtNi40NiwwLTEwLTIyLjgzLTIuNjQtMjIuODMtMTYuMTcsMC01LjIxLDQuMzYtOS40MywxMy4wNy05LjQzLDQuMzUsMCw5LjEsMS4zMiwxMS44MSwzLjM3bC0xLjUyLDIuNjRBMTcuNywxNy43LDAsMCwwLDU0NiwxMDguNTRjLTYuNzMsMC05LjcsMi43Ny05LjcsNi40NywwLDEwLjM2LDIyLjgzLDMsMjIuODMsMTYuMTYsMCw1LjYxLTQuODIsOS40NC0xMy41OSw5LjQ0QzUzOS44MywxNDAuNjEsNTM0LjQyLDEzOC42OSw1MzEuNzEsMTM2LjE5WiIvPjwvZz48L2c+PC9zdmc+"
-         alt="Comremit" width="180" style="display:block;margin:0 auto;max-width:180px;height:auto;border:0;"/>
+{% block logo_area %}
+<tr>
+    <td align="center" style="background-color:#ffffff;padding:20px 40px 16px 40px;border-bottom:1px solid #ebebeb;">
+        <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1ODEuNjggMTQwLjYxIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UzMDYxMzt9LmNscy0ye2ZpbGw6IzNjM2MzYjt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPkNvbXJlbWl0X2xvZ28gY29sb3I8L3RpdGxlPjxnIGlkPSJDYXBhXzIiIGRhdGEtbmFtZT0iQ2FwYSAyIj48ZyBpZD0iQ2FwYV8xLTIiIGRhdGEtbmFtZT0iQ2FwYSAxIj48ZWxsaXBzZSBjbGFzcz0iY2xzLTEiIGN4PSIxMTMuNyIgY3k9IjQwLjQiIHJ4PSIxNS4wMiIgcnk9IjE1LjQ2Ii8+PHBhdGggY2xhc3M9ImNscy0yIiBkPSJNMTQ4LjU3LDgxLjUxYTQuNzksNC43OSwwLDAsMS0xLjQ5LS4yNGwtMTUtNWEyLDIsMCwwLDAtMS41Ni4xNCw0MC40NCw0MC40NCwwLDEsMSwxNy42Ni0xNy41OCwyLDIsMCwwLDAtLjE1LDEuNTZsNSwxNWE0LjY5LDQuNjksMCwwLDEtNC40Miw2LjE2Wm0tMTcuMTQtOGE0LjczLDQuNzMsMCwwLDEsMS40NC4yNGwxNSw1YTIsMiwwLDAsMCwyLjEyLS41LDIsMiwwLDAsMCwuNDktMi4xMWwtNS0xNWE0LjYxLDQuNjEsMCwwLDEsLjI5LTMuNTgsMzcuNzcsMzcuNzcsMCwxLDAtNzAuNjctOS45MWgwQTM3Ljc0LDM3Ljc0LDAsMCwwLDEyOS4zLDc0LjA2LDQuNzgsNC43OCwwLDAsMSwxMzEuNDMsNzMuNTRaIi8+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNMCw0Mi4xMnYtLjIxQzAsMjAuNjcsMTYuMzUsNCwzOC40MSw0YzE0Ljg5LDAsMjQuNDcsNi4yNSwzMC45MiwxNS4yTDU0LjEzLDMxYy00LjE2LTUuMi05LTguNTQtMTUuOTItOC41NC0xMC4yLDAtMTcuMzksOC42NS0xNy4zOSwxOS4yNnYuMjFjMCwxMC45Myw3LjE5LDE5LjQ3LDE3LjM5LDE5LjQ3LDcuNiwwLDEyLjA3LTMuNTQsMTYuNDUtOC44NUw2OS44NSw2My4zNkM2Myw3Mi44Myw1My43Miw3OS44MSwzNy41OCw3OS44MSwxNi43Niw3OS44MSwwLDYzLjg4LDAsNDIuMTJaIi8+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNMTYyLjg3LDUuNDhoMjEuMzVMMjAxLjYsMzMuNjksMjE5LDUuNDhoMjEuMzRWNzguMzVoLTIwLjFWMzYuNUwyMDEuNiw2NWgtLjQyTDE4Mi42NiwzNi43MVY3OC4zNUgxNjIuODdaIi8+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNMjUzLjIxLDUuNDhoMzQuNDZjMTEuMTQsMCwxOC44NCwyLjkxLDIzLjczLDcuOTEsNC4yNyw0LjE2LDYuNDYsOS43OCw2LjQ2LDE3di4yYzAsMTEuMTQtNS45MywxOC41NC0xNSwyMi4zOWwxNy4zOCwyNS40SDI5Ni45M0wyODIuMjUsNTYuMjhoLTguODRWNzguMzVoLTIwLjJabTMzLjUyLDM1YzYuODcsMCwxMC44My0zLjMzLDEwLjgzLTguNjR2LS4yYzAtNS43My00LjE3LTguNjQtMTAuOTMtOC42NEgyNzMuNDFWNDAuNDVaIi8+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNMzI4LDUuNDhoNTguNjJWMjIuNjVIMzQ4djExaDM1VjQ5LjYySDM0OFY2MS4xN2gzOS4xNVY3OC4zNUgzMjhaIi8+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNMzk3LjQ1LDUuNDhoMjEuMzRsMTcuMzksMjguMjFMNDUzLjU2LDUuNDhINDc0LjlWNzguMzVINDU0LjgxVjM2LjVMNDM2LjE4LDY1aC0uNDJMNDE3LjIzLDM2LjcxVjc4LjM1SDM5Ny40NVoiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik00ODguMiw1LjJoMjAuM1Y3OC4zNUg0ODguMloiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik01MzkuNjIsMjMuMTdINTE3Ljc2VjUuNDhoNjMuOTJWMjMuMTdINTU5LjgyVjc4LjM1aC0yMC4yWiIvPjxwYXRoIGNsYXNzPSJjbHMtMiIgZD0iTTE2Mi4zNSwxMzYuMTlsMS41Mi0yLjY0YTIwLjA3LDIwLjA3LDAsMCwwLDEyLjQsNC4xNWM3LjI2LDAsMTAuMTctMi41NywxMC4xNy02LjQ2LDAtMTAtMjIuODMtMi42NC0yMi44My0xNi4xNywwLTUuMjEsNC4zNS05LjQzLDEzLjA2LTkuNDMsNC4zNiwwLDkuMTEsMS4zMiwxMS44MSwzLjM3TDE4NywxMTEuNjVhMTcuNjcsMTcuNjcsMCwwLDAtMTAuMzUtMy4xMWMtNi43NCwwLTkuNywyLjc3LTkuNyw2LjQ3LDAsMTAuMzYsMjIuODIsMywyMi44MiwxNi4xNiwwLDUuNjEtNC44MSw5LjQ0LTEzLjU5LDkuNDRDMTcwLjQ3LDE0MC42MSwxNjUuMDUsMTM4LjY5LDE2Mi4zNSwxMzYuMTlaIi8+PHBhdGggY2xhc3M9ImNscy0yIiBkPSJNMjA4LjM4LDEyMy4xMmMwLTEwLjIyLDcuMzMtMTcuNDgsMTcuMjItMTcuNDhzMTcuMjMsNy4yNiwxNy4yMywxNy40OC03LjMzLDE3LjQ5LTE3LjIzLDE3LjQ5UzIwOC4zOCwxMzMuMzUsMjA4LjM4LDEyMy4xMlptMzEuMDgsMGMwLTguNjQtNS45NC0xNC41MS0xMy44Ni0xNC41MXMtMTMuODUsNS44Ny0xMy44NSwxNC41MSw1LjkzLDE0LjUyLDEzLjg1LDE0LjUyUzIzOS40NiwxMzEuNzcsMjM5LjQ2LDEyMy4xMloiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik0yNjYuMjIsMTMxLjMxVjkxLjM5aDMuM3YzOS41MmMwLDQuNDIsMiw2Ljg2LDYuMDcsNi44NmE4LjgyLDguODIsMCwwLDAsMy4zLS42NmwuMjYsMi43N2ExMS40LDExLjQsMCwwLDEtNCwuNzNDMjY5LjMyLDE0MC42MSwyNjYuMjIsMTM3LjA1LDI2Ni4yMiwxMzEuMzFaIi8+PHBhdGggY2xhc3M9ImNscy0yIiBkPSJNMzI5LjIyLDEwNS45djM0LjQ0aC0zLjE3VjEzM2MtMi4yNCw0LjgyLTYuOTMsNy42Ni0xMyw3LjY2LTguNzcsMC0xNC4zOS01LDE0LjM5LTE0LjU5VjEwNS45SDMwMnYxOS44N2MwLDcuNzgsNC4xNiwxMS44NywxMS4zNSwxMS44Nyw3Ljc5LDAsMTIuNjEtNS4yMSwxMi42MS0xMy4zOVYxMDUuOVoiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik0zNzIuNCwxMzguMTdhMTAuNDMsMTAuNDMsMCwwLDEtNy4wNiwyLjQ0Yy02LjA3LDAtOS4zNy0zLjU2LTkuMzctOS4zN1Y5OC4zOGgzLjN2Ny41MmgxMXYyLjg0aC0xMXYyMi4xN2MwLDQuNDIsMi4xOCw2Ljg2LDYuNCw2Ljg2YTgsOCwwLDAsMCw1LjM1LTEuOTFaIi8+PHBhdGggY2xhc3M9ImNscy0yIiBkPSJNMzkzLjY5LDk0Ljg5YTIuNzMsMi43MywwLDAsMSwyLjcxLTIuNzEsMi42OCwyLjY4LDAsMSwxLTIuNzEsMi43MVptMS4wNiwxMWgzLjN2MzQuNDRoLTMuM1oiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik00MjEuMzksMTIzLjEyYzAtMTAuMjIsNy4zMi0xNy40OCwxNy4yMi0xNy40OHMxNy4yMiw3LjI2LDE3LjIyLDE3LjQ4LTcuMzIsMTcuNDktMTcuMjIsMTcuNDlTNDIxLjM5LDEzMy4zNSw0MjEuMzksMTIzLjEyWm0zMS4wOCwwYzAtOC42NC01Ljk0LTE0LjUxLTEzLjg2LTE0LjUxcy0xMy44NSw1Ljg3LTEzLjg1LDE0LjUxLDUuOTMsMTQuNTIsMTMuODUsMTQuNTJTNDUyLjQ3LDEzMS43Nyw0NTIuNDcsMTIzLjEyWiIvPjxwYXRoIGNsYXNzPSJjbHMtMiIgZD0iTTUxMCwxMjAuMjJ2MjAuMTJoLTMuM1YxMjAuNDhjMC03Ljc4LTQuMTYtMTEuODctMTEuMTUtMTEuODctOC4xMiwwLTEzLjA3LDUuMjEtMTMuMDcsMTMuMzl2MTguMzRoLTMuMjlWMTA1LjloMy4xN3Y3LjQ2YzIuMy00LjgyLDcuMTItNy43MiwxMy42NS03LjcyQzUwNC40MywxMDUuNjQsNTEwLDExMC41OSw1MTAsMTIwLjIyWiIvPjxwYXRoIGNsYXNzPSJjbHMtMiIgZD0iTTUzMS43MSwxMzYuMTlsMS41Mi0yLjY0YTIwLjA4LDIwLjA4LDAsMCwwLDEyLjQxLDQuMTVjNy4yNSwwLDEwLjE2LTIuNTcsMTAuMTYtNi40NiwwLTEwLTIyLjgzLTIuNjQtMjIuODMtMTYuMTcsMC01LjIxLDQuMzYtOS40MywxMy4wNy05LjQzLDQuMzUsMCw5LjEsMS4zMiwxMS44MSwzLjM3bC0xLjUyLDIuNjRBMTcuNywxNy43LDAsMCwwLDU0NiwxMDguNTRjLTYuNzMsMC05LjcsMi43Ny05LjcsNi40NywwLDEwLjM2LDIyLjgzLDMsMjIuODMsMTYuMTYsMCw1LjYxLTQuODIsOS40NC0xMy41OSw5LjQ0QzUzOS44MywxNDAuNjEsNTM0LjQyLDEzOC42OSw1MzEuNzEsMTM2LjE5WiIvPjwvZz48L2c+PC9zdmc+"
+             alt="Comremit" width="160" style="display:block;margin:0 auto;max-width:160px;height:auto;border:0;"/>
+    </td>
+</tr>
+{% endblock %}
+
+{% block banner %}
+<tr>
+    <td align="center" style="background-color:{{ alert_bg }};padding:28px 40px 24px 40px;">
+        <p style="margin:0 0 6px 0;font-size:24px;font-weight:bold;color:#ffffff;
+                  font-family:Arial,Helvetica,sans-serif;line-height:1.2;">
+            Alerta de Saldo
+        </p>
+        <p style="margin:0;font-size:14px;color:rgba(255,255,255,0.85);font-family:Arial,Helvetica,sans-serif;">
+            &#9888;&#xFE0E;&nbsp; Saldo en estado {{ status_es }} &bull; {{ status_en }} Balance
+        </p>
+    </td>
+</tr>
 {% endblock %}
 
 {% block content %}
 <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
-
-    <!-- ALERT BANNER -->
-    <tr>
-        <td style="padding-bottom:28px;">
-            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
-                <tr>
-                    <td align="center"
-                        style="background-color:{{ alert_bg }};padding:16px 24px;border-radius:4px;">
-                        <span style="color:#ffffff;font-size:11px;font-weight:bold;letter-spacing:2px;text-transform:uppercase;font-family:Arial,Helvetica,sans-serif;">
-                            &#9888;&#xFE0E;&nbsp;&nbsp;SALDO EN ESTADO {{ status_es }}&nbsp;&nbsp;&bull;&nbsp;&nbsp;{{ status_en }} BALANCE
-                        </span>
-                    </td>
-                </tr>
-            </table>
-        </td>
-    </tr>
 
     <!-- GREETING + MESSAGE ES -->
     <tr>
@@ -59,7 +63,7 @@
             <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0"
                    style="border:1px solid #e0e0e0;border-collapse:collapse;border-radius:4px;">
 
-                <!-- Amount row — highlighted -->
+                <!-- Amount row -->
                 <tr>
                     <td style="background-color:#fafafa;padding:14px 18px;font-size:12px;font-weight:bold;
                                 color:#666666;text-transform:uppercase;letter-spacing:0.5px;
@@ -143,26 +147,27 @@
 {% block footer %}
 <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
     <tr>
-        <td align="center" style="color:#ffffff;font-size:14px;font-weight:bold;padding-bottom:6px;font-family:Arial,Helvetica,sans-serif;">
+        <td align="center" style="color:#ffffff;font-size:13px;font-weight:bold;padding-bottom:4px;font-family:Arial,Helvetica,sans-serif;">
             Comremit Solutions SL
         </td>
     </tr>
     <tr>
-        <td align="center" style="color:rgba(255,255,255,0.8);font-size:12px;line-height:18px;padding-bottom:4px;font-family:Arial,Helvetica,sans-serif;">
-            Pasaje del Carme, 24 &mdash; Sant Cugat del Vall&eacute;s, 08173 &mdash; Barcelona, Espa&ntilde;a
+        <td align="center" style="color:rgba(255,255,255,0.6);font-size:11px;line-height:18px;padding-bottom:10px;font-family:Arial,Helvetica,sans-serif;">
+            Pasaje del Carme, 24 &mdash; Sant Cugat del Vall&eacute;s, 08173 &mdash; Barcelona, Espa&ntilde;a &mdash; CIF: B10583565
         </td>
     </tr>
     <tr>
-        <td align="center" style="color:rgba(255,255,255,0.6);font-size:11px;padding-bottom:10px;font-family:Arial,Helvetica,sans-serif;">
-            CIF: B10583565
-        </td>
-    </tr>
-    <tr>
-        <td align="center">
+        <td align="center" style="padding-bottom:10px;">
             <a href="https://dashboard.comremit.com"
-               style="color:rgba(255,255,255,0.9);font-size:12px;text-decoration:underline;font-family:Arial,Helvetica,sans-serif;">
+               style="color:rgba(255,255,255,0.8);font-size:12px;text-decoration:underline;font-family:Arial,Helvetica,sans-serif;">
                 dashboard.comremit.com
             </a>
+        </td>
+    </tr>
+    <tr>
+        <td align="center" style="border-top:1px solid rgba(255,255,255,0.12);padding-top:12px;
+                                   font-size:11px;color:rgba(255,255,255,0.45);font-family:Arial,Helvetica,sans-serif;">
+            Este es un mensaje autom&aacute;tico &mdash; por favor no respondas a este correo.
         </td>
     </tr>
 </table>

--- a/templates/emails/balance/balance.sendmundo.html.twig
+++ b/templates/emails/balance/balance.sendmundo.html.twig
@@ -1,38 +1,42 @@
 {% extends 'emails/_base.html.twig' %}
 
-{% set brand    = '#D9000D' %}
 {% set alert_bg = status_en == 'CRITICAL' ? '#D9000D' : '#D97706' %}
 
 {% block title %}Alerta de saldo — SendMundo{% endblock %}
 
-{% block preheader %}⚠ Saldo {{ status_es }} en {{ platform }} — {{ balance|round(2, 'floor') }} {{ currency }}{% endblock %}
+{% block preheader %}&#9888; Saldo {{ status_es }} en {{ platform }} — {{ balance|round(2, 'floor') }} {{ currency }}{% endblock %}
 
-{% block accent_color %}#D9000D{% endblock %}
-{% block footer_bg_color %}#D9000D{% endblock %}
+{% block brand_header %}
+<span style="font-size:20px;font-weight:bold;color:#ffffff;font-family:Arial,Helvetica,sans-serif;letter-spacing:0.5px;">
+    SendMundo
+</span>
+{% endblock %}
 
-{% block logo %}
-    <img src="https://www.sendmundo.com/img/header/comremit-logo.svg" alt="SendMundo"
-         width="180" style="display:block;margin:0 auto;max-width:180px;height:auto;border:0;"/>
+{% block logo_area %}
+<tr>
+    <td align="center" style="background-color:#ffffff;padding:20px 40px 16px 40px;border-bottom:1px solid #ebebeb;">
+        <img src="https://www.sendmundo.com/img/header/comremit-logo.svg"
+             alt="SendMundo" width="160" style="display:block;margin:0 auto;max-width:160px;height:auto;border:0;"/>
+    </td>
+</tr>
+{% endblock %}
+
+{% block banner %}
+<tr>
+    <td align="center" style="background-color:{{ alert_bg }};padding:28px 40px 24px 40px;">
+        <p style="margin:0 0 6px 0;font-size:24px;font-weight:bold;color:#ffffff;
+                  font-family:Arial,Helvetica,sans-serif;line-height:1.2;">
+            Alerta de Saldo
+        </p>
+        <p style="margin:0;font-size:14px;color:rgba(255,255,255,0.85);font-family:Arial,Helvetica,sans-serif;">
+            &#9888;&#xFE0E;&nbsp; Saldo en estado {{ status_es }} &bull; {{ status_en }} Balance
+        </p>
+    </td>
+</tr>
 {% endblock %}
 
 {% block content %}
 <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
-
-    <!-- ALERT BANNER -->
-    <tr>
-        <td style="padding-bottom:28px;">
-            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
-                <tr>
-                    <td align="center"
-                        style="background-color:{{ alert_bg }};padding:16px 24px;border-radius:4px;">
-                        <span style="color:#ffffff;font-size:11px;font-weight:bold;letter-spacing:2px;text-transform:uppercase;font-family:Arial,Helvetica,sans-serif;">
-                            &#9888;&#xFE0E;&nbsp;&nbsp;SALDO EN ESTADO {{ status_es }}&nbsp;&nbsp;&bull;&nbsp;&nbsp;{{ status_en }} BALANCE
-                        </span>
-                    </td>
-                </tr>
-            </table>
-        </td>
-    </tr>
 
     <!-- GREETING + MESSAGE ES -->
     <tr>
@@ -143,26 +147,27 @@
 {% block footer %}
 <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
     <tr>
-        <td align="center" style="color:#ffffff;font-size:14px;font-weight:bold;padding-bottom:6px;font-family:Arial,Helvetica,sans-serif;">
+        <td align="center" style="color:#ffffff;font-size:13px;font-weight:bold;padding-bottom:4px;font-family:Arial,Helvetica,sans-serif;">
             SendMundo Communications and Finance Technologies SL
         </td>
     </tr>
     <tr>
-        <td align="center" style="color:rgba(255,255,255,0.8);font-size:12px;line-height:18px;padding-bottom:4px;font-family:Arial,Helvetica,sans-serif;">
-            Pasaje del Carme, 24 &mdash; Sant Cugat del Vall&eacute;s, 08173 &mdash; Barcelona, Espa&ntilde;a
+        <td align="center" style="color:rgba(255,255,255,0.6);font-size:11px;line-height:18px;padding-bottom:10px;font-family:Arial,Helvetica,sans-serif;">
+            Pasaje del Carme, 24 &mdash; Sant Cugat del Vall&eacute;s, 08173 &mdash; Barcelona, Espa&ntilde;a &mdash; CIF: B42981191
         </td>
     </tr>
     <tr>
-        <td align="center" style="color:rgba(255,255,255,0.6);font-size:11px;padding-bottom:10px;font-family:Arial,Helvetica,sans-serif;">
-            CIF: B42981191
-        </td>
-    </tr>
-    <tr>
-        <td align="center">
+        <td align="center" style="padding-bottom:10px;">
             <a href="https://dashboard.sendmundo.com"
-               style="color:rgba(255,255,255,0.9);font-size:12px;text-decoration:underline;font-family:Arial,Helvetica,sans-serif;">
+               style="color:rgba(255,255,255,0.8);font-size:12px;text-decoration:underline;font-family:Arial,Helvetica,sans-serif;">
                 dashboard.sendmundo.com
             </a>
+        </td>
+    </tr>
+    <tr>
+        <td align="center" style="border-top:1px solid rgba(255,255,255,0.12);padding-top:12px;
+                                   font-size:11px;color:rgba(255,255,255,0.45);font-family:Arial,Helvetica,sans-serif;">
+            Este es un mensaje autom&aacute;tico &mdash; por favor no respondas a este correo.
         </td>
     </tr>
 </table>

--- a/templates/emails/password/forgot-password.comremit.html.twig
+++ b/templates/emails/password/forgot-password.comremit.html.twig
@@ -4,59 +4,67 @@
 
 {% block preheader %}Su c&oacute;digo de verificaci&oacute;n es {{ code }}. V&aacute;lido por 30 minutos.{% endblock %}
 
-{% block accent_color %}#E30613{% endblock %}
-{% block footer_bg_color %}#E30613{% endblock %}
+{% block brand_header %}
+<span style="font-size:20px;font-weight:bold;color:#ffffff;font-family:Arial,Helvetica,sans-serif;letter-spacing:0.5px;">
+    Comremit
+</span>
+{% endblock %}
 
-{% block logo %}
-    <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1ODEuNjggMTQwLjYxIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UzMDYxMzt9LmNscy0ye2ZpbGw6IzNjM2MzYjt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPkNvbXJlbWl0X2xvZ28gY29sb3I8L3RpdGxlPjxnIGlkPSJDYXBhXzIiIGRhdGEtbmFtZT0iQ2FwYSAyIj48ZyBpZD0iQ2FwYV8xLTIiIGRhdGEtbmFtZT0iQ2FwYSAxIj48ZWxsaXBzZSBjbGFzcz0iY2xzLTEiIGN4PSIxMTMuNyIgY3k9IjQwLjQiIHJ4PSIxNS4wMiIgcnk9IjE1LjQ2Ii8+PHBhdGggY2xhc3M9ImNscy0yIiBkPSJNMTQ4LjU3LDgxLjUxYTQuNzksNC43OSwwLDAsMS0xLjQ5LS4yNGwtMTUtNWEyLDIsMCwwLDAtMS41Ni4xNCw0MC40NCw0MC40NCwwLDEsMSwxNy42Ni0xNy41OCwyLDIsMCwwLDAtLjE1LDEuNTZsNSwxNWE0LjY5LDQuNjksMCwwLDEtNC40Miw2LjE2Wm0tMTcuMTQtOGE0LjczLDQuNzMsMCwwLDEsMS40NC4yNGwxNSw1YTIsMiwwLDAsMCwyLjEyLS41LDIsMiwwLDAsMCwuNDktMi4xMWwtNS0xNWE0LjYxLDQuNjEsMCwwLDEsLjI5LTMuNTgsMzcuNzcsMzcuNzcsMCwxLDAtNzAuNjctOS45MWgwQTM3Ljc0LDM3Ljc0LDAsMCwwLDEyOS4zLDc0LjA2LDQuNzgsNC43OCwwLDAsMSwxMzEuNDMsNzMuNTRaIi8+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNMCw0Mi4xMnYtLjIxQzAsMjAuNjcsMTYuMzUsNCwzOC40MSw0YzE0Ljg5LDAsMjQuNDcsNi4yNSwzMC45MiwxNS4yTDU0LjEzLDMxYy00LjE2LTUuMi05LTguNTQtMTUuOTItOC41NC0xMC4yLDAtMTcuMzksOC42NS0xNy4zOSwxOS4yNnYuMjFjMCwxMC45Myw3LjE5LDE5LjQ3LDE3LjM5LDE5LjQ3LDcuNiwwLDEyLjA3LTMuNTQsMTYuNDUtOC44NUw2OS44NSw2My4zNkM2Myw3Mi44Myw1My43Miw3OS44MSwzNy41OCw3OS44MSwxNi43Niw3OS44MSwwLDYzLjg4LDAsNDIuMTJaIi8+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNMTYyLjg3LDUuNDhoMjEuMzVMMjAxLjYsMzMuNjksMjE5LDUuNDhoMjEuMzRWNzguMzVoLTIwLjFWMzYuNUwyMDEuNiw2NWgtLjQyTDE4Mi42NiwzNi43MVY3OC4zNUgxNjIuODdaIi8+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNMjUzLjIxLDUuNDhoMzQuNDZjMTEuMTQsMCwxOC44NCwyLjkxLDIzLjczLDcuOTEsNC4yNyw0LjE2LDYuNDYsOS43OCw2LjQ2LDE3di4yYzAsMTEuMTQtNS45MywxOC41NC0xNSwyMi4zOWwxNy4zOCwyNS40SDI5Ni45M0wyODIuMjUsNTYuMjhoLTguODRWNzguMzVoLTIwLjJabTMzLjUyLDM1YzYuODcsMCwxMC44My0zLjMzLDEwLjgzLTguNjR2LS4yYzAtNS43My00LjE3LTguNjQtMTAuOTMtOC42NEgyNzMuNDFWNDAuNDVaIi8+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNMzI4LDUuNDhoNTguNjJWMjIuNjVIMzQ4djExaDM1VjQ5LjYySDM0OFY2MS4xN2gzOS4xNVY3OC4zNUgzMjhaIi8+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNMzk3LjQ1LDUuNDhoMjEuMzRsMTcuMzksMjguMjFMNDUzLjU2LDUuNDhINDc0LjlWNzguMzVINDU0LjgxVjM2LjVMNDM2LjE4LDY1aC0uNDJMNDE3LjIzLDM2LjcxVjc4LjM1SDM5Ny40NVoiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik00ODguMiw1LjJoMjAuM1Y3OC4zNUg0ODguMloiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik01MzkuNjIsMjMuMTdINTE3Ljc2VjUuNDhoNjMuOTJWMjMuMTdINTU5LjgyVjc4LjM1aC0yMC4yWiIvPjxwYXRoIGNsYXNzPSJjbHMtMiIgZD0iTTE2Mi4zNSwxMzYuMTlsMS41Mi0yLjY0YTIwLjA3LDIwLjA3LDAsMCwwLDEyLjQsNC4xNWM3LjI2LDAsMTAuMTctMi41NywxMC4xNy02LjQ2LDAtMTAtMjIuODMtMi42NC0yMi44My0xNi4xNywwLTUuMjEsNC4zNS05LjQzLDEzLjA2LTkuNDMsNC4zNiwwLDkuMTEsMS4zMiwxMS44MSwzLjM3TDE4NywxMTEuNjVhMTcuNjcsMTcuNjcsMCwwLDAtMTAuMzUtMy4xMWMtNi43NCwwLTkuNywyLjc3LTkuNyw2LjQ3LDAsMTAuMzYsMjIuODIsMywyMi44MiwxNi4xNiwwLDUuNjEtNC44MSw5LjQ0LTEzLjU5LDkuNDRDMTcwLjQ3LDE0MC42MSwxNjUuMDUsMTM4LjY5LDE2Mi4zNSwxMzYuMTlaIi8+PHBhdGggY2xhc3M9ImNscy0yIiBkPSJNMjA4LjM4LDEyMy4xMmMwLTEwLjIyLDcuMzMtMTcuNDgsMTcuMjItMTcuNDhzMTcuMjMsNy4yNiwxNy4yMywxNy40OC03LjMzLDE3LjQ5LTE3LjIzLDE3LjQ5UzIwOC4zOCwxMzMuMzUsMjA4LjM4LDEyMy4xMlptMzEuMDgsMGMwLTguNjQtNS45NC0xNC41MS0xMy44Ni0xNC41MXMtMTMuODUsNS44Ny0xMy44NSwxNC41MSw1LjkzLDE0LjUyLDEzLjg1LDE0LjUyUzIzOS40NiwxMzEuNzcsMjM5LjQ2LDEyMy4xMloiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik0yNjYuMjIsMTMxLjMxVjkxLjM5aDMuM3YzOS41MmMwLDQuNDIsMiw2Ljg2LDYuMDcsNi44NmE4LjgyLDguODIsMCwwLDAsMy4zLS42NmwuMjYsMi43N2ExMS40LDExLjQsMCwwLDEtNCwuNzNDMjY5LjMyLDE0MC42MSwyNjYuMjIsMTM3LjA1LDI2Ni4yMiwxMzEuMzFaIi8+PHBhdGggY2xhc3M9ImNscy0yIiBkPSJNMzI5LjIyLDEwNS45djM0LjQ0aC0zLjE3VjEzM2MtMi4yNCw0LjgyLTYuOTMsNy42Ni0xMyw3LjY2LTguNzcsMC0xNC4zOS01LDE0LjM5LTE0LjU5VjEwNS45SDMwMnYxOS44N2MwLDcuNzgsNC4xNiwxMS44NywxMS4zNSwxMS44Nyw3Ljc5LDAsMTIuNjEtNS4yMSwxMi42MS0xMy4zOVYxMDUuOVoiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik0zNzIuNCwxMzguMTdhMTAuNDMsMTAuNDMsMCwwLDEtNy4wNiwyLjQ0Yy02LjA3LDAtOS4zNy0zLjU2LTkuMzctOS4zN1Y5OC4zOGgzLjN2Ny41MmgxMXYyLjg0aC0xMXYyMi4xN2MwLDQuNDIsMi4xOCw2Ljg2LDYuNCw2Ljg2YTgsOCwwLDAsMCw1LjM1LTEuOTFaIi8+PHBhdGggY2xhc3M9ImNscy0yIiBkPSJNMzkzLjY5LDk0Ljg5YTIuNzMsMi43MywwLDAsMSwyLjcxLTIuNzEsMi42OCwyLjY4LDAsMSwxLTIuNzEsMi43MVptMS4wNiwxMWgzLjN2MzQuNDRoLTMuM1oiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik00MjEuMzksMTIzLjEyYzAtMTAuMjIsNy4zMi0xNy40OCwxNy4yMi0xNy40OHMxNy4yMiw3LjI2LDE3LjIyLDE3LjQ4LTcuMzIsMTcuNDktMTcuMjIsMTcuNDlTNDIxLjM5LDEzMy4zNSw0MjEuMzksMTIzLjEyWm0zMS4wOCwwYzAtOC42NC01Ljk0LTE0LjUxLTEzLjg2LTE0LjUxcy0xMy44NSw1Ljg3LTEzLjg1LDE0LjUxLDUuOTMsMTQuNTIsMTMuODUsMTQuNTJTNDUyLjQ3LDEzMS43Nyw0NTIuNDcsMTIzLjEyWiIvPjxwYXRoIGNsYXNzPSJjbHMtMiIgZD0iTTUxMCwxMjAuMjJ2MjAuMTJoLTMuM1YxMjAuNDhjMC03Ljc4LTQuMTYtMTEuODctMTEuMTUtMTEuODctOC4xMiwwLTEzLjA3LDUuMjEtMTMuMDcsMTMuMzl2MTguMzRoLTMuMjlWMTA1LjloMy4xN3Y3LjQ2YzIuMy00LjgyLDcuMTItNy43MiwxMy42NS03LjcyQzUwNC40MywxMDUuNjQsNTEwLDExMC41OSw1MTAsMTIwLjIyWiIvPjxwYXRoIGNsYXNzPSJjbHMtMiIgZD0iTTUzMS43MSwxMzYuMTlsMS41Mi0yLjY0YTIwLjA4LDIwLjA4LDAsMCwwLDEyLjQxLDQuMTVjNy4yNSwwLDEwLjE2LTIuNTcsMTAuMTYtNi40NiwwLTEwLTIyLjgzLTIuNjQtMjIuODMtMTYuMTcsMC01LjIxLDQuMzYtOS40MywxMy4wNy05LjQzLDQuMzUsMCw5LjEsMS4zMiwxMS44MSwzLjM3bC0xLjUyLDIuNjRBMTcuNywxNy43LDAsMCwwLDU0NiwxMDguNTRjLTYuNzMsMC05LjcsMi43Ny05LjcsNi40NywwLDEwLjM2LDIyLjgzLDMsMjIuODMsMTYuMTYsMCw1LjYxLTQuODIsOS40NC0xMy41OSw5LjQ0QzUzOS44MywxNDAuNjEsNTM0LjQyLDEzOC42OSw1MzEuNzEsMTM2LjE5WiIvPjwvZz48L2c+PC9zdmc+"
-         alt="Comremit" width="180" style="display:block;margin:0 auto;max-width:180px;height:auto;border:0;"/>
+{% block logo_area %}
+<tr>
+    <td align="center" style="background-color:#ffffff;padding:20px 40px 16px 40px;border-bottom:1px solid #ebebeb;">
+        <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1ODEuNjggMTQwLjYxIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UzMDYxMzt9LmNscy0ye2ZpbGw6IzNjM2MzYjt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPkNvbXJlbWl0X2xvZ28gY29sb3I8L3RpdGxlPjxnIGlkPSJDYXBhXzIiIGRhdGEtbmFtZT0iQ2FwYSAyIj48ZyBpZD0iQ2FwYV8xLTIiIGRhdGEtbmFtZT0iQ2FwYSAxIj48ZWxsaXBzZSBjbGFzcz0iY2xzLTEiIGN4PSIxMTMuNyIgY3k9IjQwLjQiIHJ4PSIxNS4wMiIgcnk9IjE1LjQ2Ii8+PHBhdGggY2xhc3M9ImNscy0yIiBkPSJNMTQ4LjU3LDgxLjUxYTQuNzksNC43OSwwLDAsMS0xLjQ5LS4yNGwtMTUtNWEyLDIsMCwwLDAtMS41Ni4xNCw0MC40NCw0MC40NCwwLDEsMSwxNy42Ni0xNy41OCwyLDIsMCwwLDAtLjE1LDEuNTZsNSwxNWE0LjY5LDQuNjksMCwwLDEtNC40Miw2LjE2Wm0tMTcuMTQtOGE0LjczLDQuNzMsMCwwLDEsMS40NC4yNGwxNSw1YTIsMiwwLDAsMCwyLjEyLS41LDIsMiwwLDAsMCwuNDktMi4xMWwtNS0xNWE0LjYxLDQuNjEsMCwwLDEsLjI5LTMuNTgsMzcuNzcsMzcuNzcsMCwxLDAtNzAuNjctOS45MWgwQTM3Ljc0LDM3Ljc0LDAsMCwwLDEyOS4zLDc0LjA2LDQuNzgsNC43OCwwLDAsMSwxMzEuNDMsNzMuNTRaIi8+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNMCw0Mi4xMnYtLjIxQzAsMjAuNjcsMTYuMzUsNCwzOC40MSw0YzE0Ljg5LDAsMjQuNDcsNi4yNSwzMC45MiwxNS4yTDU0LjEzLDMxYy00LjE2LTUuMi05LTguNTQtMTUuOTItOC41NC0xMC4yLDAtMTcuMzksOC42NS0xNy4zOSwxOS4yNnYuMjFjMCwxMC45Myw3LjE5LDE5LjQ3LDE3LjM5LDE5LjQ3LDcuNiwwLDEyLjA3LTMuNTQsMTYuNDUtOC44NUw2OS44NSw2My4zNkM2Myw3Mi44Myw1My43Miw3OS44MSwzNy41OCw3OS44MSwxNi43Niw3OS44MSwwLDYzLjg4LDAsNDIuMTJaIi8+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNMTYyLjg3LDUuNDhoMjEuMzVMMjAxLjYsMzMuNjksMjE5LDUuNDhoMjEuMzRWNzguMzVoLTIwLjFWMzYuNUwyMDEuNiw2NWgtLjQyTDE4Mi42NiwzNi43MVY3OC4zNUgxNjIuODdaIi8+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNMjUzLjIxLDUuNDhoMzQuNDZjMTEuMTQsMCwxOC44NCwyLjkxLDIzLjczLDcuOTEsNC4yNyw0LjE2LDYuNDYsOS43OCw2LjQ2LDE3di4yYzAsMTEuMTQtNS45MywxOC41NC0xNSwyMi4zOWwxNy4zOCwyNS40SDI5Ni45M0wyODIuMjUsNTYuMjhoLTguODRWNzguMzVoLTIwLjJabTMzLjUyLDM1YzYuODcsMCwxMC44My0zLjMzLDEwLjgzLTguNjR2LS4yYzAtNS43My00LjE3LTguNjQtMTAuOTMtOC42NEgyNzMuNDFWNDAuNDVaIi8+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNMzI4LDUuNDhoNTguNjJWMjIuNjVIMzQ4djExaDM1VjQ5LjYySDM0OFY2MS4xN2gzOS4xNVY3OC4zNUgzMjhaIi8+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNMzk3LjQ1LDUuNDhoMjEuMzRsMTcuMzksMjguMjFMNDUzLjU2LDUuNDhINDc0LjlWNzguMzVINDU0LjgxVjM2LjVMNDM2LjE4LDY1aC0uNDJMNDE3LjIzLDM2LjcxVjc4LjM1SDM5Ny40NVoiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik00ODguMiw1LjJoMjAuM1Y3OC4zNUg0ODguMloiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik01MzkuNjIsMjMuMTdINTE3Ljc2VjUuNDhoNjMuOTJWMjMuMTdINTU5LjgyVjc4LjM1aC0yMC4yWiIvPjxwYXRoIGNsYXNzPSJjbHMtMiIgZD0iTTE2Mi4zNSwxMzYuMTlsMS41Mi0yLjY0YTIwLjA3LDIwLjA3LDAsMCwwLDEyLjQsNC4xNWM3LjI2LDAsMTAuMTctMi41NywxMC4xNy02LjQ2LDAtMTAtMjIuODMtMi42NC0yMi44My0xNi4xNywwLTUuMjEsNC4zNS05LjQzLDEzLjA2LTkuNDMsNC4zNiwwLDkuMTEsMS4zMiwxMS44MSwzLjM3TDE4NywxMTEuNjVhMTcuNjcsMTcuNjcsMCwwLDAtMTAuMzUtMy4xMWMtNi43NCwwLTkuNywyLjc3LTkuNyw2LjQ3LDAsMTAuMzYsMjIuODIsMywyMi44MiwxNi4xNiwwLDUuNjEtNC44MSw5LjQ0LTEzLjU5LDkuNDRDMTcwLjQ3LDE0MC42MSwxNjUuMDUsMTM4LjY5LDE2Mi4zNSwxMzYuMTlaIi8+PHBhdGggY2xhc3M9ImNscy0yIiBkPSJNMjA4LjM4LDEyMy4xMmMwLTEwLjIyLDcuMzMtMTcuNDgsMTcuMjItMTcuNDhzMTcuMjMsNy4yNiwxNy4yMywxNy40OC03LjMzLDE3LjQ5LTE3LjIzLDE3LjQ5UzIwOC4zOCwxMzMuMzUsMjA4LjM4LDEyMy4xMlptMzEuMDgsMGMwLTguNjQtNS45NC0xNC41MS0xMy44Ni0xNC41MXMtMTMuODUsNS44Ny0xMy44NSwxNC41MSw1LjkzLDE0LjUyLDEzLjg1LDE0LjUyUzIzOS40NiwxMzEuNzcsMjM5LjQ2LDEyMy4xMloiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik0yNjYuMjIsMTMxLjMxVjkxLjM5aDMuM3YzOS41MmMwLDQuNDIsMiw2Ljg2LDYuMDcsNi44NmE4LjgyLDguODIsMCwwLDAsMy4zLS42NmwuMjYsMi43N2ExMS40LDExLjQsMCwwLDEtNCwuNzNDMjY5LjMyLDE0MC42MSwyNjYuMjIsMTM3LjA1LDI2Ni4yMiwxMzEuMzFaIi8+PHBhdGggY2xhc3M9ImNscy0yIiBkPSJNMzI5LjIyLDEwNS45djM0LjQ0aC0zLjE3VjEzM2MtMi4yNCw0LjgyLTYuOTMsNy42Ni0xMyw3LjY2LTguNzcsMC0xNC4zOS01LDE0LjM5LTE0LjU5VjEwNS45SDMwMnYxOS44N2MwLDcuNzgsNC4xNiwxMS44NywxMS4zNSwxMS44Nyw3Ljc5LDAsMTIuNjEtNS4yMSwxMi42MS0xMy4zOVYxMDUuOVoiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik0zNzIuNCwxMzguMTdhMTAuNDMsMTAuNDMsMCwwLDEtNy4wNiwyLjQ0Yy02LjA3LDAtOS4zNy0zLjU2LTkuMzctOS4zN1Y5OC4zOGgzLjN2Ny41MmgxMXYyLjg0aC0xMXYyMi4xN2MwLDQuNDIsMi4xOCw2Ljg2LDYuNCw2Ljg2YTgsOCwwLDAsMCw1LjM1LTEuOTFaIi8+PHBhdGggY2xhc3M9ImNscy0yIiBkPSJNMzkzLjY5LDk0Ljg5YTIuNzMsMi43MywwLDAsMSwyLjcxLTIuNzEsMi42OCwyLjY4LDAsMSwxLTIuNzEsMi43MVptMS4wNiwxMWgzLjN2MzQuNDRoLTMuM1oiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik00MjEuMzksMTIzLjEyYzAtMTAuMjIsNy4zMi0xNy40OCwxNy4yMi0xNy40OHMxNy4yMiw3LjI2LDE3LjIyLDE3LjQ4LTcuMzIsMTcuNDktMTcuMjIsMTcuNDlTNDIxLjM5LDEzMy4zNSw0MjEuMzksMTIzLjEyWm0zMS4wOCwwYzAtOC42NC01Ljk0LTE0LjUxLTEzLjg2LTE0LjUxcy0xMy44NSw1Ljg3LTEzLjg1LDE0LjUxLDUuOTMsMTQuNTIsMTMuODUsMTQuNTJTNDUyLjQ3LDEzMS43Nyw0NTIuNDcsMTIzLjEyWiIvPjxwYXRoIGNsYXNzPSJjbHMtMiIgZD0iTTUxMCwxMjAuMjJ2MjAuMTJoLTMuM1YxMjAuNDhjMC03Ljc4LTQuMTYtMTEuODctMTEuMTUtMTEuODctOC4xMiwwLTEzLjA3LDUuMjEtMTMuMDcsMTMuMzl2MTguMzRoLTMuMjlWMTA1LjloMy4xN3Y3LjQ2YzIuMy00LjgyLDcuMTItNy43MiwxMy42NS03LjcyQzUwNC40MywxMDUuNjQsNTEwLDExMC41OSw1MTAsMTIwLjIyWiIvPjxwYXRoIGNsYXNzPSJjbHMtMiIgZD0iTTUzMS43MSwxMzYuMTlsMS41Mi0yLjY0YTIwLjA4LDIwLjA4LDAsMCwwLDEyLjQxLDQuMTVjNy4yNSwwLDEwLjE2LTIuNTcsMTAuMTYtNi40NiwwLTEwLTIyLjgzLTIuNjQtMjIuODMtMTYuMTcsMC01LjIxLDQuMzYtOS40MywxMy4wNy05LjQzLDQuMzUsMCw5LjEsMS4zMiwxMS44MSwzLjM3bC0xLjUyLDIuNjRBMTcuNywxNy43LDAsMCwwLDU0NiwxMDguNTRjLTYuNzMsMC05LjcsMi43Ny05LjcsNi40NywwLDEwLjM2LDIyLjgzLDMsMjIuODMsMTYuMTYsMCw1LjYxLTQuODIsOS40NC0xMy41OSw5LjQ0QzUzOS44MywxNDAuNjEsNTM0LjQyLDEzOC42OSw1MzEuNzEsMTM2LjE5WiIvPjwvZz48L2c+PC9zdmc+"
+             alt="Comremit" width="160" style="display:block;margin:0 auto;max-width:160px;height:auto;border:0;"/>
+    </td>
+</tr>
+{% endblock %}
+
+{% block banner %}
+<tr>
+    <td align="center" style="background-color:#E30613;padding:28px 40px 24px 40px;">
+        <p style="margin:0 0 6px 0;font-size:24px;font-weight:bold;color:#ffffff;
+                  font-family:Arial,Helvetica,sans-serif;line-height:1.2;">
+            Cambio de contrase&ntilde;a
+        </p>
+        <p style="margin:0;font-size:14px;color:rgba(255,255,255,0.85);font-family:Arial,Helvetica,sans-serif;">
+            Password reset request
+        </p>
+    </td>
+</tr>
 {% endblock %}
 
 {% block content %}
 <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
 
-    <!-- TITLE -->
-    <tr>
-        <td align="center" style="font-size:22px;font-weight:bold;color:#E30613;padding-bottom:6px;letter-spacing:-0.3px;font-family:Arial,Helvetica,sans-serif;">
-            Cambio de contrase&ntilde;a
-        </td>
-    </tr>
-    <tr>
-        <td align="center" style="font-size:16px;color:#888888;padding-bottom:28px;font-family:Arial,Helvetica,sans-serif;">
-            Change password
-        </td>
-    </tr>
-
     <!-- INSTRUCTION ES -->
     <tr>
-        <td align="center" style="font-size:14px;color:#1a1a1a;line-height:22px;padding-bottom:6px;font-family:Arial,Helvetica,sans-serif;">
+        <td style="font-size:14px;color:#1a1a1a;line-height:22px;padding-bottom:6px;font-family:Arial,Helvetica,sans-serif;">
             Hemos recibido una solicitud de cambio de contrase&ntilde;a.<br/>
             Introduce el siguiente c&oacute;digo de verificaci&oacute;n en la plataforma:
         </td>
     </tr>
     <!-- INSTRUCTION EN -->
     <tr>
-        <td align="center" style="font-size:13px;color:#888888;line-height:20px;padding-bottom:28px;font-family:Arial,Helvetica,sans-serif;">
+        <td style="font-size:13px;color:#888888;line-height:20px;padding-bottom:28px;font-family:Arial,Helvetica,sans-serif;">
             We received a request to change your password.<br/>
             Enter the verification code below in the platform:
         </td>
     </tr>
 
-    <!-- CODE BOXES -->
+    <!-- CODE UNDERLINE -->
     <tr>
-        <td align="center" style="padding-bottom:10px;">
+        <td align="center" style="padding:8px 0 20px 0;">
             <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:0 auto;">
                 <tr>
-                    {% for char in code %}
-                    <td style="width:48px;height:58px;border:2px solid #E30613;
-                                {% if not loop.last %}border-right:1px solid #e0e0e0;{% endif %}
-                                font-size:28px;font-weight:bold;text-align:center;vertical-align:middle;
-                                color:#E30613;background-color:#fff9f9;
-                                font-family:Arial,Helvetica,sans-serif;
-                                {% if loop.first %}border-radius:4px 0 0 4px;{% endif %}
-                                {% if loop.last %}border-radius:0 4px 4px 0;{% endif %}">
-                        {{ char }}
-                    </td>
+                    {% for char in code|split('') %}
+                    <td style="width:38px;padding:4px 2px 12px 2px;
+                                border-bottom:3px solid #E30613;
+                                font-size:36px;font-weight:bold;text-align:center;vertical-align:middle;
+                                color:#1a1a1a;line-height:1;
+                                font-family:'Courier New',Courier,monospace,Arial,Helvetica,sans-serif;">{{ char }}</td>
+                    {% if not loop.last %}
+                    <td style="width:12px;font-size:1px;line-height:1px;border:0;">&nbsp;</td>
+                    {% endif %}
                     {% endfor %}
                 </tr>
             </table>
@@ -81,10 +89,7 @@
 
     <!-- DISCLAIMER -->
     <tr>
-        <td align="center"
-            style="font-size:12px;color:#999999;line-height:20px;padding:12px 16px;
-                   background-color:#f8f8f8;border-left:3px solid #e0e0e0;text-align:left;
-                   font-family:Arial,Helvetica,sans-serif;">
+        <td style="font-size:12px;color:#999999;line-height:20px;font-family:Arial,Helvetica,sans-serif;">
             <strong style="color:#555555;">ES:</strong> Si no has solicitado este cambio, puedes ignorar este mensaje. Tu contrase&ntilde;a no ser&aacute; modificada.<br/>
             <strong style="color:#555555;">EN:</strong> If you did not request this change, you can safely ignore this email. Your password will not be modified.
         </td>
@@ -96,26 +101,27 @@
 {% block footer %}
 <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
     <tr>
-        <td align="center" style="color:#ffffff;font-size:14px;font-weight:bold;padding-bottom:6px;font-family:Arial,Helvetica,sans-serif;">
+        <td align="center" style="color:#ffffff;font-size:13px;font-weight:bold;padding-bottom:4px;font-family:Arial,Helvetica,sans-serif;">
             Comremit Solutions SL
         </td>
     </tr>
     <tr>
-        <td align="center" style="color:rgba(255,255,255,0.8);font-size:12px;line-height:18px;padding-bottom:4px;font-family:Arial,Helvetica,sans-serif;">
-            Pasaje del Carme, 24 &mdash; Sant Cugat del Vall&eacute;s, 08173 &mdash; Barcelona, Espa&ntilde;a
+        <td align="center" style="color:rgba(255,255,255,0.6);font-size:11px;line-height:18px;padding-bottom:10px;font-family:Arial,Helvetica,sans-serif;">
+            Pasaje del Carme, 24 &mdash; Sant Cugat del Vall&eacute;s, 08173 &mdash; Barcelona, Espa&ntilde;a &mdash; CIF: B10583565
         </td>
     </tr>
     <tr>
-        <td align="center" style="color:rgba(255,255,255,0.6);font-size:11px;padding-bottom:10px;font-family:Arial,Helvetica,sans-serif;">
-            CIF: B10583565
-        </td>
-    </tr>
-    <tr>
-        <td align="center">
+        <td align="center" style="padding-bottom:10px;">
             <a href="https://dashboard.comremit.com"
-               style="color:rgba(255,255,255,0.9);font-size:12px;text-decoration:underline;font-family:Arial,Helvetica,sans-serif;">
+               style="color:rgba(255,255,255,0.8);font-size:12px;text-decoration:underline;font-family:Arial,Helvetica,sans-serif;">
                 dashboard.comremit.com
             </a>
+        </td>
+    </tr>
+    <tr>
+        <td align="center" style="border-top:1px solid rgba(255,255,255,0.12);padding-top:12px;
+                                   font-size:11px;color:rgba(255,255,255,0.45);font-family:Arial,Helvetica,sans-serif;">
+            Este es un mensaje autom&aacute;tico &mdash; por favor no respondas a este correo.
         </td>
     </tr>
 </table>

--- a/templates/emails/password/forgot-password.sendmundo.html.twig
+++ b/templates/emails/password/forgot-password.sendmundo.html.twig
@@ -4,59 +4,67 @@
 
 {% block preheader %}Su c&oacute;digo de verificaci&oacute;n es {{ code }}. V&aacute;lido por 30 minutos.{% endblock %}
 
-{% block accent_color %}#D9000D{% endblock %}
-{% block footer_bg_color %}#D9000D{% endblock %}
+{% block brand_header %}
+<span style="font-size:20px;font-weight:bold;color:#ffffff;font-family:Arial,Helvetica,sans-serif;letter-spacing:0.5px;">
+    SendMundo
+</span>
+{% endblock %}
 
-{% block logo %}
-    <img src="https://www.sendmundo.com/img/header/comremit-logo.svg" alt="SendMundo"
-         width="180" style="display:block;margin:0 auto;max-width:180px;height:auto;border:0;"/>
+{% block logo_area %}
+<tr>
+    <td align="center" style="background-color:#ffffff;padding:20px 40px 16px 40px;border-bottom:1px solid #ebebeb;">
+        <img src="https://www.sendmundo.com/img/header/comremit-logo.svg"
+             alt="SendMundo" width="160" style="display:block;margin:0 auto;max-width:160px;height:auto;border:0;"/>
+    </td>
+</tr>
+{% endblock %}
+
+{% block banner %}
+<tr>
+    <td align="center" style="background-color:#D9000D;padding:28px 40px 24px 40px;">
+        <p style="margin:0 0 6px 0;font-size:24px;font-weight:bold;color:#ffffff;
+                  font-family:Arial,Helvetica,sans-serif;line-height:1.2;">
+            Cambio de contrase&ntilde;a
+        </p>
+        <p style="margin:0;font-size:14px;color:rgba(255,255,255,0.85);font-family:Arial,Helvetica,sans-serif;">
+            Password reset request
+        </p>
+    </td>
+</tr>
 {% endblock %}
 
 {% block content %}
 <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
 
-    <!-- TITLE -->
-    <tr>
-        <td align="center" style="font-size:22px;font-weight:bold;color:#D9000D;padding-bottom:6px;letter-spacing:-0.3px;font-family:Arial,Helvetica,sans-serif;">
-            Cambio de contrase&ntilde;a
-        </td>
-    </tr>
-    <tr>
-        <td align="center" style="font-size:16px;color:#888888;padding-bottom:28px;font-family:Arial,Helvetica,sans-serif;">
-            Change password
-        </td>
-    </tr>
-
     <!-- INSTRUCTION ES -->
     <tr>
-        <td align="center" style="font-size:14px;color:#1a1a1a;line-height:22px;padding-bottom:6px;font-family:Arial,Helvetica,sans-serif;">
+        <td style="font-size:14px;color:#1a1a1a;line-height:22px;padding-bottom:6px;font-family:Arial,Helvetica,sans-serif;">
             Hemos recibido una solicitud de cambio de contrase&ntilde;a.<br/>
             Introduce el siguiente c&oacute;digo de verificaci&oacute;n en la plataforma:
         </td>
     </tr>
     <!-- INSTRUCTION EN -->
     <tr>
-        <td align="center" style="font-size:13px;color:#888888;line-height:20px;padding-bottom:28px;font-family:Arial,Helvetica,sans-serif;">
+        <td style="font-size:13px;color:#888888;line-height:20px;padding-bottom:28px;font-family:Arial,Helvetica,sans-serif;">
             We received a request to change your password.<br/>
             Enter the verification code below in the platform:
         </td>
     </tr>
 
-    <!-- CODE BOXES -->
+    <!-- CODE UNDERLINE -->
     <tr>
-        <td align="center" style="padding-bottom:10px;">
+        <td align="center" style="padding:8px 0 20px 0;">
             <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:0 auto;">
                 <tr>
-                    {% for char in code %}
-                    <td style="width:48px;height:58px;border:2px solid #D9000D;
-                                {% if not loop.last %}border-right:1px solid #e0e0e0;{% endif %}
-                                font-size:28px;font-weight:bold;text-align:center;vertical-align:middle;
-                                color:#D9000D;background-color:#fff9f9;
-                                font-family:Arial,Helvetica,sans-serif;
-                                {% if loop.first %}border-radius:4px 0 0 4px;{% endif %}
-                                {% if loop.last %}border-radius:0 4px 4px 0;{% endif %}">
-                        {{ char }}
-                    </td>
+                    {% for char in code|split('') %}
+                    <td style="width:38px;padding:4px 2px 12px 2px;
+                                border-bottom:3px solid #D9000D;
+                                font-size:36px;font-weight:bold;text-align:center;vertical-align:middle;
+                                color:#1a1a1a;line-height:1;
+                                font-family:'Courier New',Courier,monospace,Arial,Helvetica,sans-serif;">{{ char }}</td>
+                    {% if not loop.last %}
+                    <td style="width:12px;font-size:1px;line-height:1px;border:0;">&nbsp;</td>
+                    {% endif %}
                     {% endfor %}
                 </tr>
             </table>
@@ -81,10 +89,7 @@
 
     <!-- DISCLAIMER -->
     <tr>
-        <td align="center"
-            style="font-size:12px;color:#999999;line-height:20px;padding:12px 16px;
-                   background-color:#f8f8f8;border-left:3px solid #e0e0e0;text-align:left;
-                   font-family:Arial,Helvetica,sans-serif;">
+        <td style="font-size:12px;color:#999999;line-height:20px;font-family:Arial,Helvetica,sans-serif;">
             <strong style="color:#555555;">ES:</strong> Si no has solicitado este cambio, puedes ignorar este mensaje. Tu contrase&ntilde;a no ser&aacute; modificada.<br/>
             <strong style="color:#555555;">EN:</strong> If you did not request this change, you can safely ignore this email. Your password will not be modified.
         </td>
@@ -96,26 +101,27 @@
 {% block footer %}
 <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
     <tr>
-        <td align="center" style="color:#ffffff;font-size:14px;font-weight:bold;padding-bottom:6px;font-family:Arial,Helvetica,sans-serif;">
+        <td align="center" style="color:#ffffff;font-size:13px;font-weight:bold;padding-bottom:4px;font-family:Arial,Helvetica,sans-serif;">
             SendMundo Communications and Finance Technologies SL
         </td>
     </tr>
     <tr>
-        <td align="center" style="color:rgba(255,255,255,0.8);font-size:12px;line-height:18px;padding-bottom:4px;font-family:Arial,Helvetica,sans-serif;">
-            Pasaje del Carme, 24 &mdash; Sant Cugat del Vall&eacute;s, 08173 &mdash; Barcelona, Espa&ntilde;a
+        <td align="center" style="color:rgba(255,255,255,0.6);font-size:11px;line-height:18px;padding-bottom:10px;font-family:Arial,Helvetica,sans-serif;">
+            Pasaje del Carme, 24 &mdash; Sant Cugat del Vall&eacute;s, 08173 &mdash; Barcelona, Espa&ntilde;a &mdash; CIF: B42981191
         </td>
     </tr>
     <tr>
-        <td align="center" style="color:rgba(255,255,255,0.6);font-size:11px;padding-bottom:10px;font-family:Arial,Helvetica,sans-serif;">
-            CIF: B42981191
-        </td>
-    </tr>
-    <tr>
-        <td align="center">
+        <td align="center" style="padding-bottom:10px;">
             <a href="https://dashboard.sendmundo.com"
-               style="color:rgba(255,255,255,0.9);font-size:12px;text-decoration:underline;font-family:Arial,Helvetica,sans-serif;">
+               style="color:rgba(255,255,255,0.8);font-size:12px;text-decoration:underline;font-family:Arial,Helvetica,sans-serif;">
                 dashboard.sendmundo.com
             </a>
+        </td>
+    </tr>
+    <tr>
+        <td align="center" style="border-top:1px solid rgba(255,255,255,0.12);padding-top:12px;
+                                   font-size:11px;color:rgba(255,255,255,0.45);font-family:Arial,Helvetica,sans-serif;">
+            Este es un mensaje autom&aacute;tico &mdash; por favor no respondas a este correo.
         </td>
     </tr>
 </table>


### PR DESCRIPTION
- Fix forgot-password: use code|split('') so Twig 3 iterates the string character by character ({% for char in code %} on a string produces nothing in Twig 3)
- Redesign all templates to match reference style: dark navy header, brand logo on white, colored banner with email type, dark navy footer
- Add website link (dashboard.comremit.com / dashboard.sendmundo.com) to footer of all templates
- Replace accent strip + colored footer with unified dark navy (#1e2a3a) header/footer across _base.html.twig
- Introduce logo_area and banner blocks in base for child templates
- Apply redesign to balance.comremit and balance.sendmundo as well