### PR TITLE
fix(migration): convert report_marked.data_array from PHP-serialized …

### DIFF
--- a/migrations/Version20260512100000.php
+++ b/migrations/Version20260512100000.php
@@ -16,14 +16,60 @@ final class Version20260512100000 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        // DBAL 4 removes Types::ARRAY. The column was stored as PHP-serialized text.
-        // Converting to JSON: existing rows with serialized data must be migrated manually
-        // before running this migration, or the column must be empty.
-        $this->addSql('ALTER TABLE report_marked ALTER COLUMN data_array TYPE JSON USING data_array::json');
+        // Postgres cannot deserialize PHP's serialize() format, so we convert each row in PHP first.
+        $rows = $this->connection->fetchAllAssociative(
+            'SELECT id, data_array FROM report_marked WHERE data_array IS NOT NULL'
+        );
+
+        foreach ($rows as $row) {
+            $value = (string) $row['data_array'];
+
+            // Already valid JSON (idempotent re-run guard)
+            json_decode($value);
+            if (json_last_error() === JSON_ERROR_NONE) {
+                continue;
+            }
+
+            $decoded = @unserialize($value, ['allowed_classes' => false]);
+            $this->abortIf(
+                $decoded === false && $value !== 'b:0;',
+                sprintf('report_marked row #%d: data_array is neither valid PHP-serialized nor JSON — manual inspection required', $row['id'])
+            );
+
+            $this->connection->executeStatement(
+                'UPDATE report_marked SET data_array = :json WHERE id = :id',
+                ['json' => json_encode($decoded, JSON_UNESCAPED_UNICODE), 'id' => $row['id']]
+            );
+        }
+
+        // All non-null values are now valid JSON — safe to change the column type.
+        $this->connection->executeStatement(
+            'ALTER TABLE report_marked ALTER COLUMN data_array TYPE JSON USING data_array::json'
+        );
     }
 
     public function down(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE report_marked ALTER COLUMN data_array TYPE TEXT');
+        // Revert column type to TEXT first (JSON values become their text representation).
+        $this->connection->executeStatement(
+            'ALTER TABLE report_marked ALTER COLUMN data_array TYPE TEXT'
+        );
+
+        // Re-serialize JSON values back to PHP serialized format for symmetry.
+        $rows = $this->connection->fetchAllAssociative(
+            'SELECT id, data_array FROM report_marked WHERE data_array IS NOT NULL'
+        );
+
+        foreach ($rows as $row) {
+            $decoded = json_decode((string) $row['data_array'], true);
+            if ($decoded === null && json_last_error() !== JSON_ERROR_NONE) {
+                continue;
+            }
+
+            $this->connection->executeStatement(
+                'UPDATE report_marked SET data_array = :serialized WHERE id = :id',
+                ['serialized' => serialize($decoded), 'id' => $row['id']]
+            );
+        }
     }
 }


### PR DESCRIPTION
…to JSON in-place

The original migration used `USING data_array::json` which fails when rows contain PHP-serialized data (DBAL Types::ARRAY legacy format). Rewrote up() to unserialize each row in PHP and UPDATE before the ALTER, and down() to re-serialize back symmetrically.