### PR TITLE
feat(sys-config): add encrypted value support + wire api.communicatio…

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -60,3 +60,9 @@ APP_MAILER_FROM=noreply@example.com
 APP_ERROR_RECIPIENTS=admin@example.com
 COMREMIT_DASHBOARD_URL=https://dashboard.comremit.com
 SENDMUNDO_DASHBOARD_URL=https://dashboard.sendmundo.com
+
+###> SysConfig encryption ###
+# Clave AES para cifrar valores sensibles en sys_config (ej: api.communications.key)
+# Generar con: openssl rand -hex 32
+SYS_CONFIG_ENCRYPTION_KEY=change-me-generate-with-openssl-rand-hex-32
+###< SysConfig encryption ###

--- a/.env.vps.prod.example
+++ b/.env.vps.prod.example
@@ -47,7 +47,12 @@ CORS_DASHBOARD_ORIGIN='^https://dashboard\.comremit\.com$$'
 # --- Otros ---
 MICROSOFT_URL=https://login.microsoftonline.com
 APP_TEST_PHONE=5350499650
-APP_MAILER_FROM=soporte@comremit.com
+APP_MAILER_FROM=info@comremit.com
 APP_ERROR_RECIPIENTS=aportela7@gmail.com,alexander.afonsecac@gmail.com
 COMREMIT_DASHBOARD_URL=https://dashboard.comremit.com
 SENDMUNDO_DASHBOARD_URL=https://dashboard.sendmundo.com
+
+# --- SysConfig encryption ---
+# Clave AES para cifrar valores sensibles en sys_config (ej: api.communications.key)
+# Generar con: openssl rand -hex 32
+SYS_CONFIG_ENCRYPTION_KEY=CHANGE_ME_GENERATE_WITH_openssl_rand_hex_32

--- a/.env.vps.staging.example
+++ b/.env.vps.staging.example
@@ -49,3 +49,7 @@ APP_MAILER_FROM=soporte@comremit.com
 APP_ERROR_RECIPIENTS=afonsecacardosa@gmail.com
 COMREMIT_DASHBOARD_URL=https://dashboard-staging.comremit.com
 SENDMUNDO_DASHBOARD_URL=https://dashboard-staging.sendmundo.com
+# --- SysConfig encryption ---
+# Clave AES para cifrar valores sensibles en sys_config (ej: api.communications.key)
+# Generar con: openssl rand -hex 32
+SYS_CONFIG_ENCRYPTION_KEY=CHANGE_ME_GENERATE_WITH_openssl_rand_hex_32

--- a/migrations/Version20260515000000.php
+++ b/migrations/Version20260515000000.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260515000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add is_encrypted column to sys_config to support encrypted property values';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE sys_config
+                ADD COLUMN IF NOT EXISTS is_encrypted BOOLEAN NOT NULL DEFAULT FALSE
+        SQL);
+        // Drop the DB-level default — Doctrine manages it in PHP
+        $this->addSql('ALTER TABLE sys_config ALTER COLUMN is_encrypted DROP DEFAULT');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE sys_config DROP COLUMN IF EXISTS is_encrypted');
+    }
+}

--- a/src/Controller/DashboardSysConfigController.php
+++ b/src/Controller/DashboardSysConfigController.php
@@ -168,7 +168,8 @@ class DashboardSysConfigController extends AbstractController
         return [
             'id'            => $config->getId(),
             'propertyName'  => $config->getPropertyName(),
-            'propertyValue' => $config->getPropertyValue(),
+            'propertyValue' => $config->isEncrypted() ? '***' : $config->getPropertyValue(),
+            'isEncrypted'   => $config->isEncrypted(),
             'isActive'      => $config->isActive(),
             'clients'       => $config->getClients(),
             'createdAt'     => $config->getCreatedAt()?->format('c'),

--- a/src/DTO/CreateSysConfigDto.php
+++ b/src/DTO/CreateSysConfigDto.php
@@ -22,16 +22,21 @@ class CreateSysConfigDto implements IInput
     #[OAProperty(schema: ['type' => 'array', 'items' => ['type' => 'integer'], 'nullable' => true], description: 'IDs de clientes a los que aplica esta variable. null significa que aplica a todos')]
     protected ?array $clients;
 
+    #[OAProperty(description: 'Si true, el valor se almacena cifrado en la BD y sólo se expone como "***" en la API')]
+    protected ?bool $isEncrypted;
+
     public function __construct(
         ?string $propertyName = null,
         ?string $propertyValue = null,
         ?bool $isActive = null,
         ?array $clients = null,
+        ?bool $isEncrypted = null,
     ) {
         $this->propertyName  = $propertyName;
         $this->propertyValue = $propertyValue;
         $this->isActive      = $isActive;
         $this->clients       = $clients;
+        $this->isEncrypted   = $isEncrypted;
     }
 
     public function getPropertyName(): ?string { return $this->propertyName; }
@@ -45,4 +50,7 @@ class CreateSysConfigDto implements IInput
 
     public function getClients(): ?array { return $this->clients; }
     public function setClients(?array $v): void { $this->clients = $v; }
+
+    public function getIsEncrypted(): ?bool { return $this->isEncrypted; }
+    public function setIsEncrypted(?bool $v): void { $this->isEncrypted = $v; }
 }

--- a/src/DTO/UpdateSysConfigDto.php
+++ b/src/DTO/UpdateSysConfigDto.php
@@ -20,16 +20,21 @@ class UpdateSysConfigDto implements IInput
     #[OAProperty(schema: ['type' => 'array', 'items' => ['type' => 'integer'], 'nullable' => true], description: 'IDs de clientes a los que aplica. null significa que aplica a todos')]
     protected ?array $clients;
 
+    #[OAProperty(description: 'Cambiar el modo de cifrado del valor')]
+    protected ?bool $isEncrypted;
+
     public function __construct(
         ?string $propertyName = null,
         ?string $propertyValue = null,
         ?bool $isActive = null,
         ?array $clients = null,
+        ?bool $isEncrypted = null,
     ) {
         $this->propertyName  = $propertyName;
         $this->propertyValue = $propertyValue;
         $this->isActive      = $isActive;
         $this->clients       = $clients;
+        $this->isEncrypted   = $isEncrypted;
     }
 
     public function getPropertyName(): ?string { return $this->propertyName; }
@@ -43,4 +48,7 @@ class UpdateSysConfigDto implements IInput
 
     public function getClients(): ?array { return $this->clients; }
     public function setClients(?array $v): void { $this->clients = $v; }
+
+    public function getIsEncrypted(): ?bool { return $this->isEncrypted; }
+    public function setIsEncrypted(?bool $v): void { $this->isEncrypted = $v; }
 }

--- a/src/Entity/SysConfig.php
+++ b/src/Entity/SysConfig.php
@@ -36,6 +36,9 @@ class SysConfig
     #[ORM\Column(type: Types::JSON, nullable: true)]
     private ?array $clients = null;
 
+    #[ORM\Column]
+    private bool $isEncrypted = false;
+
     public function getId(): ?int
     {
         return $this->id;
@@ -121,6 +124,18 @@ class SysConfig
     public function setClients(?array $clients): static
     {
         $this->clients = $clients;
+
+        return $this;
+    }
+
+    public function isEncrypted(): bool
+    {
+        return $this->isEncrypted;
+    }
+
+    public function setIsEncrypted(bool $isEncrypted): static
+    {
+        $this->isEncrypted = $isEncrypted;
 
         return $this;
     }

--- a/src/Repository/SysConfigRepository.php
+++ b/src/Repository/SysConfigRepository.php
@@ -3,6 +3,7 @@
 namespace App\Repository;
 
 use App\Entity\SysConfig;
+use App\Service\SysConfigCipher;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -25,12 +26,15 @@ class SysConfigRepository extends ServiceEntityRepository
         ManagerRegistry $registry,
         #[Autowire(service: 'cache.sys_config')]
         private readonly TagAwareCacheInterface $cache,
+        #[Autowire('%env(default::SYS_CONFIG_ENCRYPTION_KEY)%')]
+        private readonly string $encryptionKey = '',
     ) {
         parent::__construct($registry, SysConfig::class);
     }
 
     /**
      * Devuelve el propertyValue de una configuración, usando caché.
+     * Si el valor está cifrado, lo descifra antes de devolver (y cachea el valor descifrado).
      * Para lecturas de escritura (update de la entidad), usar findOneBy() directamente.
      */
     public function findCachedValue(string $propertyName, bool $mustBeActive = false): ?string
@@ -43,7 +47,15 @@ class SysConfigRepository extends ServiceEntityRepository
             if ($mustBeActive) {
                 $criteria['isActive'] = true;
             }
-            return $this->findOneBy($criteria)?->getPropertyValue();
+            $config = $this->findOneBy($criteria);
+            if ($config === null) {
+                return null;
+            }
+            $value = $config->getPropertyValue();
+            if ($config->isEncrypted() && $value !== null && $this->encryptionKey !== '') {
+                $value = SysConfigCipher::decrypt($value, $this->encryptionKey);
+            }
+            return $value;
         });
     }
 

--- a/src/Service/Etecsa/EtecsaGatewayClient.php
+++ b/src/Service/Etecsa/EtecsaGatewayClient.php
@@ -37,7 +37,6 @@ class EtecsaGatewayClient extends CommonService
         SerializerInterface $serializer,
         private readonly HttpClientInterface $httpClient,
         #[Autowire('@monolog.logger.etecsa')] private readonly LoggerInterface $etecsaLogger,
-        #[Autowire('%env(API_COMMUNICATIONS_KEY)%')] private readonly string $apiKey,
         #[Autowire('%env(APP_TEST_PHONE)%')] private readonly string $testPhone,
     ) {
         parent::__construct($em, $security, $parameters, $mailer, $logger, $passwordHasher, $environmentRepository, $sysConfigRepo, $serializer);
@@ -189,13 +188,18 @@ class EtecsaGatewayClient extends CommonService
         $url = $env->getBasePath() . $path;
         $start = microtime(true);
 
+        $apiKey = $this->sysConfigRepo->findCachedValue('api.' . strtolower($env->getType()) . '.communications.key');
+        $headers = [
+            'Content-Type' => 'application/json',
+            'Accept'       => 'application/json',
+        ];
+        if ($apiKey !== null && $apiKey !== '') {
+            $headers['X-Api-Key'] = $apiKey;
+        }
+
         try {
             $response = $this->httpClient->request('POST', $url, [
-                'headers' => [
-                    'Content-Type'  => 'application/json',
-                    'Accept'        => 'application/json',
-                    'X-Api-Key'     => $this->apiKey,
-                ],
+                'headers' => $headers,
                 'body' => $this->serializer->serialize($body, 'json'),
             ]);
 

--- a/src/Service/SysConfigAdminService.php
+++ b/src/Service/SysConfigAdminService.php
@@ -7,7 +7,9 @@ use App\DTO\UpdateSysConfigDto;
 use App\Entity\SysConfig;
 use App\Exception\MyCurrentException;
 use App\Repository\SysConfigRepository;
+use App\Service\SysConfigCipher;
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\Response;
 
 class SysConfigAdminService
@@ -15,6 +17,8 @@ class SysConfigAdminService
     public function __construct(
         private readonly EntityManagerInterface $em,
         private readonly SysConfigRepository $sysConfigRepo,
+        #[Autowire('%env(default::SYS_CONFIG_ENCRYPTION_KEY)%')]
+        private readonly string $encryptionKey = '',
     ) {}
 
     public function create(CreateSysConfigDto $dto): SysConfig
@@ -28,9 +32,17 @@ class SysConfigAdminService
             );
         }
 
+        $isEncrypted = $dto->getIsEncrypted() ?? false;
+        $value = $dto->getPropertyValue();
+        if ($isEncrypted) {
+            $this->assertEncryptionKeyAvailable();
+            $value = SysConfigCipher::encrypt($value, $this->encryptionKey);
+        }
+
         $config = new SysConfig();
         $config->setPropertyName($dto->getPropertyName());
-        $config->setPropertyValue($dto->getPropertyValue());
+        $config->setPropertyValue($value);
+        $config->setIsEncrypted($isEncrypted);
         $config->setIsActive($dto->getIsActive() ?? true);
         $config->setClients($dto->getClients());
 
@@ -55,8 +67,29 @@ class SysConfigAdminService
             $config->setPropertyName($dto->getPropertyName());
         }
 
+        $currentIsEncrypted = $config->isEncrypted();
+        $newIsEncrypted = $dto->getIsEncrypted() ?? $currentIsEncrypted;
+
         if ($dto->getPropertyValue() !== null) {
-            $config->setPropertyValue($dto->getPropertyValue());
+            $value = $dto->getPropertyValue();
+            if ($newIsEncrypted) {
+                $this->assertEncryptionKeyAvailable();
+                $value = SysConfigCipher::encrypt($value, $this->encryptionKey);
+            }
+            $config->setPropertyValue($value);
+        } elseif ($newIsEncrypted !== $currentIsEncrypted) {
+            // Cambio de modo sin nuevo valor: re-cifrar o descifrar el valor existente
+            $stored = $config->getPropertyValue() ?? '';
+            $this->assertEncryptionKeyAvailable();
+            if ($newIsEncrypted) {
+                $config->setPropertyValue(SysConfigCipher::encrypt($stored, $this->encryptionKey));
+            } else {
+                $config->setPropertyValue(SysConfigCipher::decrypt($stored, $this->encryptionKey));
+            }
+        }
+
+        if ($dto->getIsEncrypted() !== null) {
+            $config->setIsEncrypted($newIsEncrypted);
         }
 
         if ($dto->getIsActive() !== null) {
@@ -87,5 +120,16 @@ class SysConfigAdminService
         $config->setRemovedAt(new \DateTimeImmutable('now'));
         $this->em->flush();
         $this->sysConfigRepo->invalidateCache();
+    }
+
+    private function assertEncryptionKeyAvailable(): void
+    {
+        if ($this->encryptionKey === '') {
+            throw new MyCurrentException(
+                'SYS_CONFIG_ENCRYPTION_KEY_MISSING',
+                'La variable de entorno SYS_CONFIG_ENCRYPTION_KEY no está configurada.',
+                Response::HTTP_INTERNAL_SERVER_ERROR
+            );
+        }
     }
 }

--- a/src/Service/SysConfigCipher.php
+++ b/src/Service/SysConfigCipher.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Service;
+
+final class SysConfigCipher
+{
+    public static function encrypt(string $plaintext, string $hexKey): string
+    {
+        $key = sodium_hex2bin($hexKey);
+        $nonce = random_bytes(SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
+        $ciphertext = sodium_crypto_secretbox($plaintext, $nonce, $key);
+        return base64_encode($nonce . $ciphertext);
+    }
+
+    public static function decrypt(string $encoded, string $hexKey): string
+    {
+        $key = sodium_hex2bin($hexKey);
+        $decoded = base64_decode($encoded, true);
+        if ($decoded === false || strlen($decoded) <= SODIUM_CRYPTO_SECRETBOX_NONCEBYTES) {
+            throw new \RuntimeException('SysConfig: datos cifrados inválidos');
+        }
+        $nonce = substr($decoded, 0, SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
+        $ciphertext = substr($decoded, SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
+        $plaintext = sodium_crypto_secretbox_open($ciphertext, $nonce, $key);
+        if ($plaintext === false) {
+            throw new \RuntimeException('SysConfig: falló el descifrado — clave incorrecta o dato corrompido');
+        }
+        return $plaintext;
+    }
+}


### PR DESCRIPTION
…ns.key per environment

- Add is_encrypted field to SysConfig entity and migration
- SysConfigCipher: XSalsa20-Poly1305 (libsodium) encrypt/decrypt driven by SYS_CONFIG_ENCRYPTION_KEY env var
- SysConfigAdminService: encrypts on create/update, re-encrypts/decrypts automatically when isEncrypted flag changes
- SysConfigRepository.findCachedValue: decrypts transparently before caching the plaintext value
- DashboardSysConfigController: masks encrypted values as "***" in API responses
- EtecsaGatewayClient: reads X-Api-Key from sys_config key api.{env}.communications.key (per-environment); omits header if absent