### PR TITLE
fix(sys-config): null-safe env injection for SYS_CONFIG_ENCRYPTION_KEY

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -60,3 +60,9 @@ APP_MAILER_FROM=noreply@example.com
 APP_ERROR_RECIPIENTS=admin@example.com
 COMREMIT_DASHBOARD_URL=https://dashboard.comremit.com
 SENDMUNDO_DASHBOARD_URL=https://dashboard.sendmundo.com
+
+###> SysConfig encryption ###
+# Clave AES para cifrar valores sensibles en sys_config (ej: api.communications.key)
+# Generar con: openssl rand -hex 32
+SYS_CONFIG_ENCRYPTION_KEY=change-me-generate-with-openssl-rand-hex-32
+###< SysConfig encryption ###

--- a/.env.vps.prod.example
+++ b/.env.vps.prod.example
@@ -47,7 +47,12 @@ CORS_DASHBOARD_ORIGIN='^https://dashboard\.comremit\.com$$'
 # --- Otros ---
 MICROSOFT_URL=https://login.microsoftonline.com
 APP_TEST_PHONE=5350499650
-APP_MAILER_FROM=soporte@comremit.com
+APP_MAILER_FROM=info@comremit.com
 APP_ERROR_RECIPIENTS=aportela7@gmail.com,alexander.afonsecac@gmail.com
 COMREMIT_DASHBOARD_URL=https://dashboard.comremit.com
 SENDMUNDO_DASHBOARD_URL=https://dashboard.sendmundo.com
+
+# --- SysConfig encryption ---
+# Clave AES para cifrar valores sensibles en sys_config (ej: api.communications.key)
+# Generar con: openssl rand -hex 32
+SYS_CONFIG_ENCRYPTION_KEY=CHANGE_ME_GENERATE_WITH_openssl_rand_hex_32

--- a/.env.vps.staging.example
+++ b/.env.vps.staging.example
@@ -49,3 +49,7 @@ APP_MAILER_FROM=soporte@comremit.com
 APP_ERROR_RECIPIENTS=afonsecacardosa@gmail.com
 COMREMIT_DASHBOARD_URL=https://dashboard-staging.comremit.com
 SENDMUNDO_DASHBOARD_URL=https://dashboard-staging.sendmundo.com
+# --- SysConfig encryption ---
+# Clave AES para cifrar valores sensibles en sys_config (ej: api.communications.key)
+# Generar con: openssl rand -hex 32
+SYS_CONFIG_ENCRYPTION_KEY=CHANGE_ME_GENERATE_WITH_openssl_rand_hex_32

--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,10 @@
         "ext-amqp": "*",
         "ext-ctype": "*",
         "ext-iconv": "*",
-        "api-platform/core": "v3.4.17",
+        "api-platform/core": "^4.3",
         "chillerlan/php-qrcode": "^5.0",
-        "doctrine/annotations": "^2.0",
-        "doctrine/dbal": "^3",
-        "doctrine/doctrine-bundle": "^2.11",
+        "doctrine/dbal": "^4",
+        "doctrine/doctrine-bundle": "^3.0",
         "doctrine/doctrine-migrations-bundle": "^3.3",
         "doctrine/orm": "^3.2.2",
         "dragonmantank/cron-expression": "^3.3",
@@ -22,32 +21,32 @@
         "nelmio/cors-bundle": "^2.3",
         "phpdocumentor/reflection-docblock": "^5.3",
         "phpstan/phpdoc-parser": "^1.24",
-        "symfony/amqp-messenger": "7.4.*",
-        "symfony/asset": "7.4.*",
-        "symfony/console": "7.4.*",
-        "symfony/doctrine-messenger": "7.4.*",
-        "symfony/dotenv": "7.4.*",
-        "symfony/expression-language": "7.4.*",
+        "symfony/amqp-messenger": "8.0.*",
+        "symfony/asset": "8.0.*",
+        "symfony/console": "8.0.*",
+        "symfony/doctrine-messenger": "8.0.*",
+        "symfony/dotenv": "8.0.*",
+        "symfony/expression-language": "8.0.*",
         "symfony/flex": "^2",
-        "symfony/framework-bundle": "7.4.*",
-        "symfony/http-client": "7.4.*",
-        "symfony/intl": "7.4.*",
-        "symfony/mailer": "7.4.*",
-        "symfony/messenger": "7.4.*",
+        "symfony/framework-bundle": "8.0.*",
+        "symfony/http-client": "8.0.*",
+        "symfony/intl": "8.0.*",
+        "symfony/mailer": "8.0.*",
+        "symfony/messenger": "8.0.*",
         "symfony/monolog-bundle": "^3.10 || ^4.0",
-        "symfony/notifier": "7.4.*",
-        "symfony/property-access": "7.4.*",
-        "symfony/property-info": "7.4.*",
-        "symfony/rate-limiter": "7.4.*",
+        "symfony/notifier": "8.0.*",
+        "symfony/property-access": "8.0.*",
+        "symfony/property-info": "8.0.*",
+        "symfony/rate-limiter": "8.0.*",
         "symfony/requirements-checker": "^2",
-        "symfony/runtime": "7.4.*",
-        "symfony/scheduler": "7.4.*",
-        "symfony/security-bundle": "7.4.*",
-        "symfony/serializer": "7.4.*",
-        "symfony/twig-bundle": "7.4.*",
-        "symfony/uid": "7.4.*",
-        "symfony/validator": "7.4.*",
-        "symfony/yaml": "7.4.*"
+        "symfony/runtime": "8.0.*",
+        "symfony/scheduler": "8.0.*",
+        "symfony/security-bundle": "8.0.*",
+        "symfony/serializer": "8.0.*",
+        "symfony/twig-bundle": "8.0.*",
+        "symfony/uid": "8.0.*",
+        "symfony/validator": "8.0.*",
+        "symfony/yaml": "8.0.*"
     },
     "config": {
         "allow-plugins": {
@@ -103,7 +102,7 @@
     "extra": {
         "symfony": {
             "allow-contrib": false,
-            "require": "7.4.*"
+            "require": "8.0.*"
         }
     },
     "require-dev": {
@@ -111,6 +110,6 @@
         "phpstan/phpstan-symfony": "^2.0",
         "roave/security-advisories": "dev-latest",
         "symfony/maker-bundle": "^1.63",
-        "symfony/phpunit-bridge": "^7.4"
+        "symfony/phpunit-bridge": "^8.0"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,47 +4,50 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "25afcf2dc7059c101fe55df87eae732d",
+    "content-hash": "f7eb3b41aae1376d78cd422b43417fd2",
     "packages": [
         {
             "name": "api-platform/core",
-            "version": "v3.4.17",
+            "version": "v4.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/api-platform/core.git",
-                "reference": "c5fb664d17ed9ae919394514ea69a5039d2ad9ab"
+                "reference": "ad027fbbe1b64294174b962c9d9f02d0a3bca7a7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/api-platform/core/zipball/c5fb664d17ed9ae919394514ea69a5039d2ad9ab",
-                "reference": "c5fb664d17ed9ae919394514ea69a5039d2ad9ab",
+                "url": "https://api.github.com/repos/api-platform/core/zipball/ad027fbbe1b64294174b962c9d9f02d0a3bca7a7",
+                "reference": "ad027fbbe1b64294174b962c9d9f02d0a3bca7a7",
                 "shasum": ""
             },
             "require": {
-                "doctrine/inflector": "^1.0 || ^2.0",
-                "php": ">=8.1",
+                "composer/semver": "^3.4",
+                "doctrine/inflector": "^2.0",
+                "php": ">=8.2",
                 "psr/cache": "^1.0 || ^2.0 || ^3.0",
                 "psr/container": "^1.0 || ^2.0",
                 "symfony/deprecation-contracts": "^3.1",
-                "symfony/http-foundation": "^6.4 || ^7.1",
-                "symfony/http-kernel": "^6.4 || ^7.1",
-                "symfony/property-access": "^6.4 || ^7.1",
-                "symfony/property-info": "^6.4 || ^7.1",
-                "symfony/serializer": "^6.4 || ^7.1",
+                "symfony/http-foundation": "^6.4.14 || ^7.0 || ^8.0",
+                "symfony/http-kernel": "^6.4.13 || ^7.0 || ^8.0",
+                "symfony/property-access": "^6.4 || ^7.0 || ^8.0",
+                "symfony/property-info": "^6.4 || ^7.1 || ^8.0",
+                "symfony/serializer": "^6.4 || ^7.0 || ^8.0",
                 "symfony/translation-contracts": "^3.3",
-                "symfony/web-link": "^6.4 || ^7.1",
-                "willdurand/negotiation": "^3.0"
+                "symfony/type-info": "^7.4 || ^8.0",
+                "symfony/validator": "^6.4.11 || ^7.1 || ^8.0",
+                "symfony/web-link": "^6.4 || ^7.1 || ^8.0",
+                "willdurand/negotiation": "^3.1"
             },
             "conflict": {
                 "doctrine/common": "<3.2.2",
                 "doctrine/dbal": "<2.10",
                 "doctrine/mongodb-odm": "<2.4",
-                "doctrine/orm": "<2.14.0",
+                "doctrine/orm": "<2.14.0 || 3.0.0",
                 "doctrine/persistence": "<1.3",
-                "elasticsearch/elasticsearch": ">=8.0,<8.4",
                 "phpspec/prophecy": "<1.15",
                 "phpunit/phpunit": "<9.5",
                 "symfony/framework-bundle": "6.4.6 || 7.0.6",
+                "symfony/object-mapper": "<7.3.4",
                 "symfony/var-exporter": "<6.1.1"
             },
             "replace": {
@@ -54,13 +57,14 @@
                 "api-platform/documentation": "self.version",
                 "api-platform/elasticsearch": "self.version",
                 "api-platform/graphql": "self.version",
+                "api-platform/hal": "self.version",
                 "api-platform/http-cache": "self.version",
                 "api-platform/hydra": "self.version",
                 "api-platform/json-api": "self.version",
-                "api-platform/json-hal": "self.version",
                 "api-platform/json-schema": "self.version",
                 "api-platform/jsonld": "self.version",
                 "api-platform/laravel": "self.version",
+                "api-platform/mcp": "self.version",
                 "api-platform/metadata": "self.version",
                 "api-platform/openapi": "self.version",
                 "api-platform/parameter-validator": "self.version",
@@ -71,93 +75,84 @@
                 "api-platform/validator": "self.version"
             },
             "require-dev": {
-                "api-platform/doctrine-common": "^3.4 || ^4.0",
-                "api-platform/doctrine-odm": "^3.4 || ^4.0",
-                "api-platform/doctrine-orm": "^3.4 || ^4.0",
-                "api-platform/documentation": "^3.4 || ^4.0",
-                "api-platform/elasticsearch": "^3.4 || ^4.0",
-                "api-platform/graphql": "^3.4 || ^4.0",
-                "api-platform/http-cache": "^3.4 || ^4.0",
-                "api-platform/hydra": "^3.4 || ^4.0",
-                "api-platform/json-api": "^3.3 || ^4.0",
-                "api-platform/json-schema": "^3.4 || ^4.0",
-                "api-platform/jsonld": "^3.4 || ^4.0",
-                "api-platform/metadata": "^3.4 || ^4.0",
-                "api-platform/openapi": "^3.4 || ^4.0",
-                "api-platform/parameter-validator": "^3.4",
-                "api-platform/ramsey-uuid": "^3.4 || ^4.0",
-                "api-platform/serializer": "^3.4 || ^4.0",
-                "api-platform/state": "^3.4 || ^4.0",
-                "api-platform/validator": "^3.4 || ^4.0",
                 "behat/behat": "^3.11",
                 "behat/mink": "^1.9",
-                "doctrine/cache": "^1.11 || ^2.1",
                 "doctrine/common": "^3.2.2",
-                "doctrine/dbal": "^3.4.0 || ^4.0",
-                "doctrine/doctrine-bundle": "^1.12 || ^2.0",
-                "doctrine/mongodb-odm": "^2.2",
-                "doctrine/mongodb-odm-bundle": "^4.0 || ^5.0",
-                "doctrine/orm": "^2.14 || ^3.0",
-                "elasticsearch/elasticsearch": "^7.11 || ^8.4",
+                "doctrine/dbal": "^4.0",
+                "doctrine/doctrine-bundle": "^2.11 || ^3.1",
+                "doctrine/orm": "^2.17 || ^3.0",
+                "elasticsearch/elasticsearch": "^7.17 || ^8.4 || ^9.0",
                 "friends-of-behat/mink-browserkit-driver": "^1.3.1",
                 "friends-of-behat/mink-extension": "^2.2",
                 "friends-of-behat/symfony-extension": "^2.1",
-                "guzzlehttp/guzzle": "^6.0 || ^7.1",
-                "jangregor/phpstan-prophecy": "^1.0",
-                "justinrainbow/json-schema": "^5.2.1",
-                "phpspec/prophecy-phpunit": "^2.0",
+                "friendsofphp/php-cs-fixer": "^3.93",
+                "guzzlehttp/guzzle": "^6.0 || ^7.0",
+                "illuminate/config": "^11.0 || ^12.0 || ^13.0",
+                "illuminate/contracts": "^11.0 || ^12.0 || ^13.0",
+                "illuminate/database": "^11.0 || ^12.0 || ^13.0",
+                "illuminate/http": "^11.0 || ^12.0 || ^13.0",
+                "illuminate/pagination": "^11.0 || ^12.0 || ^13.0",
+                "illuminate/routing": "^11.0 || ^12.0 || ^13.0",
+                "illuminate/support": "^11.0 || ^12.0 || ^13.0",
+                "jangregor/phpstan-prophecy": "^2.1.11",
+                "justinrainbow/json-schema": "^6.5.2",
+                "laravel/framework": "^11.0 || ^12.0 || ^13.0",
+                "mcp/sdk": ">=0.4 <1.0",
+                "orchestra/testbench": "^10.9 || ^11.0",
+                "phpspec/prophecy-phpunit": "^2.2",
                 "phpstan/extension-installer": "^1.1",
-                "phpstan/phpdoc-parser": "^1.13|^2.0",
-                "phpstan/phpstan": "^1.10",
-                "phpstan/phpstan-doctrine": "^1.0",
-                "phpstan/phpstan-phpunit": "^1.0",
-                "phpstan/phpstan-symfony": "^1.0",
-                "phpunit/phpunit": "^9.6",
+                "phpstan/phpdoc-parser": "^1.29 || ^2.0",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-doctrine": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-symfony": "^2.0",
+                "phpunit/phpunit": "^11.5 || ^12.2",
                 "psr/log": "^1.0 || ^2.0 || ^3.0",
-                "ramsey/uuid": "^3.9.7 || ^4.0",
-                "ramsey/uuid-doctrine": "^1.4 || ^2.0 || ^3.0",
-                "sebastian/comparator": "<5.0",
-                "soyuka/contexts": "v3.3.9",
-                "soyuka/pmu": "^0.0.12",
+                "ramsey/uuid": "^4.7",
+                "ramsey/uuid-doctrine": "^2.0",
+                "soyuka/contexts": "^3.3.10",
+                "soyuka/pmu": "^0.2.0",
                 "soyuka/stubs-mongodb": "^1.0",
-                "symfony/asset": "^6.4 || ^7.1",
-                "symfony/browser-kit": "^6.4 || ^7.1",
-                "symfony/cache": "^6.4 || ^7.1",
-                "symfony/config": "^6.4 || ^7.1",
-                "symfony/console": "^6.4 || ^7.1",
-                "symfony/css-selector": "^6.4 || ^7.1",
-                "symfony/dependency-injection": "^6.4 || ^7.1",
-                "symfony/doctrine-bridge": "^6.4 || ^7.1",
-                "symfony/dom-crawler": "^6.4 || ^7.1",
-                "symfony/error-handler": "^6.4 || ^7.1",
-                "symfony/event-dispatcher": "^6.4 || ^7.1",
-                "symfony/expression-language": "^6.4 || ^7.1",
-                "symfony/finder": "^6.4 || ^7.1",
-                "symfony/form": "^6.4 || ^7.1",
-                "symfony/framework-bundle": "^6.4 || ^7.1",
-                "symfony/http-client": "^6.4 || ^7.1",
-                "symfony/intl": "^6.4 || ^7.1",
+                "symfony/asset": "^6.4 || ^7.0 || ^8.0",
+                "symfony/browser-kit": "^6.4 || ^7.0 || ^8.0",
+                "symfony/cache": "^6.4 || ^7.0 || ^8.0",
+                "symfony/config": "^6.4 || ^7.0 || ^8.0",
+                "symfony/console": "^6.4 || ^7.0 || ^8.0",
+                "symfony/css-selector": "^6.4 || ^7.0 || ^8.0",
+                "symfony/dependency-injection": "^6.4 || ^7.0 || ^8.0",
+                "symfony/doctrine-bridge": "^6.4.2 || ^7.1 || ^8.0",
+                "symfony/dom-crawler": "^6.4 || ^7.0 || ^8.0",
+                "symfony/error-handler": "^6.4 || ^7.0 || ^8.0",
+                "symfony/event-dispatcher": "^6.4 || ^7.0 || ^8.0",
+                "symfony/expression-language": "^6.4 || ^7.0 || ^8.0",
+                "symfony/finder": "^6.4 || ^7.0 || ^8.0",
+                "symfony/form": "^6.4 || ^7.0 || ^8.0",
+                "symfony/framework-bundle": "^6.4 || ^7.0 || ^8.0",
+                "symfony/http-client": "^6.4 || ^7.0 || ^8.0",
+                "symfony/intl": "^6.4 || ^7.0 || ^8.0",
+                "symfony/json-streamer": "^7.4 || ^8.0",
                 "symfony/maker-bundle": "^1.24",
+                "symfony/mcp-bundle": "dev-main",
                 "symfony/mercure-bundle": "*",
-                "symfony/messenger": "^6.4 || ^7.1",
-                "symfony/phpunit-bridge": "^6.4.1 || ^7.1",
-                "symfony/routing": "^6.4 || ^7.1",
-                "symfony/security-bundle": "^6.4 || ^7.1",
-                "symfony/security-core": "^6.4 || ^7.1",
-                "symfony/stopwatch": "^6.4 || ^7.1",
-                "symfony/string": "^6.4 || ^7.1",
-                "symfony/twig-bundle": "^6.4 || ^7.1",
-                "symfony/uid": "^6.4 || ^7.1",
-                "symfony/validator": "^6.4 || ^7.1",
-                "symfony/web-profiler-bundle": "^6.4 || ^7.1",
-                "symfony/yaml": "^6.4 || ^7.1",
+                "symfony/messenger": "^6.4 || ^7.0 || ^8.0",
+                "symfony/object-mapper": "^7.4 || ^8.0",
+                "symfony/routing": "^6.4 || ^7.0 || ^8.0",
+                "symfony/security-bundle": "^6.4 || ^7.0 || ^8.0",
+                "symfony/security-core": "^6.4 || ^7.0 || ^8.0",
+                "symfony/stopwatch": "^6.4 || ^7.0 || ^8.0",
+                "symfony/string": "^6.4 || ^7.0 || ^8.0",
+                "symfony/twig-bundle": "^6.4 || ^7.0 || ^8.0",
+                "symfony/uid": "^6.4 || ^7.0 || ^8.0",
+                "symfony/var-exporter": "^7.4 || ^8.0",
+                "symfony/web-profiler-bundle": "^6.4 || ^7.0 || ^8.0",
+                "symfony/yaml": "^6.4 || ^7.0 || ^8.0",
                 "twig/twig": "^1.42.3 || ^2.12 || ^3.0",
-                "webonyx/graphql-php": "^14.0 || ^15.0"
+                "webonyx/graphql-php": "^15.0"
             },
             "suggest": {
                 "doctrine/mongodb-odm-bundle": "To support MongoDB. Only versions 4.0 and later are supported.",
                 "elasticsearch/elasticsearch": "To support Elasticsearch.",
-                "ocramius/package-versions": "To display the API Platform's version in the debug bar.",
+                "opensearch-project/opensearch-php": "To support OpenSearch (^2.5).",
                 "phpstan/phpdoc-parser": "To support extracting metadata from PHPDoc.",
                 "psr/cache-implementation": "To use metadata caching.",
                 "ramsey/uuid": "To support Ramsey's UUID identifiers.",
@@ -165,6 +160,7 @@
                 "symfony/config": "To load XML configuration files.",
                 "symfony/expression-language": "To use authorization features.",
                 "symfony/http-client": "To use the HTTP cache invalidation system.",
+                "symfony/json-streamer": "To use the JSON Streamer component.",
                 "symfony/messenger": "To support messenger integration.",
                 "symfony/security": "To use authorization features.",
                 "symfony/twig-bundle": "To use the Swagger UI integration.",
@@ -185,14 +181,19 @@
                     "name": "api-platform/api-platform"
                 },
                 "symfony": {
-                    "require": "^6.4 || ^7.1"
+                    "require": "^6.4 || ^7.1 || ^8.0"
                 },
                 "branch-alias": {
                     "dev-3.4": "3.4.x-dev",
-                    "dev-main": "4.0.x-dev"
+                    "dev-4.1": "4.1.x-dev",
+                    "dev-4.2": "4.2.x-dev",
+                    "dev-main": "4.4.x-dev"
                 }
             },
             "autoload": {
+                "files": [
+                    "src/JsonLd/HydraContext.php"
+                ],
                 "psr-4": {
                     "ApiPlatform\\": "src/"
                 }
@@ -217,15 +218,17 @@
                 "graphql",
                 "hal",
                 "jsonapi",
+                "laravel",
                 "openapi",
                 "rest",
-                "swagger"
+                "swagger",
+                "symfony"
             ],
             "support": {
                 "issues": "https://github.com/api-platform/core/issues",
-                "source": "https://github.com/api-platform/core/tree/v3.4.17"
+                "source": "https://github.com/api-platform/core/tree/v4.3.5"
             },
-            "time": "2025-04-07T08:40:57+00:00"
+            "time": "2026-05-11T12:20:22+00:00"
         },
         {
             "name": "chillerlan/php-qrcode",
@@ -387,40 +390,35 @@
             "time": "2024-07-16T11:13:48+00:00"
         },
         {
-            "name": "doctrine/annotations",
-            "version": "2.0.2",
+            "name": "composer/semver",
+            "version": "3.4.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/doctrine/annotations.git",
-                "reference": "901c2ee5d26eb64ff43c47976e114bf00843acf7"
+                "url": "https://github.com/composer/semver.git",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/901c2ee5d26eb64ff43c47976e114bf00843acf7",
-                "reference": "901c2ee5d26eb64ff43c47976e114bf00843acf7",
+                "url": "https://api.github.com/repos/composer/semver/zipball/198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95",
                 "shasum": ""
             },
             "require": {
-                "doctrine/lexer": "^2 || ^3",
-                "ext-tokenizer": "*",
-                "php": "^7.2 || ^8.0",
-                "psr/cache": "^1 || ^2 || ^3"
+                "php": "^5.3.2 || ^7.0 || ^8.0"
             },
             "require-dev": {
-                "doctrine/cache": "^2.0",
-                "doctrine/coding-standard": "^10",
-                "phpstan/phpstan": "^1.10.28",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "symfony/cache": "^5.4 || ^6.4 || ^7",
-                "vimeo/psalm": "^4.30 || ^5.14"
-            },
-            "suggest": {
-                "php": "PHP 8.0 or higher comes with attributes, a native replacement for annotations"
+                "phpstan/phpstan": "^1.11",
+                "symfony/phpunit-bridge": "^3 || ^7"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
-                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
+                    "Composer\\Semver\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -429,52 +427,57 @@
             ],
             "authors": [
                 {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
                 },
                 {
-                    "name": "Roman Borschel",
-                    "email": "roman@code-factory.org"
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
                 },
                 {
-                    "name": "Benjamin Eberlei",
-                    "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Jonathan Wage",
-                    "email": "jonwage@gmail.com"
-                },
-                {
-                    "name": "Johannes Schmitt",
-                    "email": "schmittjoh@gmail.com"
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
                 }
             ],
-            "description": "Docblock Annotations Parser",
-            "homepage": "https://www.doctrine-project.org/projects/annotations.html",
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
             "keywords": [
-                "annotations",
-                "docblock",
-                "parser"
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
             ],
             "support": {
-                "issues": "https://github.com/doctrine/annotations/issues",
-                "source": "https://github.com/doctrine/annotations/tree/2.0.2"
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/semver/issues",
+                "source": "https://github.com/composer/semver/tree/3.4.4"
             },
-            "abandoned": true,
-            "time": "2024-09-05T10:17:24+00:00"
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-20T19:15:30+00:00"
         },
         {
             "name": "doctrine/collections",
-            "version": "2.4.0",
+            "version": "2.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/collections.git",
-                "reference": "9acfeea2e8666536edff3d77c531261c63680160"
+                "reference": "7713da39d8e237f28411d6a616a3dce5e20d5de2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/collections/zipball/9acfeea2e8666536edff3d77c531261c63680160",
-                "reference": "9acfeea2e8666536edff3d77c531261c63680160",
+                "url": "https://api.github.com/repos/doctrine/collections/zipball/7713da39d8e237f28411d6a616a3dce5e20d5de2",
+                "reference": "7713da39d8e237f28411d6a616a3dce5e20d5de2",
                 "shasum": ""
             },
             "require": {
@@ -531,7 +534,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/collections/issues",
-                "source": "https://github.com/doctrine/collections/tree/2.4.0"
+                "source": "https://github.com/doctrine/collections/tree/2.6.0"
             },
             "funding": [
                 {
@@ -547,52 +550,44 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-10-25T09:18:13+00:00"
+            "time": "2026-01-15T10:01:58+00:00"
         },
         {
             "name": "doctrine/dbal",
-            "version": "3.10.4",
+            "version": "4.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "63a46cb5aa6f60991186cc98c1d1b50c09311868"
+                "reference": "61e730f1658814821a85f2402c945f3883407dec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/63a46cb5aa6f60991186cc98c1d1b50c09311868",
-                "reference": "63a46cb5aa6f60991186cc98c1d1b50c09311868",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/61e730f1658814821a85f2402c945f3883407dec",
+                "reference": "61e730f1658814821a85f2402c945f3883407dec",
                 "shasum": ""
             },
             "require": {
-                "composer-runtime-api": "^2",
-                "doctrine/deprecations": "^0.5.3|^1",
-                "doctrine/event-manager": "^1|^2",
-                "php": "^7.4 || ^8.0",
+                "doctrine/deprecations": "^1.1.5",
+                "php": "^8.2",
                 "psr/cache": "^1|^2|^3",
                 "psr/log": "^1|^2|^3"
             },
-            "conflict": {
-                "doctrine/cache": "< 1.11"
-            },
             "require-dev": {
-                "doctrine/cache": "^1.11|^2.0",
                 "doctrine/coding-standard": "14.0.0",
                 "fig/log-test": "^1",
-                "jetbrains/phpstorm-stubs": "2023.1",
+                "jetbrains/phpstorm-stubs": "2023.2",
                 "phpstan/phpstan": "2.1.30",
+                "phpstan/phpstan-phpunit": "2.0.7",
                 "phpstan/phpstan-strict-rules": "^2",
-                "phpunit/phpunit": "9.6.29",
-                "slevomat/coding-standard": "8.24.0",
-                "squizlabs/php_codesniffer": "4.0.0",
-                "symfony/cache": "^5.4|^6.0|^7.0|^8.0",
-                "symfony/console": "^4.4|^5.4|^6.0|^7.0|^8.0"
+                "phpunit/phpunit": "11.5.50",
+                "slevomat/coding-standard": "8.27.1",
+                "squizlabs/php_codesniffer": "4.0.1",
+                "symfony/cache": "^6.3.8|^7.0|^8.0",
+                "symfony/console": "^5.4|^6.3|^7.0|^8.0"
             },
             "suggest": {
                 "symfony/console": "For helpful console commands such as SQL execution and import of files."
             },
-            "bin": [
-                "bin/doctrine-dbal"
-            ],
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -645,7 +640,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/dbal/issues",
-                "source": "https://github.com/doctrine/dbal/tree/3.10.4"
+                "source": "https://github.com/doctrine/dbal/tree/4.4.3"
             },
             "funding": [
                 {
@@ -661,33 +656,33 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-29T10:46:08+00:00"
+            "time": "2026-03-20T08:52:12+00:00"
         },
         {
             "name": "doctrine/deprecations",
-            "version": "1.1.5",
+            "version": "1.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38"
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
-                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "conflict": {
-                "phpunit/phpunit": "<=7.5 || >=13"
+                "phpunit/phpunit": "<=7.5 || >=14"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9 || ^12 || ^13",
-                "phpstan/phpstan": "1.4.10 || 2.1.11",
+                "doctrine/coding-standard": "^9 || ^12 || ^14",
+                "phpstan/phpstan": "1.4.10 || 2.1.30",
                 "phpstan/phpstan-phpunit": "^1.0 || ^2",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12.4 || ^13.0",
                 "psr/log": "^1 || ^2 || ^3"
             },
             "suggest": {
@@ -707,69 +702,63 @@
             "homepage": "https://www.doctrine-project.org/",
             "support": {
                 "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/1.1.5"
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.6"
             },
-            "time": "2025-04-07T20:06:18+00:00"
+            "time": "2026-02-07T07:09:04+00:00"
         },
         {
             "name": "doctrine/doctrine-bundle",
-            "version": "2.18.1",
+            "version": "3.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/DoctrineBundle.git",
-                "reference": "b769877014de053da0e5cbbb63d0ea2f3b2fea76"
+                "reference": "af84173db6978c3d2688ea3bcf3a91720b0704ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/DoctrineBundle/zipball/b769877014de053da0e5cbbb63d0ea2f3b2fea76",
-                "reference": "b769877014de053da0e5cbbb63d0ea2f3b2fea76",
+                "url": "https://api.github.com/repos/doctrine/DoctrineBundle/zipball/af84173db6978c3d2688ea3bcf3a91720b0704ce",
+                "reference": "af84173db6978c3d2688ea3bcf3a91720b0704ce",
                 "shasum": ""
             },
             "require": {
-                "doctrine/dbal": "^3.7.0 || ^4.0",
+                "doctrine/dbal": "^4.0",
                 "doctrine/deprecations": "^1.0",
-                "doctrine/persistence": "^3.1 || ^4",
+                "doctrine/persistence": "^4",
                 "doctrine/sql-formatter": "^1.0.1",
-                "php": "^8.1",
-                "symfony/cache": "^6.4 || ^7.0",
-                "symfony/config": "^6.4 || ^7.0",
-                "symfony/console": "^6.4 || ^7.0",
-                "symfony/dependency-injection": "^6.4 || ^7.0",
-                "symfony/doctrine-bridge": "^6.4.3 || ^7.0.3",
-                "symfony/framework-bundle": "^6.4 || ^7.0",
-                "symfony/service-contracts": "^2.5 || ^3"
+                "php": "^8.4",
+                "symfony/cache": "^6.4 || ^7.0 || ^8.0",
+                "symfony/config": "^6.4 || ^7.0 || ^8.0",
+                "symfony/console": "^6.4 || ^7.0 || ^8.0",
+                "symfony/dependency-injection": "^6.4 || ^7.0 || ^8.0",
+                "symfony/doctrine-bridge": "^6.4.3 || ^7.0.3 || ^8.0",
+                "symfony/framework-bundle": "^6.4 || ^7.0 || ^8.0",
+                "symfony/service-contracts": "^3"
             },
             "conflict": {
-                "doctrine/annotations": ">=3.0",
-                "doctrine/cache": "< 1.11",
-                "doctrine/orm": "<2.17 || >=4.0",
-                "symfony/var-exporter": "< 6.4.1 || 7.0.0",
-                "twig/twig": "<2.13 || >=3.0 <3.0.4"
+                "doctrine/orm": "<3.0 || >=4.0",
+                "twig/twig": "<3.0.4"
             },
             "require-dev": {
-                "doctrine/annotations": "^1 || ^2",
-                "doctrine/cache": "^1.11 || ^2.0",
                 "doctrine/coding-standard": "^14",
-                "doctrine/orm": "^2.17 || ^3.1",
-                "friendsofphp/proxy-manager-lts": "^1.0",
+                "doctrine/orm": "^3.4.4",
                 "phpstan/phpstan": "2.1.1",
                 "phpstan/phpstan-phpunit": "2.0.3",
                 "phpstan/phpstan-strict-rules": "^2",
-                "phpunit/phpunit": "^10.5.53 || ^12.3.10",
-                "psr/log": "^1.1.4 || ^2.0 || ^3.0",
-                "symfony/doctrine-messenger": "^6.4 || ^7.0",
-                "symfony/expression-language": "^6.4 || ^7.0",
-                "symfony/messenger": "^6.4 || ^7.0",
-                "symfony/property-info": "^6.4 || ^7.0",
-                "symfony/security-bundle": "^6.4 || ^7.0",
-                "symfony/stopwatch": "^6.4 || ^7.0",
-                "symfony/string": "^6.4 || ^7.0",
-                "symfony/twig-bridge": "^6.4 || ^7.0",
-                "symfony/validator": "^6.4 || ^7.0",
-                "symfony/var-exporter": "^6.4.1 || ^7.0.1",
-                "symfony/web-profiler-bundle": "^6.4 || ^7.0",
-                "symfony/yaml": "^6.4 || ^7.0",
-                "twig/twig": "^2.14.7 || ^3.0.4"
+                "phpstan/phpstan-symfony": "^2.0",
+                "phpunit/phpunit": "^12.3.10",
+                "psr/log": "^3.0",
+                "symfony/doctrine-messenger": "^6.4 || ^7.0 || ^8.0",
+                "symfony/expression-language": "^6.4 || ^7.0 || ^8.0",
+                "symfony/messenger": "^6.4 || ^7.0 || ^8.0",
+                "symfony/property-info": "^6.4 || ^7.0 || ^8.0",
+                "symfony/security-bundle": "^6.4 || ^7.0 || ^8.0",
+                "symfony/stopwatch": "^6.4 || ^7.0 || ^8.0",
+                "symfony/string": "^6.4 || ^7.0 || ^8.0",
+                "symfony/twig-bridge": "^6.4 || ^7.0 || ^8.0",
+                "symfony/validator": "^6.4 || ^7.0 || ^8.0",
+                "symfony/web-profiler-bundle": "^6.4 || ^7.0 || ^8.0",
+                "symfony/yaml": "^6.4 || ^7.0 || ^8.0",
+                "twig/twig": "^3.21.1"
             },
             "suggest": {
                 "doctrine/orm": "The Doctrine ORM integration is optional in the bundle.",
@@ -814,7 +803,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/DoctrineBundle/issues",
-                "source": "https://github.com/doctrine/DoctrineBundle/tree/2.18.1"
+                "source": "https://github.com/doctrine/DoctrineBundle/tree/3.2.2"
             },
             "funding": [
                 {
@@ -830,7 +819,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-05T14:42:10+00:00"
+            "time": "2025-12-24T12:24:29+00:00"
         },
         {
             "name": "doctrine/doctrine-migrations-bundle",
@@ -919,16 +908,16 @@
         },
         {
             "name": "doctrine/event-manager",
-            "version": "2.0.1",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/event-manager.git",
-                "reference": "b680156fa328f1dfd874fd48c7026c41570b9c6e"
+                "reference": "dda33921b198841ca8dbad2eaa5d4d34769d18cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/event-manager/zipball/b680156fa328f1dfd874fd48c7026c41570b9c6e",
-                "reference": "b680156fa328f1dfd874fd48c7026c41570b9c6e",
+                "url": "https://api.github.com/repos/doctrine/event-manager/zipball/dda33921b198841ca8dbad2eaa5d4d34769d18cf",
+                "reference": "dda33921b198841ca8dbad2eaa5d4d34769d18cf",
                 "shasum": ""
             },
             "require": {
@@ -938,10 +927,10 @@
                 "doctrine/common": "<2.9"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^12",
-                "phpstan/phpstan": "^1.8.8",
-                "phpunit/phpunit": "^10.5",
-                "vimeo/psalm": "^5.24"
+                "doctrine/coding-standard": "^14",
+                "phpdocumentor/guides-cli": "^1.4",
+                "phpstan/phpstan": "^2.1.32",
+                "phpunit/phpunit": "^10.5.58"
             },
             "type": "library",
             "autoload": {
@@ -990,7 +979,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/event-manager/issues",
-                "source": "https://github.com/doctrine/event-manager/tree/2.0.1"
+                "source": "https://github.com/doctrine/event-manager/tree/2.1.1"
             },
             "funding": [
                 {
@@ -1006,7 +995,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-22T20:47:39+00:00"
+            "time": "2026-01-29T07:11:08+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -1100,30 +1089,29 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "2.0.0",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
+                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/23da848e1a2308728fe5fdddabf4be17ff9720c7",
+                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7",
                 "shasum": ""
             },
             "require": {
-                "php": "^8.1"
+                "php": "^8.4"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^11",
+                "doctrine/coding-standard": "^14",
                 "ext-pdo": "*",
                 "ext-phar": "*",
                 "phpbench/phpbench": "^1.2",
-                "phpstan/phpstan": "^1.9.4",
-                "phpstan/phpstan-phpunit": "^1.3",
-                "phpunit/phpunit": "^9.5.27",
-                "vimeo/psalm": "^5.4"
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^10.5.58"
             },
             "type": "library",
             "autoload": {
@@ -1150,7 +1138,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
+                "source": "https://github.com/doctrine/instantiator/tree/2.1.0"
             },
             "funding": [
                 {
@@ -1166,7 +1154,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-30T00:23:10+00:00"
+            "time": "2026-01-05T06:47:08+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -1247,16 +1235,16 @@
         },
         {
             "name": "doctrine/migrations",
-            "version": "3.9.5",
+            "version": "3.9.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/migrations.git",
-                "reference": "1b823afbc40f932dae8272574faee53f2755eac5"
+                "reference": "96cb2a89b56c9efb0bac38e606dc0b0f13e650ec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/migrations/zipball/1b823afbc40f932dae8272574faee53f2755eac5",
-                "reference": "1b823afbc40f932dae8272574faee53f2755eac5",
+                "url": "https://api.github.com/repos/doctrine/migrations/zipball/96cb2a89b56c9efb0bac38e606dc0b0f13e650ec",
+                "reference": "96cb2a89b56c9efb0bac38e606dc0b0f13e650ec",
                 "shasum": ""
             },
             "require": {
@@ -1330,7 +1318,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/migrations/issues",
-                "source": "https://github.com/doctrine/migrations/tree/3.9.5"
+                "source": "https://github.com/doctrine/migrations/tree/3.9.7"
             },
             "funding": [
                 {
@@ -1346,20 +1334,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-20T11:15:36+00:00"
+            "time": "2026-04-23T19:33:20+00:00"
         },
         {
             "name": "doctrine/orm",
-            "version": "3.5.8",
+            "version": "3.6.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/orm.git",
-                "reference": "78dd074266e8b47a83bcf60ab5fe06c91a639168"
+                "reference": "7e88b416153dceeb563352ca2b12465f09eea173"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/orm/zipball/78dd074266e8b47a83bcf60ab5fe06c91a639168",
-                "reference": "78dd074266e8b47a83bcf60ab5fe06c91a639168",
+                "url": "https://api.github.com/repos/doctrine/orm/zipball/7e88b416153dceeb563352ca2b12465f09eea173",
+                "reference": "7e88b416153dceeb563352ca2b12465f09eea173",
                 "shasum": ""
             },
             "require": {
@@ -1432,25 +1420,26 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/orm/issues",
-                "source": "https://github.com/doctrine/orm/tree/3.5.8"
+                "source": "https://github.com/doctrine/orm/tree/3.6.5"
             },
-            "time": "2025-11-29T23:11:02+00:00"
+            "time": "2026-05-11T06:47:19+00:00"
         },
         {
             "name": "doctrine/persistence",
-            "version": "4.1.1",
+            "version": "4.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/persistence.git",
-                "reference": "b9c49ad3558bb77ef973f4e173f2e9c2eca9be09"
+                "reference": "49ab73e0d3e2ac8d1f5ecda3dd8acd5503781e8b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/persistence/zipball/b9c49ad3558bb77ef973f4e173f2e9c2eca9be09",
-                "reference": "b9c49ad3558bb77ef973f4e173f2e9c2eca9be09",
+                "url": "https://api.github.com/repos/doctrine/persistence/zipball/49ab73e0d3e2ac8d1f5ecda3dd8acd5503781e8b",
+                "reference": "49ab73e0d3e2ac8d1f5ecda3dd8acd5503781e8b",
                 "shasum": ""
             },
             "require": {
+                "doctrine/deprecations": "^1",
                 "doctrine/event-manager": "^1 || ^2",
                 "php": "^8.1",
                 "psr/cache": "^1.0 || ^2.0 || ^3.0"
@@ -1461,13 +1450,13 @@
                 "phpstan/phpstan-phpunit": "^2",
                 "phpstan/phpstan-strict-rules": "^2",
                 "phpunit/phpunit": "^10.5.58 || ^12",
-                "symfony/cache": "^4.4 || ^5.4 || ^6.0 || ^7.0",
-                "symfony/finder": "^4.4 || ^5.4 || ^6.0 || ^7.0"
+                "symfony/cache": "^4.4 || ^5.4 || ^6.0 || ^7.0 || ^8.0",
+                "symfony/finder": "^4.4 || ^5.4 || ^6.0 || ^7.0 || ^8.0"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Doctrine\\Persistence\\": "src/Persistence"
+                    "Doctrine\\Persistence\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1511,7 +1500,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/persistence/issues",
-                "source": "https://github.com/doctrine/persistence/tree/4.1.1"
+                "source": "https://github.com/doctrine/persistence/tree/4.2.0"
             },
             "funding": [
                 {
@@ -1527,20 +1516,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-10-16T20:13:18+00:00"
+            "time": "2026-04-26T12:12:52+00:00"
         },
         {
             "name": "doctrine/sql-formatter",
-            "version": "1.5.3",
+            "version": "1.5.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/sql-formatter.git",
-                "reference": "a8af23a8e9d622505baa2997465782cbe8bb7fc7"
+                "reference": "9563949f5cd3bd12a17d12fb980528bc141c5806"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/sql-formatter/zipball/a8af23a8e9d622505baa2997465782cbe8bb7fc7",
-                "reference": "a8af23a8e9d622505baa2997465782cbe8bb7fc7",
+                "url": "https://api.github.com/repos/doctrine/sql-formatter/zipball/9563949f5cd3bd12a17d12fb980528bc141c5806",
+                "reference": "9563949f5cd3bd12a17d12fb980528bc141c5806",
                 "shasum": ""
             },
             "require": {
@@ -1580,9 +1569,9 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/sql-formatter/issues",
-                "source": "https://github.com/doctrine/sql-formatter/tree/1.5.3"
+                "source": "https://github.com/doctrine/sql-formatter/tree/1.5.4"
             },
-            "time": "2025-10-26T09:35:14+00:00"
+            "time": "2026-02-08T16:21:46+00:00"
         },
         {
             "name": "dragonmantank/cron-expression",
@@ -1792,16 +1781,16 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "3.9.0",
+            "version": "3.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "10d85740180ecba7896c87e06a166e0c95a0e3b6"
+                "reference": "b321dd6749f0bf7189444158a3ce785cc16d69b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/10d85740180ecba7896c87e06a166e0c95a0e3b6",
-                "reference": "10d85740180ecba7896c87e06a166e0c95a0e3b6",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/b321dd6749f0bf7189444158a3ce785cc16d69b0",
+                "reference": "b321dd6749f0bf7189444158a3ce785cc16d69b0",
                 "shasum": ""
             },
             "require": {
@@ -1819,7 +1808,7 @@
                 "graylog2/gelf-php": "^1.4.2 || ^2.0",
                 "guzzlehttp/guzzle": "^7.4.5",
                 "guzzlehttp/psr7": "^2.2",
-                "mongodb/mongodb": "^1.8",
+                "mongodb/mongodb": "^1.8 || ^2.0",
                 "php-amqplib/php-amqplib": "~2.4 || ^3",
                 "php-console/php-console": "^3.1.8",
                 "phpstan/phpstan": "^2",
@@ -1879,7 +1868,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/monolog/issues",
-                "source": "https://github.com/Seldaek/monolog/tree/3.9.0"
+                "source": "https://github.com/Seldaek/monolog/tree/3.10.0"
             },
             "funding": [
                 {
@@ -1891,7 +1880,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-24T10:02:05+00:00"
+            "time": "2026-01-02T08:56:05+00:00"
         },
         {
             "name": "nelmio/cors-bundle",
@@ -2488,28 +2477,28 @@
         },
         {
             "name": "symfony/amqp-messenger",
-            "version": "v7.4.0",
+            "version": "v8.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/amqp-messenger.git",
-                "reference": "db89ea81a82bdc255dde7fa86cd06696204ede63"
+                "reference": "59591bb7ca054ca20a9fff0785540a19c39794fb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/amqp-messenger/zipball/db89ea81a82bdc255dde7fa86cd06696204ede63",
-                "reference": "db89ea81a82bdc255dde7fa86cd06696204ede63",
+                "url": "https://api.github.com/repos/symfony/amqp-messenger/zipball/59591bb7ca054ca20a9fff0785540a19c39794fb",
+                "reference": "59591bb7ca054ca20a9fff0785540a19c39794fb",
                 "shasum": ""
             },
             "require": {
                 "ext-amqp": "*",
-                "php": ">=8.2",
-                "symfony/messenger": "^7.3|^8.0"
+                "php": ">=8.4",
+                "symfony/messenger": "^7.4|^8.0"
             },
             "require-dev": {
-                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
-                "symfony/process": "^6.4|^7.0|^8.0",
-                "symfony/property-access": "^6.4|^7.0|^8.0",
-                "symfony/serializer": "^6.4|^7.0|^8.0"
+                "symfony/event-dispatcher": "^7.4|^8.0",
+                "symfony/process": "^7.4|^8.0",
+                "symfony/property-access": "^7.4|^8.0",
+                "symfony/serializer": "^7.4|^8.0"
             },
             "type": "symfony-messenger-bridge",
             "autoload": {
@@ -2537,7 +2526,7 @@
             "description": "Symfony AMQP extension Messenger Bridge",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/amqp-messenger/tree/v7.4.0"
+                "source": "https://github.com/symfony/amqp-messenger/tree/v8.0.9"
             },
             "funding": [
                 {
@@ -2557,32 +2546,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-17T06:06:24+00:00"
+            "time": "2026-04-30T16:10:06+00:00"
         },
         {
             "name": "symfony/asset",
-            "version": "v7.4.0",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/asset.git",
-                "reference": "0f7bccb9ffa1f373cbd659774d90629b2773464f"
+                "reference": "72eca261f3af1bef741c48bb2c91a4e619dca03a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/asset/zipball/0f7bccb9ffa1f373cbd659774d90629b2773464f",
-                "reference": "0f7bccb9ffa1f373cbd659774d90629b2773464f",
+                "url": "https://api.github.com/repos/symfony/asset/zipball/72eca261f3af1bef741c48bb2c91a4e619dca03a",
+                "reference": "72eca261f3af1bef741c48bb2c91a4e619dca03a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
-            },
-            "conflict": {
-                "symfony/http-foundation": "<6.4"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "symfony/http-client": "^6.4|^7.0|^8.0",
-                "symfony/http-foundation": "^6.4|^7.0|^8.0",
-                "symfony/http-kernel": "^6.4|^7.0|^8.0"
+                "symfony/http-client": "^7.4|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -2610,7 +2596,7 @@
             "description": "Manages URL generation and versioning of web assets such as CSS stylesheets, JavaScript files and image files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/asset/tree/v7.4.0"
+                "source": "https://github.com/symfony/asset/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -2630,38 +2616,33 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-04T07:05:15+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/cache",
-            "version": "v7.4.1",
+            "version": "v8.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache.git",
-                "reference": "21e0755783bbbab58f2bb6a7a57896d21d27a366"
+                "reference": "8ff96cde73684bfa32b702f5cff1eb83b1fac429"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/21e0755783bbbab58f2bb6a7a57896d21d27a366",
-                "reference": "21e0755783bbbab58f2bb6a7a57896d21d27a366",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/8ff96cde73684bfa32b702f5cff1eb83b1fac429",
+                "reference": "8ff96cde73684bfa32b702f5cff1eb83b1fac429",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4",
                 "psr/cache": "^2.0|^3.0",
                 "psr/log": "^1.1|^2|^3",
                 "symfony/cache-contracts": "^3.6",
-                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/var-exporter": "^6.4|^7.0|^8.0"
+                "symfony/var-exporter": "^7.4|^8.0"
             },
             "conflict": {
-                "doctrine/dbal": "<3.6",
                 "ext-redis": "<6.1",
-                "ext-relay": "<0.12.1",
-                "symfony/dependency-injection": "<6.4",
-                "symfony/http-kernel": "<6.4",
-                "symfony/var-dumper": "<6.4"
+                "ext-relay": "<0.12.1"
             },
             "provide": {
                 "psr/cache-implementation": "2.0|3.0",
@@ -2670,16 +2651,16 @@
             },
             "require-dev": {
                 "cache/integration-tests": "dev-master",
-                "doctrine/dbal": "^3.6|^4",
+                "doctrine/dbal": "^4.3",
                 "predis/predis": "^1.1|^2.0",
                 "psr/simple-cache": "^1.0|^2.0|^3.0",
-                "symfony/clock": "^6.4|^7.0|^8.0",
-                "symfony/config": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/filesystem": "^6.4|^7.0|^8.0",
-                "symfony/http-kernel": "^6.4|^7.0|^8.0",
-                "symfony/messenger": "^6.4|^7.0|^8.0",
-                "symfony/var-dumper": "^6.4|^7.0|^8.0"
+                "symfony/clock": "^7.4|^8.0",
+                "symfony/config": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/filesystem": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/messenger": "^7.4|^8.0",
+                "symfony/var-dumper": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -2714,7 +2695,7 @@
                 "psr6"
             ],
             "support": {
-                "source": "https://github.com/symfony/cache/tree/v7.4.1"
+                "source": "https://github.com/symfony/cache/tree/v8.0.10"
             },
             "funding": [
                 {
@@ -2734,20 +2715,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-04T18:11:45+00:00"
+            "time": "2026-05-05T08:24:00+00:00"
         },
         {
             "name": "symfony/cache-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache-contracts.git",
-                "reference": "5d68a57d66910405e5c0b63d6f0af941e66fc868"
+                "reference": "225e8a254166bd3442e370c6f50145465db63831"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache-contracts/zipball/5d68a57d66910405e5c0b63d6f0af941e66fc868",
-                "reference": "5d68a57d66910405e5c0b63d6f0af941e66fc868",
+                "url": "https://api.github.com/repos/symfony/cache-contracts/zipball/225e8a254166bd3442e370c6f50145465db63831",
+                "reference": "225e8a254166bd3442e370c6f50145465db63831",
                 "shasum": ""
             },
             "require": {
@@ -2761,7 +2742,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -2794,7 +2775,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/cache-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/cache-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -2806,30 +2787,33 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-13T15:25:07+00:00"
+            "time": "2026-05-05T15:33:14+00:00"
         },
         {
             "name": "symfony/clock",
-            "version": "v7.4.0",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/clock.git",
-                "reference": "9169f24776edde469914c1e7a1442a50f7a4e110"
+                "reference": "b55a638b189a6faa875e0ccdb00908fb87af95b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/clock/zipball/9169f24776edde469914c1e7a1442a50f7a4e110",
-                "reference": "9169f24776edde469914c1e7a1442a50f7a4e110",
+                "url": "https://api.github.com/repos/symfony/clock/zipball/b55a638b189a6faa875e0ccdb00908fb87af95b3",
+                "reference": "b55a638b189a6faa875e0ccdb00908fb87af95b3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "psr/clock": "^1.0",
-                "symfony/polyfill-php83": "^1.28"
+                "php": ">=8.4",
+                "psr/clock": "^1.0"
             },
             "provide": {
                 "psr/clock-implementation": "1.0"
@@ -2868,7 +2852,7 @@
                 "time"
             ],
             "support": {
-                "source": "https://github.com/symfony/clock/tree/v7.4.0"
+                "source": "https://github.com/symfony/clock/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -2888,38 +2872,37 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-12T15:39:26+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/config",
-            "version": "v7.4.1",
+            "version": "v8.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "2c323304c354a43a48b61c5fa760fc4ed60ce495"
+                "reference": "de665e669412ec2effe004d90298dbbdaf6e7e8b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/2c323304c354a43a48b61c5fa760fc4ed60ce495",
-                "reference": "2c323304c354a43a48b61c5fa760fc4ed60ce495",
+                "url": "https://api.github.com/repos/symfony/config/zipball/de665e669412ec2effe004d90298dbbdaf6e7e8b",
+                "reference": "de665e669412ec2effe004d90298dbbdaf6e7e8b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4",
                 "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/filesystem": "^7.1|^8.0",
-                "symfony/polyfill-ctype": "~1.8"
+                "symfony/filesystem": "^7.4|^8.0",
+                "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
-                "symfony/finder": "<6.4",
                 "symfony/service-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
-                "symfony/finder": "^6.4|^7.0|^8.0",
-                "symfony/messenger": "^6.4|^7.0|^8.0",
+                "symfony/event-dispatcher": "^7.4|^8.0",
+                "symfony/finder": "^7.4|^8.0",
+                "symfony/messenger": "^7.4|^8.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/yaml": "^6.4|^7.0|^8.0"
+                "symfony/yaml": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -2947,7 +2930,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v7.4.1"
+                "source": "https://github.com/symfony/config/tree/v8.0.10"
             },
             "funding": [
                 {
@@ -2967,51 +2950,43 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-05T07:52:08+00:00"
+            "time": "2026-05-04T13:41:39+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v7.4.1",
+            "version": "v8.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "6d9f0fbf2ec2e9785880096e3abd0ca0c88b506e"
+                "reference": "7113778e2e91f4709cb3194a75dfa9c0d028d94d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/6d9f0fbf2ec2e9785880096e3abd0ca0c88b506e",
-                "reference": "6d9f0fbf2ec2e9785880096e3abd0ca0c88b506e",
+                "url": "https://api.github.com/repos/symfony/console/zipball/7113778e2e91f4709cb3194a75dfa9c0d028d94d",
+                "reference": "7113778e2e91f4709cb3194a75dfa9c0d028d94d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-mbstring": "~1.0",
+                "php": ">=8.4",
+                "symfony/polyfill-mbstring": "^1.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/string": "^7.2|^8.0"
-            },
-            "conflict": {
-                "symfony/dependency-injection": "<6.4",
-                "symfony/dotenv": "<6.4",
-                "symfony/event-dispatcher": "<6.4",
-                "symfony/lock": "<6.4",
-                "symfony/process": "<6.4"
+                "symfony/string": "^7.4|^8.0"
             },
             "provide": {
                 "psr/log-implementation": "1.0|2.0|3.0"
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
-                "symfony/http-foundation": "^6.4|^7.0|^8.0",
-                "symfony/http-kernel": "^6.4|^7.0|^8.0",
-                "symfony/lock": "^6.4|^7.0|^8.0",
-                "symfony/messenger": "^6.4|^7.0|^8.0",
-                "symfony/process": "^6.4|^7.0|^8.0",
-                "symfony/stopwatch": "^6.4|^7.0|^8.0",
-                "symfony/var-dumper": "^6.4|^7.0|^8.0"
+                "symfony/config": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/event-dispatcher": "^7.4|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/lock": "^7.4|^8.0",
+                "symfony/messenger": "^7.4|^8.0",
+                "symfony/process": "^7.4|^8.0",
+                "symfony/stopwatch": "^7.4|^8.0",
+                "symfony/var-dumper": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -3045,7 +3020,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.1"
+                "source": "https://github.com/symfony/console/tree/v8.0.9"
             },
             "funding": [
                 {
@@ -3065,43 +3040,40 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-05T15:23:39+00:00"
+            "time": "2026-04-29T15:02:55+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v7.4.2",
+            "version": "v8.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "baf614f7c15b30ba6762d4b1ddabdf83dbf0d29b"
+                "reference": "6fc374dae45a7633a5865da7fc2908baf29d4900"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/baf614f7c15b30ba6762d4b1ddabdf83dbf0d29b",
-                "reference": "baf614f7c15b30ba6762d4b1ddabdf83dbf0d29b",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/6fc374dae45a7633a5865da7fc2908baf29d4900",
+                "reference": "6fc374dae45a7633a5865da7fc2908baf29d4900",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4",
                 "psr/container": "^1.1|^2.0",
                 "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/service-contracts": "^3.6",
-                "symfony/var-exporter": "^6.4.20|^7.2.5|^8.0"
+                "symfony/var-exporter": "^7.4|^8.0"
             },
             "conflict": {
-                "ext-psr": "<1.1|>=2",
-                "symfony/config": "<6.4",
-                "symfony/finder": "<6.4",
-                "symfony/yaml": "<6.4"
+                "ext-psr": "<1.1|>=2"
             },
             "provide": {
                 "psr/container-implementation": "1.1|2.0",
                 "symfony/service-implementation": "1.1|2.0|3.0"
             },
             "require-dev": {
-                "symfony/config": "^6.4|^7.0|^8.0",
-                "symfony/expression-language": "^6.4|^7.0|^8.0",
-                "symfony/yaml": "^6.4|^7.0|^8.0"
+                "symfony/config": "^7.4|^8.0",
+                "symfony/expression-language": "^7.4|^8.0",
+                "symfony/yaml": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -3129,7 +3101,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v7.4.2"
+                "source": "https://github.com/symfony/dependency-injection/tree/v8.0.10"
             },
             "funding": [
                 {
@@ -3149,20 +3121,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-08T06:57:04+00:00"
+            "time": "2026-05-06T11:55:35+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
                 "shasum": ""
             },
             "require": {
@@ -3175,7 +3147,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -3200,7 +3172,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -3212,76 +3184,69 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-04-13T15:52:40+00:00"
         },
         {
             "name": "symfony/doctrine-bridge",
-            "version": "v7.4.1",
+            "version": "v8.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/doctrine-bridge.git",
-                "reference": "7acd7ce1b71601b25d698bc2da6b52e43f3c72b3"
+                "reference": "dfe3dddc9c22756b9b145785fb5fd4b0445cd06e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/doctrine-bridge/zipball/7acd7ce1b71601b25d698bc2da6b52e43f3c72b3",
-                "reference": "7acd7ce1b71601b25d698bc2da6b52e43f3c72b3",
+                "url": "https://api.github.com/repos/symfony/doctrine-bridge/zipball/dfe3dddc9c22756b9b145785fb5fd4b0445cd06e",
+                "reference": "dfe3dddc9c22756b9b145785fb5fd4b0445cd06e",
                 "shasum": ""
             },
             "require": {
                 "doctrine/event-manager": "^2",
                 "doctrine/persistence": "^3.1|^4",
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-mbstring": "~1.0",
+                "php": ">=8.4",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-mbstring": "^1.0",
                 "symfony/service-contracts": "^2.5|^3"
             },
             "conflict": {
                 "doctrine/collections": "<1.8",
-                "doctrine/dbal": "<3.6",
+                "doctrine/dbal": "<4.3",
                 "doctrine/lexer": "<1.1",
-                "doctrine/orm": "<2.15",
-                "symfony/cache": "<6.4",
-                "symfony/dependency-injection": "<6.4",
-                "symfony/form": "<6.4.6|>=7,<7.0.6",
-                "symfony/http-foundation": "<6.4",
-                "symfony/http-kernel": "<6.4",
-                "symfony/lock": "<6.4",
-                "symfony/messenger": "<6.4",
-                "symfony/property-info": "<6.4",
-                "symfony/security-bundle": "<6.4",
-                "symfony/security-core": "<6.4",
-                "symfony/validator": "<7.4"
+                "doctrine/orm": "<3.4",
+                "symfony/property-info": "<8.0"
             },
             "require-dev": {
                 "doctrine/collections": "^1.8|^2.0",
                 "doctrine/data-fixtures": "^1.1|^2",
-                "doctrine/dbal": "^3.6|^4",
-                "doctrine/orm": "^2.15|^3",
+                "doctrine/dbal": "^4.3",
+                "doctrine/orm": "^3.4",
                 "psr/log": "^1|^2|^3",
-                "symfony/cache": "^6.4|^7.0|^8.0",
-                "symfony/config": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/doctrine-messenger": "^6.4|^7.0|^8.0",
-                "symfony/expression-language": "^6.4|^7.0|^8.0",
-                "symfony/form": "^7.2|^8.0",
-                "symfony/http-kernel": "^6.4|^7.0|^8.0",
-                "symfony/lock": "^6.4|^7.0|^8.0",
-                "symfony/messenger": "^6.4|^7.0|^8.0",
-                "symfony/property-access": "^6.4|^7.0|^8.0",
-                "symfony/property-info": "^6.4|^7.0|^8.0",
-                "symfony/security-core": "^6.4|^7.0|^8.0",
-                "symfony/stopwatch": "^6.4|^7.0|^8.0",
-                "symfony/translation": "^6.4|^7.0|^8.0",
-                "symfony/type-info": "^7.1.8|^8.0",
-                "symfony/uid": "^6.4|^7.0|^8.0",
+                "symfony/cache": "^7.4|^8.0",
+                "symfony/config": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/doctrine-messenger": "^7.4|^8.0",
+                "symfony/expression-language": "^7.4|^8.0",
+                "symfony/form": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/lock": "^7.4|^8.0",
+                "symfony/messenger": "^7.4|^8.0",
+                "symfony/property-access": "^7.4|^8.0",
+                "symfony/property-info": "^8.0",
+                "symfony/security-core": "^7.4|^8.0",
+                "symfony/stopwatch": "^7.4|^8.0",
+                "symfony/translation": "^7.4|^8.0",
+                "symfony/type-info": "^7.4|^8.0",
+                "symfony/uid": "^7.4|^8.0",
                 "symfony/validator": "^7.4|^8.0",
-                "symfony/var-dumper": "^6.4|^7.0|^8.0"
+                "symfony/var-dumper": "^7.4|^8.0"
             },
             "type": "symfony-bridge",
             "autoload": {
@@ -3309,7 +3274,7 @@
             "description": "Provides integration for Doctrine with various Symfony components",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/doctrine-bridge/tree/v7.4.1"
+                "source": "https://github.com/symfony/doctrine-bridge/tree/v8.0.9"
             },
             "funding": [
                 {
@@ -3329,26 +3294,26 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-04T17:15:58+00:00"
+            "time": "2026-04-29T15:02:55+00:00"
         },
         {
             "name": "symfony/doctrine-messenger",
-            "version": "v7.4.1",
+            "version": "v8.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/doctrine-messenger.git",
-                "reference": "f97f4ea899c467c2c8ff1b9c82b86baa9a7b2158"
+                "reference": "88329a3faba5023cfb569b3fc5b8a771336c4a88"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/doctrine-messenger/zipball/f97f4ea899c467c2c8ff1b9c82b86baa9a7b2158",
-                "reference": "f97f4ea899c467c2c8ff1b9c82b86baa9a7b2158",
+                "url": "https://api.github.com/repos/symfony/doctrine-messenger/zipball/88329a3faba5023cfb569b3fc5b8a771336c4a88",
+                "reference": "88329a3faba5023cfb569b3fc5b8a771336c4a88",
                 "shasum": ""
             },
             "require": {
-                "doctrine/dbal": "^3.6|^4",
-                "php": ">=8.2",
-                "symfony/messenger": "^7.2|^8.0",
+                "doctrine/dbal": "^4.3",
+                "php": ">=8.4",
+                "symfony/messenger": "^7.4|^8.0",
                 "symfony/service-contracts": "^2.5|^3"
             },
             "conflict": {
@@ -3356,8 +3321,8 @@
             },
             "require-dev": {
                 "doctrine/persistence": "^1.3|^2|^3",
-                "symfony/property-access": "^6.4|^7.0|^8.0",
-                "symfony/serializer": "^6.4|^7.0|^8.0"
+                "symfony/property-access": "^7.4|^8.0",
+                "symfony/serializer": "^7.4|^8.0"
             },
             "type": "symfony-messenger-bridge",
             "autoload": {
@@ -3385,7 +3350,7 @@
             "description": "Symfony Doctrine Messenger Bridge",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/doctrine-messenger/tree/v7.4.1"
+                "source": "https://github.com/symfony/doctrine-messenger/tree/v8.0.6"
             },
             "funding": [
                 {
@@ -3405,32 +3370,28 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-05T14:04:53+00:00"
+            "time": "2026-02-20T07:51:53+00:00"
         },
         {
             "name": "symfony/dotenv",
-            "version": "v7.4.0",
+            "version": "v8.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dotenv.git",
-                "reference": "1658a4d34df028f3d93bcdd8e81f04423925a364"
+                "reference": "f75c67be2c2648741c4b163546002e34265bcb91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dotenv/zipball/1658a4d34df028f3d93bcdd8e81f04423925a364",
-                "reference": "1658a4d34df028f3d93bcdd8e81f04423925a364",
+                "url": "https://api.github.com/repos/symfony/dotenv/zipball/f75c67be2c2648741c4b163546002e34265bcb91",
+                "reference": "f75c67be2c2648741c4b163546002e34265bcb91",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
-            },
-            "conflict": {
-                "symfony/console": "<6.4",
-                "symfony/process": "<6.4"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "symfony/console": "^6.4|^7.0|^8.0",
-                "symfony/process": "^6.4|^7.0|^8.0"
+                "symfony/console": "^7.4|^8.0",
+                "symfony/process": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -3463,7 +3424,7 @@
                 "environment"
             ],
             "support": {
-                "source": "https://github.com/symfony/dotenv/tree/v7.4.0"
+                "source": "https://github.com/symfony/dotenv/tree/v8.0.9"
             },
             "funding": [
                 {
@@ -3483,37 +3444,36 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-16T10:14:42+00:00"
+            "time": "2026-04-29T15:02:55+00:00"
         },
         {
             "name": "symfony/error-handler",
-            "version": "v7.4.0",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "48be2b0653594eea32dcef130cca1c811dcf25c2"
+                "reference": "c1119fe8dcfc3825ec74ec061b96ef0c8f281517"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/48be2b0653594eea32dcef130cca1c811dcf25c2",
-                "reference": "48be2b0653594eea32dcef130cca1c811dcf25c2",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/c1119fe8dcfc3825ec74ec061b96ef0c8f281517",
+                "reference": "c1119fe8dcfc3825ec74ec061b96ef0c8f281517",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4",
                 "psr/log": "^1|^2|^3",
                 "symfony/polyfill-php85": "^1.32",
-                "symfony/var-dumper": "^6.4|^7.0|^8.0"
+                "symfony/var-dumper": "^7.4|^8.0"
             },
             "conflict": {
-                "symfony/deprecation-contracts": "<2.5",
-                "symfony/http-kernel": "<6.4"
+                "symfony/deprecation-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/console": "^6.4|^7.0|^8.0",
+                "symfony/console": "^7.4|^8.0",
                 "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/http-kernel": "^6.4|^7.0|^8.0",
-                "symfony/serializer": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/serializer": "^7.4|^8.0",
                 "symfony/webpack-encore-bundle": "^1.0|^2.0"
             },
             "bin": [
@@ -3545,7 +3505,7 @@
             "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/error-handler/tree/v7.4.0"
+                "source": "https://github.com/symfony/error-handler/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -3565,28 +3525,28 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-05T14:29:59+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v7.4.0",
+            "version": "v8.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "9dddcddff1ef974ad87b3708e4b442dc38b2261d"
+                "reference": "0c3c1a17604c4dbbec4b93fe162c538482096e1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/9dddcddff1ef974ad87b3708e4b442dc38b2261d",
-                "reference": "9dddcddff1ef974ad87b3708e4b442dc38b2261d",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/0c3c1a17604c4dbbec4b93fe162c538482096e1f",
+                "reference": "0c3c1a17604c4dbbec4b93fe162c538482096e1f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4",
                 "symfony/event-dispatcher-contracts": "^2.5|^3"
             },
             "conflict": {
-                "symfony/dependency-injection": "<6.4",
+                "symfony/security-http": "<7.4",
                 "symfony/service-contracts": "<2.5"
             },
             "provide": {
@@ -3595,14 +3555,14 @@
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/error-handler": "^6.4|^7.0|^8.0",
-                "symfony/expression-language": "^6.4|^7.0|^8.0",
-                "symfony/framework-bundle": "^6.4|^7.0|^8.0",
-                "symfony/http-foundation": "^6.4|^7.0|^8.0",
+                "symfony/config": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/error-handler": "^7.4|^8.0",
+                "symfony/expression-language": "^7.4|^8.0",
+                "symfony/framework-bundle": "^7.4|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/stopwatch": "^6.4|^7.0|^8.0"
+                "symfony/stopwatch": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -3630,7 +3590,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v7.4.0"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v8.0.9"
             },
             "funding": [
                 {
@@ -3650,20 +3610,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-10-28T09:38:46+00:00"
+            "time": "2026-04-18T13:51:42+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "59eb412e93815df44f05f342958efa9f46b1e586"
+                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/59eb412e93815df44f05f342958efa9f46b1e586",
-                "reference": "59eb412e93815df44f05f342958efa9f46b1e586",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/ccba7060602b7fed0b03c85bf025257f76d9ef32",
+                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32",
                 "shasum": ""
             },
             "require": {
@@ -3677,7 +3637,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -3710,7 +3670,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -3722,30 +3682,33 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-01-05T13:30:16+00:00"
         },
         {
             "name": "symfony/expression-language",
-            "version": "v7.4.0",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/expression-language.git",
-                "reference": "8b9bbbb8c71f79a09638f6ea77c531e511139efa"
+                "reference": "b2a5fd3b7331ae10cc0ed75a28d64b25b67d2c7b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/expression-language/zipball/8b9bbbb8c71f79a09638f6ea77c531e511139efa",
-                "reference": "8b9bbbb8c71f79a09638f6ea77c531e511139efa",
+                "url": "https://api.github.com/repos/symfony/expression-language/zipball/b2a5fd3b7331ae10cc0ed75a28d64b25b67d2c7b",
+                "reference": "b2a5fd3b7331ae10cc0ed75a28d64b25b67d2c7b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/cache": "^6.4|^7.0|^8.0",
-                "symfony/deprecation-contracts": "^2.5|^3",
+                "php": ">=8.4",
+                "symfony/cache": "^7.4|^8.0",
                 "symfony/service-contracts": "^2.5|^3"
             },
             "type": "library",
@@ -3774,7 +3737,7 @@
             "description": "Provides an engine that can compile and evaluate expressions",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/expression-language/tree/v7.4.0"
+                "source": "https://github.com/symfony/expression-language/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -3794,29 +3757,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-12T15:39:26+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v7.4.0",
+            "version": "v8.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "d551b38811096d0be9c4691d406991b47c0c630a"
+                "reference": "d1ec4543d5c6c2dac78503c2fae5ea0b3608ce40"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d551b38811096d0be9c4691d406991b47c0c630a",
-                "reference": "d551b38811096d0be9c4691d406991b47c0c630a",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d1ec4543d5c6c2dac78503c2fae5ea0b3608ce40",
+                "reference": "d1ec4543d5c6c2dac78503c2fae5ea0b3608ce40",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-mbstring": "~1.8"
             },
             "require-dev": {
-                "symfony/process": "^6.4|^7.0|^8.0"
+                "symfony/process": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -3844,7 +3807,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v7.4.0"
+                "source": "https://github.com/symfony/filesystem/tree/v8.0.9"
             },
             "funding": [
                 {
@@ -3864,27 +3827,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-27T13:27:24+00:00"
+            "time": "2026-04-18T13:51:42+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v7.4.0",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "340b9ed7320570f319028a2cbec46d40535e94bd"
+                "reference": "8da41214757b87d97f181e3d14a4179286151007"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/340b9ed7320570f319028a2cbec46d40535e94bd",
-                "reference": "340b9ed7320570f319028a2cbec46d40535e94bd",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/8da41214757b87d97f181e3d14a4179286151007",
+                "reference": "8da41214757b87d97f181e3d14a4179286151007",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "symfony/filesystem": "^6.4|^7.0|^8.0"
+                "symfony/filesystem": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -3912,7 +3875,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v7.4.0"
+                "source": "https://github.com/symfony/finder/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -3932,7 +3895,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-05T05:42:40+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/flex",
@@ -4009,113 +3972,96 @@
         },
         {
             "name": "symfony/framework-bundle",
-            "version": "v7.4.1",
+            "version": "v8.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/framework-bundle.git",
-                "reference": "2fa3b3ad6ed75ce0cc8cad8a5027b4f25b990bc3"
+                "reference": "a81e320168f53a798007978dac23113b321173e3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/framework-bundle/zipball/2fa3b3ad6ed75ce0cc8cad8a5027b4f25b990bc3",
-                "reference": "2fa3b3ad6ed75ce0cc8cad8a5027b4f25b990bc3",
+                "url": "https://api.github.com/repos/symfony/framework-bundle/zipball/a81e320168f53a798007978dac23113b321173e3",
+                "reference": "a81e320168f53a798007978dac23113b321173e3",
                 "shasum": ""
             },
             "require": {
                 "composer-runtime-api": ">=2.1",
                 "ext-xml": "*",
-                "php": ">=8.2",
-                "symfony/cache": "^6.4.12|^7.0|^8.0",
-                "symfony/config": "^7.4|^8.0",
-                "symfony/dependency-injection": "^7.4|^8.0",
+                "php": ">=8.4",
+                "symfony/cache": "^7.4|^8.0",
+                "symfony/config": "^7.4.4|^8.0.4",
+                "symfony/dependency-injection": "^7.4.4|^8.0.4",
                 "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/error-handler": "^7.3|^8.0",
-                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
-                "symfony/filesystem": "^7.1|^8.0",
-                "symfony/finder": "^6.4|^7.0|^8.0",
+                "symfony/error-handler": "^7.4|^8.0",
+                "symfony/event-dispatcher": "^7.4|^8.0",
+                "symfony/filesystem": "^7.4|^8.0",
+                "symfony/finder": "^7.4|^8.0",
                 "symfony/http-foundation": "^7.4|^8.0",
                 "symfony/http-kernel": "^7.4|^8.0",
-                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-mbstring": "^1.0",
                 "symfony/polyfill-php85": "^1.32",
                 "symfony/routing": "^7.4|^8.0"
             },
             "conflict": {
                 "doctrine/persistence": "<1.3",
-                "phpdocumentor/reflection-docblock": "<3.2.2",
-                "phpdocumentor/type-resolver": "<1.4.0",
-                "symfony/asset": "<6.4",
-                "symfony/asset-mapper": "<6.4",
-                "symfony/clock": "<6.4",
-                "symfony/console": "<6.4",
-                "symfony/dom-crawler": "<6.4",
-                "symfony/dotenv": "<6.4",
+                "phpdocumentor/reflection-docblock": "<5.2|>=7",
+                "phpdocumentor/type-resolver": "<1.5.1",
+                "symfony/console": "<7.4",
                 "symfony/form": "<7.4",
-                "symfony/http-client": "<6.4",
-                "symfony/lock": "<6.4",
-                "symfony/mailer": "<6.4",
+                "symfony/json-streamer": "<7.4",
                 "symfony/messenger": "<7.4",
-                "symfony/mime": "<6.4",
-                "symfony/property-access": "<6.4",
-                "symfony/property-info": "<6.4",
-                "symfony/runtime": "<6.4.13|>=7.0,<7.1.6",
-                "symfony/scheduler": "<6.4.4|>=7.0.0,<7.0.4",
-                "symfony/security-core": "<6.4",
-                "symfony/security-csrf": "<7.2",
-                "symfony/serializer": "<7.2.5",
-                "symfony/stopwatch": "<6.4",
-                "symfony/translation": "<7.3",
-                "symfony/twig-bridge": "<6.4",
-                "symfony/twig-bundle": "<6.4",
-                "symfony/validator": "<6.4",
-                "symfony/web-profiler-bundle": "<6.4",
-                "symfony/webhook": "<7.2",
+                "symfony/mime": "<7.4.9|>=8.0,<8.0.9",
+                "symfony/security-csrf": "<7.4",
+                "symfony/serializer": "<7.4",
+                "symfony/translation": "<7.4",
+                "symfony/webhook": "<7.4",
                 "symfony/workflow": "<7.4"
             },
             "require-dev": {
                 "doctrine/persistence": "^1.3|^2|^3",
                 "dragonmantank/cron-expression": "^3.1",
-                "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
+                "phpdocumentor/reflection-docblock": "^5.2|^6.0",
+                "phpstan/phpdoc-parser": "^1.0|^2.0",
                 "seld/jsonlint": "^1.10",
-                "symfony/asset": "^6.4|^7.0|^8.0",
-                "symfony/asset-mapper": "^6.4|^7.0|^8.0",
-                "symfony/browser-kit": "^6.4|^7.0|^8.0",
-                "symfony/clock": "^6.4|^7.0|^8.0",
-                "symfony/console": "^6.4|^7.0|^8.0",
-                "symfony/css-selector": "^6.4|^7.0|^8.0",
-                "symfony/dom-crawler": "^6.4|^7.0|^8.0",
-                "symfony/dotenv": "^6.4|^7.0|^8.0",
-                "symfony/expression-language": "^6.4|^7.0|^8.0",
+                "symfony/asset": "^7.4|^8.0",
+                "symfony/asset-mapper": "^7.4|^8.0",
+                "symfony/browser-kit": "^7.4|^8.0",
+                "symfony/clock": "^7.4|^8.0",
+                "symfony/console": "^7.4|^8.0",
+                "symfony/css-selector": "^7.4|^8.0",
+                "symfony/dom-crawler": "^7.4|^8.0",
+                "symfony/dotenv": "^7.4|^8.0",
+                "symfony/expression-language": "^7.4|^8.0",
                 "symfony/form": "^7.4|^8.0",
-                "symfony/html-sanitizer": "^6.4|^7.0|^8.0",
-                "symfony/http-client": "^6.4|^7.0|^8.0",
-                "symfony/json-streamer": "^7.3|^8.0",
-                "symfony/lock": "^6.4|^7.0|^8.0",
-                "symfony/mailer": "^6.4|^7.0|^8.0",
+                "symfony/html-sanitizer": "^7.4|^8.0",
+                "symfony/http-client": "^7.4|^8.0",
+                "symfony/json-streamer": "^7.4|^8.0",
+                "symfony/lock": "^7.4|^8.0",
+                "symfony/mailer": "^7.4|^8.0",
                 "symfony/messenger": "^7.4|^8.0",
-                "symfony/mime": "^6.4|^7.0|^8.0",
-                "symfony/notifier": "^6.4|^7.0|^8.0",
-                "symfony/object-mapper": "^7.3|^8.0",
-                "symfony/polyfill-intl-icu": "~1.0",
-                "symfony/process": "^6.4|^7.0|^8.0",
-                "symfony/property-info": "^6.4|^7.0|^8.0",
-                "symfony/rate-limiter": "^6.4|^7.0|^8.0",
-                "symfony/runtime": "^6.4.13|^7.1.6|^8.0",
-                "symfony/scheduler": "^6.4.4|^7.0.4|^8.0",
-                "symfony/security-bundle": "^6.4|^7.0|^8.0",
-                "symfony/semaphore": "^6.4|^7.0|^8.0",
-                "symfony/serializer": "^7.2.5|^8.0",
-                "symfony/stopwatch": "^6.4|^7.0|^8.0",
-                "symfony/string": "^6.4|^7.0|^8.0",
-                "symfony/translation": "^7.3|^8.0",
-                "symfony/twig-bundle": "^6.4|^7.0|^8.0",
-                "symfony/type-info": "^7.1.8|^8.0",
-                "symfony/uid": "^6.4|^7.0|^8.0",
+                "symfony/mime": "^7.4.9|^8.0.9",
+                "symfony/notifier": "^7.4|^8.0",
+                "symfony/object-mapper": "^7.4.9|^8.0.9",
+                "symfony/polyfill-intl-icu": "^1.0",
+                "symfony/process": "^7.4|^8.0",
+                "symfony/property-info": "^7.4|^8.0",
+                "symfony/rate-limiter": "^7.4|^8.0",
+                "symfony/runtime": "^7.4|^8.0",
+                "symfony/scheduler": "^7.4|^8.0",
+                "symfony/security-bundle": "^7.4|^8.0",
+                "symfony/semaphore": "^7.4|^8.0",
+                "symfony/serializer": "^7.4|^8.0",
+                "symfony/stopwatch": "^7.4|^8.0",
+                "symfony/string": "^7.4|^8.0",
+                "symfony/translation": "^7.4|^8.0",
+                "symfony/twig-bundle": "^7.4|^8.0",
+                "symfony/type-info": "^7.4.1|^8.0.1",
+                "symfony/uid": "^7.4|^8.0",
                 "symfony/validator": "^7.4|^8.0",
-                "symfony/web-link": "^6.4|^7.0|^8.0",
-                "symfony/webhook": "^7.2|^8.0",
+                "symfony/web-link": "^7.4|^8.0",
+                "symfony/webhook": "^7.4|^8.0",
                 "symfony/workflow": "^7.4|^8.0",
-                "symfony/yaml": "^7.3|^8.0",
-                "twig/twig": "^3.12"
+                "symfony/yaml": "^7.4|^8.0"
             },
             "type": "symfony-bundle",
             "autoload": {
@@ -4143,7 +4089,7 @@
             "description": "Provides a tight integration between Symfony components and the Symfony full-stack framework",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/framework-bundle/tree/v7.4.1"
+                "source": "https://github.com/symfony/framework-bundle/tree/v8.0.10"
             },
             "funding": [
                 {
@@ -4163,35 +4109,31 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-05T14:04:53+00:00"
+            "time": "2026-05-05T12:00:57+00:00"
         },
         {
             "name": "symfony/http-client",
-            "version": "v7.4.1",
+            "version": "v8.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client.git",
-                "reference": "26cc224ea7103dda90e9694d9e139a389092d007"
+                "reference": "537c7f164078975b800f3f1c56810791024e4c77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client/zipball/26cc224ea7103dda90e9694d9e139a389092d007",
-                "reference": "26cc224ea7103dda90e9694d9e139a389092d007",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/537c7f164078975b800f3f1c56810791024e4c77",
+                "reference": "537c7f164078975b800f3f1c56810791024e4c77",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4",
                 "psr/log": "^1|^2|^3",
-                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/http-client-contracts": "~3.4.4|^3.5.2",
-                "symfony/polyfill-php83": "^1.29",
                 "symfony/service-contracts": "^2.5|^3"
             },
             "conflict": {
-                "amphp/amp": "<2.5",
-                "amphp/socket": "<1.1",
-                "php-http/discovery": "<1.15",
-                "symfony/http-foundation": "<6.4"
+                "amphp/amp": "<3",
+                "php-http/discovery": "<1.15"
             },
             "provide": {
                 "php-http/async-client-implementation": "*",
@@ -4200,20 +4142,19 @@
                 "symfony/http-client-implementation": "3.0"
             },
             "require-dev": {
-                "amphp/http-client": "^4.2.1|^5.0",
-                "amphp/http-tunnel": "^1.0|^2.0",
+                "amphp/http-client": "^5.3.2",
+                "amphp/http-tunnel": "^2.0",
                 "guzzlehttp/promises": "^1.4|^2.0",
                 "nyholm/psr7": "^1.0",
                 "php-http/httplug": "^1.0|^2.0",
                 "psr/http-client": "^1.0",
-                "symfony/amphp-http-client-meta": "^1.0|^2.0",
-                "symfony/cache": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/http-kernel": "^6.4|^7.0|^8.0",
-                "symfony/messenger": "^6.4|^7.0|^8.0",
-                "symfony/process": "^6.4|^7.0|^8.0",
-                "symfony/rate-limiter": "^6.4|^7.0|^8.0",
-                "symfony/stopwatch": "^6.4|^7.0|^8.0"
+                "symfony/cache": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/messenger": "^7.4|^8.0",
+                "symfony/process": "^7.4|^8.0",
+                "symfony/rate-limiter": "^7.4|^8.0",
+                "symfony/stopwatch": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -4244,7 +4185,7 @@
                 "http"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client/tree/v7.4.1"
+                "source": "https://github.com/symfony/http-client/tree/v8.0.9"
             },
             "funding": [
                 {
@@ -4264,20 +4205,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-04T21:12:57+00:00"
+            "time": "2026-04-29T15:02:55+00:00"
         },
         {
             "name": "symfony/http-client-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client-contracts.git",
-                "reference": "75d7043853a42837e68111812f4d964b01e5101c"
+                "reference": "4a2d00c37651c0bdc2b9e1c773487a8bf4edb12d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/75d7043853a42837e68111812f4d964b01e5101c",
-                "reference": "75d7043853a42837e68111812f4d964b01e5101c",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/4a2d00c37651c0bdc2b9e1c773487a8bf4edb12d",
+                "reference": "4a2d00c37651c0bdc2b9e1c773487a8bf4edb12d",
                 "shasum": ""
             },
             "require": {
@@ -4290,7 +4231,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -4326,7 +4267,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/http-client-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -4338,45 +4279,47 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-29T11:18:49+00:00"
+            "time": "2026-03-06T13:17:50+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v7.4.1",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "bd1af1e425811d6f077db240c3a588bdb405cd27"
+                "reference": "02656f7ebeae5c155d659e946f6b3a33df24051b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/bd1af1e425811d6f077db240c3a588bdb405cd27",
-                "reference": "bd1af1e425811d6f077db240c3a588bdb405cd27",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/02656f7ebeae5c155d659e946f6b3a33df24051b",
+                "reference": "02656f7ebeae5c155d659e946f6b3a33df24051b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
+                "php": ">=8.4",
                 "symfony/polyfill-mbstring": "^1.1"
             },
             "conflict": {
-                "doctrine/dbal": "<3.6",
-                "symfony/cache": "<6.4.12|>=7.0,<7.1.5"
+                "doctrine/dbal": "<4.3"
             },
             "require-dev": {
-                "doctrine/dbal": "^3.6|^4",
+                "doctrine/dbal": "^4.3",
                 "predis/predis": "^1.1|^2.0",
-                "symfony/cache": "^6.4.12|^7.1.5|^8.0",
-                "symfony/clock": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/expression-language": "^6.4|^7.0|^8.0",
-                "symfony/http-kernel": "^6.4|^7.0|^8.0",
-                "symfony/mime": "^6.4|^7.0|^8.0",
-                "symfony/rate-limiter": "^6.4|^7.0|^8.0"
+                "symfony/cache": "^7.4|^8.0",
+                "symfony/clock": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/expression-language": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/mime": "^7.4|^8.0",
+                "symfony/rate-limiter": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -4404,7 +4347,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v7.4.1"
+                "source": "https://github.com/symfony/http-foundation/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -4424,78 +4367,63 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-07T11:13:10+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v7.4.2",
+            "version": "v8.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "f6e6f0a5fa8763f75a504b930163785fb6dd055f"
+                "reference": "fb3f65b3d4ca2dad31c80d323819a762ca31d6ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/f6e6f0a5fa8763f75a504b930163785fb6dd055f",
-                "reference": "f6e6f0a5fa8763f75a504b930163785fb6dd055f",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/fb3f65b3d4ca2dad31c80d323819a762ca31d6ac",
+                "reference": "fb3f65b3d4ca2dad31c80d323819a762ca31d6ac",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4",
                 "psr/log": "^1|^2|^3",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/error-handler": "^6.4|^7.0|^8.0",
-                "symfony/event-dispatcher": "^7.3|^8.0",
+                "symfony/error-handler": "^7.4|^8.0",
+                "symfony/event-dispatcher": "^7.4|^8.0",
                 "symfony/http-foundation": "^7.4|^8.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
-                "symfony/browser-kit": "<6.4",
-                "symfony/cache": "<6.4",
-                "symfony/config": "<6.4",
-                "symfony/console": "<6.4",
-                "symfony/dependency-injection": "<6.4",
-                "symfony/doctrine-bridge": "<6.4",
                 "symfony/flex": "<2.10",
-                "symfony/form": "<6.4",
-                "symfony/http-client": "<6.4",
                 "symfony/http-client-contracts": "<2.5",
-                "symfony/mailer": "<6.4",
-                "symfony/messenger": "<6.4",
-                "symfony/translation": "<6.4",
                 "symfony/translation-contracts": "<2.5",
-                "symfony/twig-bridge": "<6.4",
-                "symfony/validator": "<6.4",
-                "symfony/var-dumper": "<6.4",
-                "twig/twig": "<3.12"
+                "twig/twig": "<3.21"
             },
             "provide": {
                 "psr/log-implementation": "1.0|2.0|3.0"
             },
             "require-dev": {
                 "psr/cache": "^1.0|^2.0|^3.0",
-                "symfony/browser-kit": "^6.4|^7.0|^8.0",
-                "symfony/clock": "^6.4|^7.0|^8.0",
-                "symfony/config": "^6.4|^7.0|^8.0",
-                "symfony/console": "^6.4|^7.0|^8.0",
-                "symfony/css-selector": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/dom-crawler": "^6.4|^7.0|^8.0",
-                "symfony/expression-language": "^6.4|^7.0|^8.0",
-                "symfony/finder": "^6.4|^7.0|^8.0",
+                "symfony/browser-kit": "^7.4|^8.0",
+                "symfony/clock": "^7.4|^8.0",
+                "symfony/config": "^7.4|^8.0",
+                "symfony/console": "^7.4|^8.0",
+                "symfony/css-selector": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/dom-crawler": "^7.4|^8.0",
+                "symfony/expression-language": "^7.4|^8.0",
+                "symfony/finder": "^7.4|^8.0",
                 "symfony/http-client-contracts": "^2.5|^3",
-                "symfony/process": "^6.4|^7.0|^8.0",
-                "symfony/property-access": "^7.1|^8.0",
-                "symfony/routing": "^6.4|^7.0|^8.0",
-                "symfony/serializer": "^7.1|^8.0",
-                "symfony/stopwatch": "^6.4|^7.0|^8.0",
-                "symfony/translation": "^6.4|^7.0|^8.0",
+                "symfony/process": "^7.4|^8.0",
+                "symfony/property-access": "^7.4|^8.0",
+                "symfony/routing": "^7.4|^8.0",
+                "symfony/serializer": "^7.4|^8.0",
+                "symfony/stopwatch": "^7.4|^8.0",
+                "symfony/translation": "^7.4|^8.0",
                 "symfony/translation-contracts": "^2.5|^3",
-                "symfony/uid": "^6.4|^7.0|^8.0",
-                "symfony/validator": "^6.4|^7.0|^8.0",
-                "symfony/var-dumper": "^6.4|^7.0|^8.0",
-                "symfony/var-exporter": "^6.4|^7.0|^8.0",
-                "twig/twig": "^3.12"
+                "symfony/uid": "^7.4|^8.0",
+                "symfony/validator": "^7.4|^8.0",
+                "symfony/var-dumper": "^7.4|^8.0",
+                "symfony/var-exporter": "^7.4|^8.0",
+                "twig/twig": "^3.21"
             },
             "type": "library",
             "autoload": {
@@ -4523,7 +4451,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v7.4.2"
+                "source": "https://github.com/symfony/http-kernel/tree/v8.0.10"
             },
             "funding": [
                 {
@@ -4543,32 +4471,31 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-08T07:43:37+00:00"
+            "time": "2026-05-06T12:27:31+00:00"
         },
         {
             "name": "symfony/intl",
-            "version": "v7.4.0",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/intl.git",
-                "reference": "2fa074de6c7faa6b54f2891fc22708f42245ed5c"
+                "reference": "604a1dbbd67471e885e93274379cadd80dc33535"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/intl/zipball/2fa074de6c7faa6b54f2891fc22708f42245ed5c",
-                "reference": "2fa074de6c7faa6b54f2891fc22708f42245ed5c",
+                "url": "https://api.github.com/repos/symfony/intl/zipball/604a1dbbd67471e885e93274379cadd80dc33535",
+                "reference": "604a1dbbd67471e885e93274379cadd80dc33535",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3"
+                "php": ">=8.4"
             },
             "conflict": {
-                "symfony/string": "<7.1"
+                "symfony/string": "<7.4"
             },
             "require-dev": {
-                "symfony/filesystem": "^6.4|^7.0|^8.0",
-                "symfony/var-exporter": "^6.4|^7.0|^8.0"
+                "symfony/filesystem": "^7.4|^8.0",
+                "symfony/var-exporter": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -4613,7 +4540,7 @@
                 "localization"
             ],
             "support": {
-                "source": "https://github.com/symfony/intl/tree/v7.4.0"
+                "source": "https://github.com/symfony/intl/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -4633,43 +4560,39 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-27T13:27:24+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/mailer",
-            "version": "v7.4.0",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mailer.git",
-                "reference": "a3d9eea8cfa467ece41f0f54ba28185d74bd53fd"
+                "reference": "ca5f6edaf8780ece814404b58a4482b22b509c56"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mailer/zipball/a3d9eea8cfa467ece41f0f54ba28185d74bd53fd",
-                "reference": "a3d9eea8cfa467ece41f0f54ba28185d74bd53fd",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/ca5f6edaf8780ece814404b58a4482b22b509c56",
+                "reference": "ca5f6edaf8780ece814404b58a4482b22b509c56",
                 "shasum": ""
             },
             "require": {
                 "egulias/email-validator": "^2.1.10|^3|^4",
-                "php": ">=8.2",
+                "php": ">=8.4",
                 "psr/event-dispatcher": "^1",
                 "psr/log": "^1|^2|^3",
-                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
-                "symfony/mime": "^7.2|^8.0",
+                "symfony/event-dispatcher": "^7.4|^8.0",
+                "symfony/mime": "^7.4|^8.0",
                 "symfony/service-contracts": "^2.5|^3"
             },
             "conflict": {
-                "symfony/http-client-contracts": "<2.5",
-                "symfony/http-kernel": "<6.4",
-                "symfony/messenger": "<6.4",
-                "symfony/mime": "<6.4",
-                "symfony/twig-bridge": "<6.4"
+                "symfony/http-client-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/console": "^6.4|^7.0|^8.0",
-                "symfony/http-client": "^6.4|^7.0|^8.0",
-                "symfony/messenger": "^6.4|^7.0|^8.0",
-                "symfony/twig-bridge": "^6.4|^7.0|^8.0"
+                "symfony/console": "^7.4|^8.0",
+                "symfony/http-client": "^7.4|^8.0",
+                "symfony/messenger": "^7.4|^8.0",
+                "symfony/twig-bridge": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -4697,7 +4620,7 @@
             "description": "Helps sending emails",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/mailer/tree/v7.4.0"
+                "source": "https://github.com/symfony/mailer/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -4717,53 +4640,49 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-21T15:26:00+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/messenger",
-            "version": "v7.4.0",
+            "version": "v8.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/messenger.git",
-                "reference": "241f2f82048d2198f3ade29397c1ceddf30ccb24"
+                "reference": "29a4a7c5f5e24913d374fb724feea18764a8a86c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/messenger/zipball/241f2f82048d2198f3ade29397c1ceddf30ccb24",
-                "reference": "241f2f82048d2198f3ade29397c1ceddf30ccb24",
+                "url": "https://api.github.com/repos/symfony/messenger/zipball/29a4a7c5f5e24913d374fb724feea18764a8a86c",
+                "reference": "29a4a7c5f5e24913d374fb724feea18764a8a86c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4",
                 "psr/log": "^1|^2|^3",
-                "symfony/clock": "^6.4|^7.0|^8.0",
-                "symfony/deprecation-contracts": "^2.5|^3"
+                "symfony/clock": "^7.4|^8.0"
             },
             "conflict": {
-                "symfony/console": "<7.2",
-                "symfony/event-dispatcher": "<6.4",
+                "symfony/console": "<7.4",
                 "symfony/event-dispatcher-contracts": "<2.5",
-                "symfony/framework-bundle": "<6.4",
-                "symfony/http-kernel": "<7.3",
-                "symfony/lock": "<6.4",
-                "symfony/serializer": "<6.4"
+                "symfony/lock": "<7.4",
+                "symfony/serializer": "<7.4.4|>=8.0,<8.0.4"
             },
             "require-dev": {
                 "psr/cache": "^1.0|^2.0|^3.0",
-                "symfony/console": "^7.2|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
-                "symfony/http-kernel": "^7.3|^8.0",
-                "symfony/lock": "^6.4|^7.0|^8.0",
-                "symfony/process": "^6.4|^7.0|^8.0",
-                "symfony/property-access": "^6.4|^7.0|^8.0",
-                "symfony/rate-limiter": "^6.4|^7.0|^8.0",
-                "symfony/routing": "^6.4|^7.0|^8.0",
-                "symfony/serializer": "^6.4|^7.0|^8.0",
+                "symfony/console": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/event-dispatcher": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/lock": "^7.4|^8.0",
+                "symfony/process": "^7.4|^8.0",
+                "symfony/property-access": "^7.4|^8.0",
+                "symfony/rate-limiter": "^7.4|^8.0",
+                "symfony/routing": "^7.4|^8.0",
+                "symfony/serializer": "^7.4.4|^8.0.4",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/stopwatch": "^6.4|^7.0|^8.0",
-                "symfony/validator": "^6.4|^7.0|^8.0",
-                "symfony/var-dumper": "^6.4|^7.0|^8.0"
+                "symfony/stopwatch": "^7.4|^8.0",
+                "symfony/validator": "^7.4|^8.0",
+                "symfony/var-dumper": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -4791,7 +4710,7 @@
             "description": "Helps applications send and receive messages to/from other applications or via message queues",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/messenger/tree/v7.4.0"
+                "source": "https://github.com/symfony/messenger/tree/v8.0.10"
             },
             "funding": [
                 {
@@ -4811,44 +4730,41 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-06T11:20:06+00:00"
+            "time": "2026-05-06T11:30:54+00:00"
         },
         {
             "name": "symfony/mime",
-            "version": "v7.4.0",
+            "version": "v8.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "bdb02729471be5d047a3ac4a69068748f1a6be7a"
+                "reference": "a9fcb293650c054b62a5b406f4e92e7b711ea333"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/bdb02729471be5d047a3ac4a69068748f1a6be7a",
-                "reference": "bdb02729471be5d047a3ac4a69068748f1a6be7a",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/a9fcb293650c054b62a5b406f4e92e7b711ea333",
+                "reference": "a9fcb293650c054b62a5b406f4e92e7b711ea333",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
+                "php": ">=8.4",
                 "symfony/polyfill-intl-idn": "^1.10",
                 "symfony/polyfill-mbstring": "^1.0"
             },
             "conflict": {
                 "egulias/email-validator": "~3.0.0",
-                "phpdocumentor/reflection-docblock": "<3.2.2",
-                "phpdocumentor/type-resolver": "<1.4.0",
-                "symfony/mailer": "<6.4",
-                "symfony/serializer": "<6.4.3|>7.0,<7.0.3"
+                "phpdocumentor/reflection-docblock": "<5.2|>=7",
+                "phpdocumentor/type-resolver": "<1.5.1"
             },
             "require-dev": {
                 "egulias/email-validator": "^2.1.10|^3.1|^4",
                 "league/html-to-markdown": "^5.0",
-                "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/process": "^6.4|^7.0|^8.0",
-                "symfony/property-access": "^6.4|^7.0|^8.0",
-                "symfony/property-info": "^6.4|^7.0|^8.0",
-                "symfony/serializer": "^6.4.3|^7.0.3|^8.0"
+                "phpdocumentor/reflection-docblock": "^5.2|^6.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/process": "^7.4|^8.0",
+                "symfony/property-access": "^7.4|^8.0",
+                "symfony/property-info": "^7.4|^8.0",
+                "symfony/serializer": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -4880,7 +4796,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v7.4.0"
+                "source": "https://github.com/symfony/mime/tree/v8.0.9"
             },
             "funding": [
                 {
@@ -4900,42 +4816,36 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-16T10:14:42+00:00"
+            "time": "2026-04-29T15:02:55+00:00"
         },
         {
             "name": "symfony/monolog-bridge",
-            "version": "v7.4.0",
+            "version": "v8.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/monolog-bridge.git",
-                "reference": "189d16466ff83d9c51fad26382bf0beeb41bda21"
+                "reference": "4b7249b1520773ad325e99231b08443017729297"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/monolog-bridge/zipball/189d16466ff83d9c51fad26382bf0beeb41bda21",
-                "reference": "189d16466ff83d9c51fad26382bf0beeb41bda21",
+                "url": "https://api.github.com/repos/symfony/monolog-bridge/zipball/4b7249b1520773ad325e99231b08443017729297",
+                "reference": "4b7249b1520773ad325e99231b08443017729297",
                 "shasum": ""
             },
             "require": {
                 "monolog/monolog": "^3",
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "php": ">=8.4",
+                "symfony/http-kernel": "^7.4|^8.0",
                 "symfony/service-contracts": "^2.5|^3"
             },
-            "conflict": {
-                "symfony/console": "<6.4",
-                "symfony/http-foundation": "<6.4",
-                "symfony/security-core": "<6.4"
-            },
             "require-dev": {
-                "symfony/console": "^6.4|^7.0|^8.0",
-                "symfony/http-client": "^6.4|^7.0|^8.0",
-                "symfony/mailer": "^6.4|^7.0|^8.0",
-                "symfony/messenger": "^6.4|^7.0|^8.0",
-                "symfony/mime": "^6.4|^7.0|^8.0",
-                "symfony/security-core": "^6.4|^7.0|^8.0",
-                "symfony/var-dumper": "^6.4|^7.0|^8.0"
+                "symfony/console": "^7.4|^8.0",
+                "symfony/http-client": "^7.4|^8.0",
+                "symfony/mailer": "^7.4|^8.0",
+                "symfony/messenger": "^7.4|^8.0",
+                "symfony/mime": "^7.4|^8.0",
+                "symfony/security-core": "^7.4|^8.0",
+                "symfony/var-dumper": "^7.4|^8.0"
             },
             "type": "symfony-bridge",
             "autoload": {
@@ -4963,7 +4873,7 @@
             "description": "Provides integration for Monolog with various Symfony components",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/monolog-bridge/tree/v7.4.0"
+                "source": "https://github.com/symfony/monolog-bridge/tree/v8.0.9"
             },
             "funding": [
                 {
@@ -4983,20 +4893,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-01T09:17:33+00:00"
+            "time": "2026-04-29T15:02:55+00:00"
         },
         {
             "name": "symfony/monolog-bundle",
-            "version": "v4.0.1",
+            "version": "v4.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/monolog-bundle.git",
-                "reference": "3b4ee2717ee56c5e1edb516140a175eb2a72bc66"
+                "reference": "c012c6aba13129eb02aa7dd61e66e720911d8598"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/monolog-bundle/zipball/3b4ee2717ee56c5e1edb516140a175eb2a72bc66",
-                "reference": "3b4ee2717ee56c5e1edb516140a175eb2a72bc66",
+                "url": "https://api.github.com/repos/symfony/monolog-bundle/zipball/c012c6aba13129eb02aa7dd61e66e720911d8598",
+                "reference": "c012c6aba13129eb02aa7dd61e66e720911d8598",
                 "shasum": ""
             },
             "require": {
@@ -5042,7 +4952,7 @@
             ],
             "support": {
                 "issues": "https://github.com/symfony/monolog-bundle/issues",
-                "source": "https://github.com/symfony/monolog-bundle/tree/v4.0.1"
+                "source": "https://github.com/symfony/monolog-bundle/tree/v4.0.2"
             },
             "funding": [
                 {
@@ -5062,37 +4972,37 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-08T08:00:13+00:00"
+            "time": "2026-04-02T18:27:21+00:00"
         },
         {
             "name": "symfony/notifier",
-            "version": "v7.4.0",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/notifier.git",
-                "reference": "3acae3ec78e920d251361adabb270e8d724a525a"
+                "reference": "e65ae16a36900c92e977733fcee22d47f79c3601"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/notifier/zipball/3acae3ec78e920d251361adabb270e8d724a525a",
-                "reference": "3acae3ec78e920d251361adabb270e8d724a525a",
+                "url": "https://api.github.com/repos/symfony/notifier/zipball/e65ae16a36900c92e977733fcee22d47f79c3601",
+                "reference": "e65ae16a36900c92e977733fcee22d47f79c3601",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4",
                 "psr/log": "^1|^2|^3"
             },
             "conflict": {
-                "symfony/event-dispatcher": "<6.4",
                 "symfony/event-dispatcher-contracts": "<2.5",
-                "symfony/http-client-contracts": "<2.5",
-                "symfony/http-kernel": "<6.4"
+                "symfony/http-client-contracts": "<2.5"
             },
             "require-dev": {
+                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
                 "symfony/event-dispatcher-contracts": "^2.5|^3",
+                "symfony/http-client": "^7.4|^8.0",
                 "symfony/http-client-contracts": "^2.5|^3",
-                "symfony/http-foundation": "^6.4|^7.0|^8.0",
-                "symfony/messenger": "^6.4|^7.0|^8.0"
+                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/messenger": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -5124,7 +5034,7 @@
                 "notifier"
             ],
             "support": {
-                "source": "https://github.com/symfony/notifier/tree/v7.4.0"
+                "source": "https://github.com/symfony/notifier/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -5144,24 +5054,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-21T15:26:00+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v7.4.0",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "b38026df55197f9e39a44f3215788edf83187b80"
+                "reference": "b48bce0a70b914f6953dafbd10474df232ed4de8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/b38026df55197f9e39a44f3215788edf83187b80",
-                "reference": "b38026df55197f9e39a44f3215788edf83187b80",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/b48bce0a70b914f6953dafbd10474df232ed4de8",
+                "reference": "b48bce0a70b914f6953dafbd10474df232ed4de8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4",
                 "symfony/deprecation-contracts": "^2.5|^3"
             },
             "type": "library",
@@ -5195,7 +5105,7 @@
                 "options"
             ],
             "support": {
-                "source": "https://github.com/symfony/options-resolver/tree/v7.4.0"
+                "source": "https://github.com/symfony/options-resolver/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -5215,31 +5125,28 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-12T15:39:26+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/password-hasher",
-            "version": "v7.4.0",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/password-hasher.git",
-                "reference": "aa075ce6f54fe931f03c1e382597912f4fd94e1e"
+                "reference": "57ee968d3c38301ed3e5b838f850a10f2d06a7f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/password-hasher/zipball/aa075ce6f54fe931f03c1e382597912f4fd94e1e",
-                "reference": "aa075ce6f54fe931f03c1e382597912f4fd94e1e",
+                "url": "https://api.github.com/repos/symfony/password-hasher/zipball/57ee968d3c38301ed3e5b838f850a10f2d06a7f6",
+                "reference": "57ee968d3c38301ed3e5b838f850a10f2d06a7f6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
-            },
-            "conflict": {
-                "symfony/security-core": "<6.4"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "symfony/console": "^6.4|^7.0|^8.0",
-                "symfony/security-core": "^6.4|^7.0|^8.0"
+                "symfony/console": "^7.4|^8.0",
+                "symfony/security-core": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -5271,7 +5178,7 @@
                 "password"
             ],
             "support": {
-                "source": "https://github.com/symfony/password-hasher/tree/v7.4.0"
+                "source": "https://github.com/symfony/password-hasher/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -5291,20 +5198,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-13T16:46:49+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70"
+                "reference": "4864388bfbd3001ce88e234fab652acd91fdc57e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/380872130d3a5dd3ace2f4010d95125fde5d5c70",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/4864388bfbd3001ce88e234fab652acd91fdc57e",
+                "reference": "4864388bfbd3001ce88e234fab652acd91fdc57e",
                 "shasum": ""
             },
             "require": {
@@ -5353,7 +5260,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -5373,11 +5280,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-27T09:58:17+00:00"
+            "time": "2026-04-26T13:13:48+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
@@ -5440,7 +5347,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -5464,7 +5371,7 @@
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
@@ -5525,7 +5432,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -5549,16 +5456,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
+                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315",
                 "shasum": ""
             },
             "require": {
@@ -5610,7 +5517,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -5630,100 +5537,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-23T08:48:59+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php83",
-            "version": "v1.33.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php83.git",
-                "reference": "17f6f9a6b1735c0f163024d959f700cfbc5155e5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/17f6f9a6b1735c0f163024d959f700cfbc5155e5",
-                "reference": "17f6f9a6b1735c0f163024d959f700cfbc5155e5",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php83\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.3+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php83/tree/v1.33.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-07-08T02:45:35+00:00"
+            "time": "2026-04-10T17:25:58+00:00"
         },
         {
             "name": "symfony/polyfill-php84",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php84.git",
-                "reference": "d8ced4d875142b6a7426000426b8abc631d6b191"
+                "reference": "88486db2c389b290bf87ff1de7ebc1e13e42bb06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/d8ced4d875142b6a7426000426b8abc631d6b191",
-                "reference": "d8ced4d875142b6a7426000426b8abc631d6b191",
+                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/88486db2c389b290bf87ff1de7ebc1e13e42bb06",
+                "reference": "88486db2c389b290bf87ff1de7ebc1e13e42bb06",
                 "shasum": ""
             },
             "require": {
@@ -5770,7 +5597,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php84/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -5790,20 +5617,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-24T13:30:11+00:00"
+            "time": "2026-04-10T18:47:49+00:00"
         },
         {
             "name": "symfony/polyfill-php85",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php85.git",
-                "reference": "d4e5fcd4ab3d998ab16c0db48e6cbb9a01993f91"
+                "reference": "fcfa4973a9917cef23f2e38774da74a2b7d115ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php85/zipball/d4e5fcd4ab3d998ab16c0db48e6cbb9a01993f91",
-                "reference": "d4e5fcd4ab3d998ab16c0db48e6cbb9a01993f91",
+                "url": "https://api.github.com/repos/symfony/polyfill-php85/zipball/fcfa4973a9917cef23f2e38774da74a2b7d115ee",
+                "reference": "fcfa4973a9917cef23f2e38774da74a2b7d115ee",
                 "shasum": ""
             },
             "require": {
@@ -5850,7 +5677,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php85/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php85/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -5870,20 +5697,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-23T16:12:55+00:00"
+            "time": "2026-04-26T13:10:57+00:00"
         },
         {
             "name": "symfony/polyfill-uuid",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-uuid.git",
-                "reference": "21533be36c24be3f4b1669c4725c7d1d2bab4ae2"
+                "reference": "26dfec253c4cf3e51b541b52ddf7e42cb0908e94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-uuid/zipball/21533be36c24be3f4b1669c4725c7d1d2bab4ae2",
-                "reference": "21533be36c24be3f4b1669c4725c7d1d2bab4ae2",
+                "url": "https://api.github.com/repos/symfony/polyfill-uuid/zipball/26dfec253c4cf3e51b541b52ddf7e42cb0908e94",
+                "reference": "26dfec253c4cf3e51b541b52ddf7e42cb0908e94",
                 "shasum": ""
             },
             "require": {
@@ -5933,7 +5760,7 @@
                 "uuid"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -5953,29 +5780,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/property-access",
-            "version": "v7.4.0",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/property-access.git",
-                "reference": "537626149d2910ca43eb9ce465654366bf4442f4"
+                "reference": "704c7808116fcdd67327db7b17de56b8ef6169e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/property-access/zipball/537626149d2910ca43eb9ce465654366bf4442f4",
-                "reference": "537626149d2910ca43eb9ce465654366bf4442f4",
+                "url": "https://api.github.com/repos/symfony/property-access/zipball/704c7808116fcdd67327db7b17de56b8ef6169e4",
+                "reference": "704c7808116fcdd67327db7b17de56b8ef6169e4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/property-info": "^6.4|^7.0|^8.0"
+                "php": ">=8.4",
+                "symfony/property-info": "^7.4.4|^8.0.4"
             },
             "require-dev": {
-                "symfony/cache": "^6.4|^7.0|^8.0",
-                "symfony/var-exporter": "^6.4.1|^7.0.1|^8.0"
+                "symfony/cache": "^7.4|^8.0",
+                "symfony/var-exporter": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -6014,7 +5841,7 @@
                 "reflection"
             ],
             "support": {
-                "source": "https://github.com/symfony/property-access/tree/v7.4.0"
+                "source": "https://github.com/symfony/property-access/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -6034,41 +5861,37 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-08T21:14:32+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/property-info",
-            "version": "v7.4.1",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/property-info.git",
-                "reference": "912aafe70bee5cfd09fec5916fe35b83f04ae6ae"
+                "reference": "c21711980653360d6ef5c26d0f9ca6f58a1135c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/property-info/zipball/912aafe70bee5cfd09fec5916fe35b83f04ae6ae",
-                "reference": "912aafe70bee5cfd09fec5916fe35b83f04ae6ae",
+                "url": "https://api.github.com/repos/symfony/property-info/zipball/c21711980653360d6ef5c26d0f9ca6f58a1135c6",
+                "reference": "c21711980653360d6ef5c26d0f9ca6f58a1135c6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/string": "^6.4|^7.0|^8.0",
-                "symfony/type-info": "~7.3.8|^7.4.1|^8.0.1"
+                "php": ">=8.4",
+                "symfony/string": "^7.4|^8.0",
+                "symfony/type-info": "^7.4.7|^8.0.7"
             },
             "conflict": {
-                "phpdocumentor/reflection-docblock": "<5.2",
-                "phpdocumentor/type-resolver": "<1.5.1",
-                "symfony/cache": "<6.4",
-                "symfony/dependency-injection": "<6.4",
-                "symfony/serializer": "<6.4"
+                "phpdocumentor/reflection-docblock": "<5.2|>=7",
+                "phpdocumentor/type-resolver": "<1.5.1"
             },
             "require-dev": {
-                "phpdocumentor/reflection-docblock": "^5.2",
+                "phpdocumentor/reflection-docblock": "^5.2|^6.0",
                 "phpstan/phpdoc-parser": "^1.0|^2.0",
-                "symfony/cache": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/serializer": "^6.4|^7.0|^8.0"
+                "symfony/cache": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/serializer": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -6104,7 +5927,7 @@
                 "validator"
             ],
             "support": {
-                "source": "https://github.com/symfony/property-info/tree/v7.4.1"
+                "source": "https://github.com/symfony/property-info/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -6124,29 +5947,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-05T14:04:53+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/rate-limiter",
-            "version": "v7.4.7",
+            "version": "v8.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/rate-limiter.git",
-                "reference": "c2ff01c8d5ed54f0721f046fde14a94f2df09666"
+                "reference": "81146a00aacbc9f610f22391cc4ea170090dfb8a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/rate-limiter/zipball/c2ff01c8d5ed54f0721f046fde14a94f2df09666",
-                "reference": "c2ff01c8d5ed54f0721f046fde14a94f2df09666",
+                "url": "https://api.github.com/repos/symfony/rate-limiter/zipball/81146a00aacbc9f610f22391cc4ea170090dfb8a",
+                "reference": "81146a00aacbc9f610f22391cc4ea170090dfb8a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/options-resolver": "^7.3|^8.0"
+                "php": ">=8.4",
+                "symfony/options-resolver": "^7.4|^8.0"
             },
             "require-dev": {
                 "psr/cache": "^1.0|^2.0|^3.0",
-                "symfony/lock": "^6.4|^7.0|^8.0"
+                "symfony/lock": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -6178,7 +6001,7 @@
                 "rate-limiter"
             ],
             "support": {
-                "source": "https://github.com/symfony/rate-limiter/tree/v7.4.7"
+                "source": "https://github.com/symfony/rate-limiter/tree/v8.0.10"
             },
             "funding": [
                 {
@@ -6198,7 +6021,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-04T13:54:41+00:00"
+            "time": "2026-05-04T13:41:39+00:00"
         },
         {
             "name": "symfony/requirements-checker",
@@ -6263,34 +6086,29 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v7.4.0",
+            "version": "v8.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "4720254cb2644a0b876233d258a32bf017330db7"
+                "reference": "75d1bd8e5da3424e4db2fc3ff0222cb4d0c73038"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/4720254cb2644a0b876233d258a32bf017330db7",
-                "reference": "4720254cb2644a0b876233d258a32bf017330db7",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/75d1bd8e5da3424e4db2fc3ff0222cb4d0c73038",
+                "reference": "75d1bd8e5da3424e4db2fc3ff0222cb4d0c73038",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4",
                 "symfony/deprecation-contracts": "^2.5|^3"
-            },
-            "conflict": {
-                "symfony/config": "<6.4",
-                "symfony/dependency-injection": "<6.4",
-                "symfony/yaml": "<6.4"
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/expression-language": "^6.4|^7.0|^8.0",
-                "symfony/http-foundation": "^6.4|^7.0|^8.0",
-                "symfony/yaml": "^6.4|^7.0|^8.0"
+                "symfony/config": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/expression-language": "^7.4|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/yaml": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -6324,7 +6142,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v7.4.0"
+                "source": "https://github.com/symfony/routing/tree/v8.0.9"
             },
             "funding": [
                 {
@@ -6344,35 +6162,35 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-27T13:27:24+00:00"
+            "time": "2026-04-29T15:02:55+00:00"
         },
         {
             "name": "symfony/runtime",
-            "version": "v7.4.1",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/runtime.git",
-                "reference": "876f902a6cb6b26c003de244188c06b2ba1c172f"
+                "reference": "30884f00e017a26100fcd9aa281082ebf9a87dce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/runtime/zipball/876f902a6cb6b26c003de244188c06b2ba1c172f",
-                "reference": "876f902a6cb6b26c003de244188c06b2ba1c172f",
+                "url": "https://api.github.com/repos/symfony/runtime/zipball/30884f00e017a26100fcd9aa281082ebf9a87dce",
+                "reference": "30884f00e017a26100fcd9aa281082ebf9a87dce",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.0|^2.0",
-                "php": ">=8.2"
+                "php": ">=8.4"
             },
             "conflict": {
-                "symfony/dotenv": "<6.4"
+                "symfony/error-handler": "<7.4"
             },
             "require-dev": {
                 "composer/composer": "^2.6",
-                "symfony/console": "^6.4|^7.0|^8.0",
-                "symfony/dotenv": "^6.4|^7.0|^8.0",
-                "symfony/http-foundation": "^6.4|^7.0|^8.0",
-                "symfony/http-kernel": "^6.4|^7.0|^8.0"
+                "symfony/console": "^7.4|^8.0",
+                "symfony/dotenv": "^7.4|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -6407,7 +6225,7 @@
                 "runtime"
             ],
             "support": {
-                "source": "https://github.com/symfony/runtime/tree/v7.4.1"
+                "source": "https://github.com/symfony/runtime/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -6427,35 +6245,35 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-05T14:04:53+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/scheduler",
-            "version": "v7.4.0",
+            "version": "v8.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/scheduler.git",
-                "reference": "481caa4284b2c831ce4b27978e215d296d8ffd0e"
+                "reference": "64a4ae9af5653fcee9cbd31ad7a8d2128eec1de2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/scheduler/zipball/481caa4284b2c831ce4b27978e215d296d8ffd0e",
-                "reference": "481caa4284b2c831ce4b27978e215d296d8ffd0e",
+                "url": "https://api.github.com/repos/symfony/scheduler/zipball/64a4ae9af5653fcee9cbd31ad7a8d2128eec1de2",
+                "reference": "64a4ae9af5653fcee9cbd31ad7a8d2128eec1de2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/clock": "^6.4|^7.0|^8.0"
+                "php": ">=8.4",
+                "symfony/clock": "^7.4|^8.0"
             },
             "require-dev": {
                 "dragonmantank/cron-expression": "^3.1",
-                "symfony/cache": "^6.4|^7.0|^8.0",
-                "symfony/console": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
-                "symfony/lock": "^6.4|^7.0|^8.0",
-                "symfony/messenger": "^6.4|^7.0|^8.0",
-                "symfony/serializer": "^6.4|^7.1|^8.0"
+                "symfony/cache": "^7.4.8|^8.0.8",
+                "symfony/console": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/event-dispatcher": "^7.4|^8.0",
+                "symfony/lock": "^7.4|^8.0",
+                "symfony/messenger": "^7.4|^8.0",
+                "symfony/serializer": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -6492,7 +6310,7 @@
                 "scheduler"
             ],
             "support": {
-                "source": "https://github.com/symfony/scheduler/tree/v7.4.0"
+                "source": "https://github.com/symfony/scheduler/tree/v8.0.10"
             },
             "funding": [
                 {
@@ -6512,70 +6330,58 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-30T06:01:53+00:00"
+            "time": "2026-05-06T12:05:43+00:00"
         },
         {
             "name": "symfony/security-bundle",
-            "version": "v7.4.0",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security-bundle.git",
-                "reference": "48a64e746857464a5e8fd7bab84b31c9ba967eb9"
+                "reference": "00a13be2abf3fe9baf54e1e16e7583ca9c708f09"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-bundle/zipball/48a64e746857464a5e8fd7bab84b31c9ba967eb9",
-                "reference": "48a64e746857464a5e8fd7bab84b31c9ba967eb9",
+                "url": "https://api.github.com/repos/symfony/security-bundle/zipball/00a13be2abf3fe9baf54e1e16e7583ca9c708f09",
+                "reference": "00a13be2abf3fe9baf54e1e16e7583ca9c708f09",
                 "shasum": ""
             },
             "require": {
                 "composer-runtime-api": ">=2.1",
                 "ext-xml": "*",
-                "php": ">=8.2",
-                "symfony/clock": "^6.4|^7.0|^8.0",
+                "php": ">=8.4",
+                "symfony/clock": "^7.4|^8.0",
                 "symfony/config": "^7.4|^8.0",
-                "symfony/dependency-injection": "^6.4.11|^7.1.4|^8.0",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
-                "symfony/http-foundation": "^6.4|^7.0|^8.0",
-                "symfony/http-kernel": "^6.4.13|^7.1.6|^8.0",
-                "symfony/password-hasher": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/event-dispatcher": "^7.4|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/password-hasher": "^7.4|^8.0",
                 "symfony/security-core": "^7.4|^8.0",
-                "symfony/security-csrf": "^6.4|^7.0|^8.0",
+                "symfony/security-csrf": "^7.4|^8.0",
                 "symfony/security-http": "^7.4|^8.0",
                 "symfony/service-contracts": "^2.5|^3"
             },
-            "conflict": {
-                "symfony/browser-kit": "<6.4",
-                "symfony/console": "<6.4",
-                "symfony/framework-bundle": "<6.4",
-                "symfony/http-client": "<6.4",
-                "symfony/ldap": "<6.4",
-                "symfony/serializer": "<6.4",
-                "symfony/twig-bundle": "<6.4",
-                "symfony/validator": "<6.4"
-            },
             "require-dev": {
-                "symfony/asset": "^6.4|^7.0|^8.0",
-                "symfony/browser-kit": "^6.4|^7.0|^8.0",
-                "symfony/console": "^6.4|^7.0|^8.0",
-                "symfony/css-selector": "^6.4|^7.0|^8.0",
-                "symfony/dom-crawler": "^6.4|^7.0|^8.0",
-                "symfony/expression-language": "^6.4|^7.0|^8.0",
-                "symfony/form": "^6.4|^7.0|^8.0",
-                "symfony/framework-bundle": "^6.4.13|^7.1.6|^8.0",
-                "symfony/http-client": "^6.4|^7.0|^8.0",
-                "symfony/ldap": "^6.4|^7.0|^8.0",
-                "symfony/process": "^6.4|^7.0|^8.0",
-                "symfony/rate-limiter": "^6.4|^7.0|^8.0",
-                "symfony/runtime": "^6.4.13|^7.1.6|^8.0",
-                "symfony/serializer": "^6.4|^7.0|^8.0",
-                "symfony/translation": "^6.4|^7.0|^8.0",
-                "symfony/twig-bridge": "^6.4|^7.0|^8.0",
-                "symfony/twig-bundle": "^6.4|^7.0|^8.0",
-                "symfony/validator": "^6.4|^7.0|^8.0",
-                "symfony/yaml": "^6.4|^7.0|^8.0",
-                "twig/twig": "^3.15",
+                "symfony/asset": "^7.4|^8.0",
+                "symfony/browser-kit": "^7.4|^8.0",
+                "symfony/console": "^7.4|^8.0",
+                "symfony/css-selector": "^7.4|^8.0",
+                "symfony/dom-crawler": "^7.4|^8.0",
+                "symfony/expression-language": "^7.4|^8.0",
+                "symfony/form": "^7.4|^8.0",
+                "symfony/framework-bundle": "^7.4|^8.0",
+                "symfony/http-client": "^7.4|^8.0",
+                "symfony/ldap": "^7.4|^8.0",
+                "symfony/process": "^7.4|^8.0",
+                "symfony/rate-limiter": "^7.4|^8.0",
+                "symfony/runtime": "^7.4|^8.0",
+                "symfony/serializer": "^7.4|^8.0",
+                "symfony/translation": "^7.4|^8.0",
+                "symfony/twig-bridge": "^7.4|^8.0",
+                "symfony/twig-bundle": "^7.4|^8.0",
+                "symfony/validator": "^7.4|^8.0",
+                "symfony/yaml": "^7.4|^8.0",
                 "web-token/jwt-library": "^3.3.2|^4.0"
             },
             "type": "symfony-bundle",
@@ -6604,7 +6410,7 @@
             "description": "Provides a tight integration of the Security component into the Symfony full-stack framework",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/security-bundle/tree/v7.4.0"
+                "source": "https://github.com/symfony/security-bundle/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -6624,50 +6430,41 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-14T09:57:20+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/security-core",
-            "version": "v7.4.0",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security-core.git",
-                "reference": "fe4d25e5700a2f3b605bf23f520be57504ae5c51"
+                "reference": "8456ed58e22f59a4c50f50d7dd82b2f41d162c5f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-core/zipball/fe4d25e5700a2f3b605bf23f520be57504ae5c51",
-                "reference": "fe4d25e5700a2f3b605bf23f520be57504ae5c51",
+                "url": "https://api.github.com/repos/symfony/security-core/zipball/8456ed58e22f59a4c50f50d7dd82b2f41d162c5f",
+                "reference": "8456ed58e22f59a4c50f50d7dd82b2f41d162c5f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
+                "php": ">=8.4",
                 "symfony/event-dispatcher-contracts": "^2.5|^3",
-                "symfony/password-hasher": "^6.4|^7.0|^8.0",
+                "symfony/password-hasher": "^7.4|^8.0",
                 "symfony/service-contracts": "^2.5|^3"
-            },
-            "conflict": {
-                "symfony/dependency-injection": "<6.4",
-                "symfony/event-dispatcher": "<6.4",
-                "symfony/http-foundation": "<6.4",
-                "symfony/ldap": "<6.4",
-                "symfony/translation": "<6.4.3|>=7.0,<7.0.3",
-                "symfony/validator": "<6.4"
             },
             "require-dev": {
                 "psr/cache": "^1.0|^2.0|^3.0",
                 "psr/container": "^1.1|^2.0",
                 "psr/log": "^1|^2|^3",
-                "symfony/cache": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
-                "symfony/expression-language": "^6.4|^7.0|^8.0",
-                "symfony/http-foundation": "^6.4|^7.0|^8.0",
-                "symfony/ldap": "^6.4|^7.0|^8.0",
-                "symfony/string": "^6.4|^7.0|^8.0",
-                "symfony/translation": "^6.4.3|^7.0.3|^8.0",
-                "symfony/validator": "^6.4|^7.0|^8.0"
+                "symfony/cache": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/event-dispatcher": "^7.4|^8.0",
+                "symfony/expression-language": "^7.4|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/ldap": "^7.4|^8.0",
+                "symfony/string": "^7.4|^8.0",
+                "symfony/translation": "^7.4|^8.0",
+                "symfony/validator": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -6695,7 +6492,7 @@
             "description": "Symfony Security Component - Core Library",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/security-core/tree/v7.4.0"
+                "source": "https://github.com/symfony/security-core/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -6715,33 +6512,30 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-21T15:26:00+00:00"
+            "time": "2026-03-31T07:15:36+00:00"
         },
         {
             "name": "symfony/security-csrf",
-            "version": "v7.4.0",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security-csrf.git",
-                "reference": "ec41009e83589d0b3d86bd131d07e6fc8ecf35ab"
+                "reference": "83c8f60ef8d385c05ea863093c9efabe74800883"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-csrf/zipball/ec41009e83589d0b3d86bd131d07e6fc8ecf35ab",
-                "reference": "ec41009e83589d0b3d86bd131d07e6fc8ecf35ab",
+                "url": "https://api.github.com/repos/symfony/security-csrf/zipball/83c8f60ef8d385c05ea863093c9efabe74800883",
+                "reference": "83c8f60ef8d385c05ea863093c9efabe74800883",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/security-core": "^6.4|^7.0|^8.0"
-            },
-            "conflict": {
-                "symfony/http-foundation": "<6.4"
+                "php": ">=8.4",
+                "symfony/security-core": "^7.4|^8.0"
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/http-foundation": "^6.4|^7.0|^8.0",
-                "symfony/http-kernel": "^6.4|^7.0|^8.0"
+                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -6769,7 +6563,7 @@
             "description": "Symfony Security Component - CSRF Library",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/security-csrf/tree/v7.4.0"
+                "source": "https://github.com/symfony/security-csrf/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -6789,50 +6583,45 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-21T15:26:00+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/security-http",
-            "version": "v7.4.1",
+            "version": "v8.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security-http.git",
-                "reference": "46a4432ad2fab65735216d113e18f1f9eb6d28ea"
+                "reference": "51fff88fc8436e42b4d92cae005f86b9233e0f88"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-http/zipball/46a4432ad2fab65735216d113e18f1f9eb6d28ea",
-                "reference": "46a4432ad2fab65735216d113e18f1f9eb6d28ea",
+                "url": "https://api.github.com/repos/symfony/security-http/zipball/51fff88fc8436e42b4d92cae005f86b9233e0f88",
+                "reference": "51fff88fc8436e42b4d92cae005f86b9233e0f88",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/event-dispatcher": "^6.4|^7.0",
-                "symfony/http-foundation": "^6.4|^7.0|^8.0",
-                "symfony/http-kernel": "^6.4|^7.0|^8.0",
-                "symfony/polyfill-mbstring": "~1.0",
-                "symfony/property-access": "^6.4|^7.0|^8.0",
-                "symfony/security-core": "^7.3|^8.0",
+                "php": ">=8.4",
+                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/polyfill-mbstring": "^1.0",
+                "symfony/property-access": "^7.4|^8.0",
+                "symfony/security-core": "^7.4|^8.0",
                 "symfony/service-contracts": "^2.5|^3"
             },
             "conflict": {
-                "symfony/clock": "<6.4",
-                "symfony/http-client-contracts": "<3.0",
-                "symfony/security-bundle": "<6.4",
-                "symfony/security-csrf": "<6.4"
+                "symfony/http-client-contracts": "<3.0"
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/cache": "^6.4|^7.0|^8.0",
-                "symfony/clock": "^6.4|^7.0|^8.0",
-                "symfony/expression-language": "^6.4|^7.0|^8.0",
-                "symfony/http-client": "^6.4|^7.0|^8.0",
+                "symfony/cache": "^7.4|^8.0",
+                "symfony/clock": "^7.4|^8.0",
+                "symfony/expression-language": "^7.4|^8.0",
+                "symfony/http-client": "^7.4|^8.0",
                 "symfony/http-client-contracts": "^3.0",
-                "symfony/rate-limiter": "^6.4|^7.0|^8.0",
-                "symfony/routing": "^6.4|^7.0|^8.0",
-                "symfony/security-csrf": "^6.4|^7.0|^8.0",
-                "symfony/translation": "^6.4|^7.0|^8.0",
+                "symfony/rate-limiter": "^7.4|^8.0",
+                "symfony/routing": "^7.4|^8.0",
+                "symfony/security-csrf": "^7.4|^8.0",
+                "symfony/translation": "^7.4|^8.0",
                 "web-token/jwt-library": "^3.3.2|^4.0"
             },
             "type": "library",
@@ -6861,7 +6650,7 @@
             "description": "Symfony Security Component - HTTP Integration",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/security-http/tree/v7.4.1"
+                "source": "https://github.com/symfony/security-http/tree/v8.0.9"
             },
             "funding": [
                 {
@@ -6881,62 +6670,57 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-05T08:41:26+00:00"
+            "time": "2026-04-29T15:02:55+00:00"
         },
         {
             "name": "symfony/serializer",
-            "version": "v7.4.2",
+            "version": "v8.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/serializer.git",
-                "reference": "1a957acb613b520e443c2c659a67c782b67794bc"
+                "reference": "72ed7e1475790714f07c3a59bd01fd32cd022fdf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/serializer/zipball/1a957acb613b520e443c2c659a67c782b67794bc",
-                "reference": "1a957acb613b520e443c2c659a67c782b67794bc",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/72ed7e1475790714f07c3a59bd01fd32cd022fdf",
+                "reference": "72ed7e1475790714f07c3a59bd01fd32cd022fdf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-php84": "^1.30"
+                "php": ">=8.4",
+                "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
-                "phpdocumentor/reflection-docblock": "<3.2.2",
-                "phpdocumentor/type-resolver": "<1.4.0",
-                "symfony/dependency-injection": "<6.4",
-                "symfony/property-access": "<6.4",
-                "symfony/property-info": "<6.4",
-                "symfony/uid": "<6.4",
-                "symfony/validator": "<6.4",
-                "symfony/yaml": "<6.4"
+                "phpdocumentor/reflection-docblock": "<5.2|>=7",
+                "phpdocumentor/type-resolver": "<1.5.1",
+                "symfony/property-access": "<7.4.2|>=8.0,<8.0.2",
+                "symfony/property-info": "<7.4",
+                "symfony/type-info": "<7.4"
             },
             "require-dev": {
-                "phpdocumentor/reflection-docblock": "^3.2|^4.0|^5.0",
+                "phpdocumentor/reflection-docblock": "^5.2|^6.0",
                 "phpstan/phpdoc-parser": "^1.0|^2.0",
                 "seld/jsonlint": "^1.10",
-                "symfony/cache": "^6.4|^7.0|^8.0",
-                "symfony/config": "^6.4|^7.0|^8.0",
-                "symfony/console": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^7.2|^8.0",
-                "symfony/error-handler": "^6.4|^7.0|^8.0",
-                "symfony/filesystem": "^6.4|^7.0|^8.0",
-                "symfony/form": "^6.4|^7.0|^8.0",
-                "symfony/http-foundation": "^6.4|^7.0|^8.0",
-                "symfony/http-kernel": "^6.4|^7.0|^8.0",
-                "symfony/messenger": "^6.4|^7.0|^8.0",
-                "symfony/mime": "^6.4|^7.0|^8.0",
-                "symfony/property-access": "^6.4|^7.0|^8.0",
-                "symfony/property-info": "^6.4|^7.0|^8.0",
+                "symfony/cache": "^7.4|^8.0",
+                "symfony/config": "^7.4|^8.0",
+                "symfony/console": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/error-handler": "^7.4|^8.0",
+                "symfony/filesystem": "^7.4|^8.0",
+                "symfony/form": "^7.4|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/messenger": "^7.4|^8.0",
+                "symfony/mime": "^7.4|^8.0",
+                "symfony/property-access": "^7.4.2|^8.0.2",
+                "symfony/property-info": "^7.4|^8.0",
                 "symfony/translation-contracts": "^2.5|^3",
-                "symfony/type-info": "^7.1.8|^8.0",
-                "symfony/uid": "^6.4|^7.0|^8.0",
-                "symfony/validator": "^6.4|^7.0|^8.0",
-                "symfony/var-dumper": "^6.4|^7.0|^8.0",
-                "symfony/var-exporter": "^6.4|^7.0|^8.0",
-                "symfony/yaml": "^6.4|^7.0|^8.0"
+                "symfony/type-info": "^7.4|^8.0",
+                "symfony/uid": "^7.4|^8.0",
+                "symfony/validator": "^7.4|^8.0",
+                "symfony/var-dumper": "^7.4|^8.0",
+                "symfony/var-exporter": "^7.4|^8.0",
+                "symfony/yaml": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -6964,7 +6748,7 @@
             "description": "Handles serializing and deserializing data structures, including object graphs, into array structures or other formats like XML and JSON.",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/serializer/tree/v7.4.2"
+                "source": "https://github.com/symfony/serializer/tree/v8.0.10"
             },
             "funding": [
                 {
@@ -6984,20 +6768,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-07T17:35:40+00:00"
+            "time": "2026-05-04T13:41:39+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.6.1",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43"
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/45112560a3ba2d715666a509a0bc9521d10b6c43",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d25d82433a80eba6aa0e6c24b61d7370d99e444a",
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a",
                 "shasum": ""
             },
             "require": {
@@ -7015,7 +6799,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -7051,7 +6835,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.6.1"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -7071,24 +6855,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-15T11:30:57+00:00"
+            "time": "2026-03-28T09:44:51+00:00"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v7.4.0",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "8a24af0a2e8a872fb745047180649b8418303084"
+                "reference": "85954ed72d5440ea4dc9a10b7e49e01df766ffa3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/8a24af0a2e8a872fb745047180649b8418303084",
-                "reference": "8a24af0a2e8a872fb745047180649b8418303084",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/85954ed72d5440ea4dc9a10b7e49e01df766ffa3",
+                "reference": "85954ed72d5440ea4dc9a10b7e49e01df766ffa3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4",
                 "symfony/service-contracts": "^2.5|^3"
             },
             "type": "library",
@@ -7117,7 +6901,7 @@
             "description": "Provides a way to profile code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/stopwatch/tree/v7.4.0"
+                "source": "https://github.com/symfony/stopwatch/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -7137,39 +6921,38 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-04T07:05:15+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v7.4.0",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "d50e862cb0a0e0886f73ca1f31b865efbb795003"
+                "reference": "ae9488f874d7603f9d2dfbf120203882b645d963"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/d50e862cb0a0e0886f73ca1f31b865efbb795003",
-                "reference": "d50e862cb0a0e0886f73ca1f31b865efbb795003",
+                "url": "https://api.github.com/repos/symfony/string/zipball/ae9488f874d7603f9d2dfbf120203882b645d963",
+                "reference": "ae9488f874d7603f9d2dfbf120203882b645d963",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3.0",
-                "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-intl-grapheme": "~1.33",
-                "symfony/polyfill-intl-normalizer": "~1.0",
-                "symfony/polyfill-mbstring": "~1.0"
+                "php": ">=8.4",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-intl-grapheme": "^1.33",
+                "symfony/polyfill-intl-normalizer": "^1.0",
+                "symfony/polyfill-mbstring": "^1.0"
             },
             "conflict": {
                 "symfony/translation-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/emoji": "^7.1|^8.0",
-                "symfony/http-client": "^6.4|^7.0|^8.0",
-                "symfony/intl": "^6.4|^7.0|^8.0",
+                "symfony/emoji": "^7.4|^8.0",
+                "symfony/http-client": "^7.4|^8.0",
+                "symfony/intl": "^7.4|^8.0",
                 "symfony/translation-contracts": "^2.5|^3.0",
-                "symfony/var-exporter": "^6.4|^7.0|^8.0"
+                "symfony/var-exporter": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -7208,7 +6991,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.4.0"
+                "source": "https://github.com/symfony/string/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -7228,20 +7011,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-27T13:27:24+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "v3.6.1",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "65a8bc82080447fae78373aa10f8d13b38338977"
+                "reference": "0ab302977a952b42fd51475c4ebac81f8da0a95d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/65a8bc82080447fae78373aa10f8d13b38338977",
-                "reference": "65a8bc82080447fae78373aa10f8d13b38338977",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/0ab302977a952b42fd51475c4ebac81f8da0a95d",
+                "reference": "0ab302977a952b42fd51475c4ebac81f8da0a95d",
                 "shasum": ""
             },
             "require": {
@@ -7254,7 +7037,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -7290,7 +7073,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/translation-contracts/tree/v3.6.1"
+                "source": "https://github.com/symfony/translation-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -7310,71 +7093,64 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-15T13:41:35+00:00"
+            "time": "2026-01-05T13:30:16+00:00"
         },
         {
             "name": "symfony/twig-bridge",
-            "version": "v7.4.1",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/twig-bridge.git",
-                "reference": "9103559ef3e9f06708d8bff6810f6335b8f1eee8"
+                "reference": "a892d0b7f3d5d51b35895467e48aafbd1f2612a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/twig-bridge/zipball/9103559ef3e9f06708d8bff6810f6335b8f1eee8",
-                "reference": "9103559ef3e9f06708d8bff6810f6335b8f1eee8",
+                "url": "https://api.github.com/repos/symfony/twig-bridge/zipball/a892d0b7f3d5d51b35895467e48aafbd1f2612a0",
+                "reference": "a892d0b7f3d5d51b35895467e48aafbd1f2612a0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
+                "php": ">=8.4",
                 "symfony/translation-contracts": "^2.5|^3",
                 "twig/twig": "^3.21"
             },
             "conflict": {
-                "phpdocumentor/reflection-docblock": "<3.2.2",
-                "phpdocumentor/type-resolver": "<1.4.0",
-                "symfony/console": "<6.4",
-                "symfony/form": "<6.4",
-                "symfony/http-foundation": "<6.4",
-                "symfony/http-kernel": "<6.4",
-                "symfony/mime": "<6.4",
-                "symfony/serializer": "<6.4",
-                "symfony/translation": "<6.4",
-                "symfony/workflow": "<6.4"
+                "phpdocumentor/reflection-docblock": "<5.2|>=7",
+                "phpdocumentor/type-resolver": "<1.5.1",
+                "symfony/form": "<7.4.4|>8.0,<8.0.4",
+                "symfony/mime": "<7.4.8|>8.0,<8.0.8"
             },
             "require-dev": {
                 "egulias/email-validator": "^2.1.10|^3|^4",
                 "league/html-to-markdown": "^5.0",
-                "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
-                "symfony/asset": "^6.4|^7.0|^8.0",
-                "symfony/asset-mapper": "^6.4|^7.0|^8.0",
-                "symfony/console": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/emoji": "^7.1|^8.0",
-                "symfony/expression-language": "^6.4|^7.0|^8.0",
-                "symfony/finder": "^6.4|^7.0|^8.0",
-                "symfony/form": "^6.4.30|~7.3.8|^7.4.1|^8.0.1",
-                "symfony/html-sanitizer": "^6.4|^7.0|^8.0",
-                "symfony/http-foundation": "^7.3|^8.0",
-                "symfony/http-kernel": "^6.4|^7.0|^8.0",
-                "symfony/intl": "^6.4|^7.0|^8.0",
-                "symfony/mime": "^6.4|^7.0|^8.0",
-                "symfony/polyfill-intl-icu": "~1.0",
-                "symfony/property-info": "^6.4|^7.0|^8.0",
-                "symfony/routing": "^6.4|^7.0|^8.0",
+                "phpdocumentor/reflection-docblock": "^5.2|^6.0",
+                "symfony/asset": "^7.4|^8.0",
+                "symfony/asset-mapper": "^7.4|^8.0",
+                "symfony/console": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/emoji": "^7.4|^8.0",
+                "symfony/expression-language": "^7.4|^8.0",
+                "symfony/finder": "^7.4|^8.0",
+                "symfony/form": "^7.4.4|^8.0.4",
+                "symfony/html-sanitizer": "^7.4|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/intl": "^7.4|^8.0",
+                "symfony/mime": "^7.4.8|^8.0.8",
+                "symfony/polyfill-intl-icu": "^1.0",
+                "symfony/property-info": "^7.4|^8.0",
+                "symfony/routing": "^7.4|^8.0",
                 "symfony/security-acl": "^2.8|^3.0",
-                "symfony/security-core": "^6.4|^7.0|^8.0",
-                "symfony/security-csrf": "^6.4|^7.0|^8.0",
-                "symfony/security-http": "^6.4|^7.0|^8.0",
-                "symfony/serializer": "^6.4.3|^7.0.3|^8.0",
-                "symfony/stopwatch": "^6.4|^7.0|^8.0",
-                "symfony/translation": "^6.4|^7.0|^8.0",
-                "symfony/validator": "^6.4|^7.0|^8.0",
-                "symfony/web-link": "^6.4|^7.0|^8.0",
-                "symfony/workflow": "^6.4|^7.0|^8.0",
-                "symfony/yaml": "^6.4|^7.0|^8.0",
+                "symfony/security-core": "^7.4|^8.0",
+                "symfony/security-csrf": "^7.4|^8.0",
+                "symfony/security-http": "^7.4|^8.0",
+                "symfony/serializer": "^7.4|^8.0",
+                "symfony/stopwatch": "^7.4|^8.0",
+                "symfony/translation": "^7.4|^8.0",
+                "symfony/validator": "^7.4|^8.0",
+                "symfony/web-link": "^7.4|^8.0",
+                "symfony/workflow": "^7.4|^8.0",
+                "symfony/yaml": "^7.4|^8.0",
                 "twig/cssinliner-extra": "^3",
                 "twig/inky-extra": "^3",
                 "twig/markdown-extra": "^3"
@@ -7405,7 +7181,7 @@
             "description": "Provides integration for Twig with various Symfony components",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/twig-bridge/tree/v7.4.1"
+                "source": "https://github.com/symfony/twig-bridge/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -7425,48 +7201,43 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-05T14:04:53+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/twig-bundle",
-            "version": "v7.4.0",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/twig-bundle.git",
-                "reference": "f83f530d00d1bbc6f7fafeb433077887c83326ef"
+                "reference": "f83767b78e2580ca9fe9a2cf6fcff19cd5389bc1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/twig-bundle/zipball/f83f530d00d1bbc6f7fafeb433077887c83326ef",
-                "reference": "f83f530d00d1bbc6f7fafeb433077887c83326ef",
+                "url": "https://api.github.com/repos/symfony/twig-bundle/zipball/f83767b78e2580ca9fe9a2cf6fcff19cd5389bc1",
+                "reference": "f83767b78e2580ca9fe9a2cf6fcff19cd5389bc1",
                 "shasum": ""
             },
             "require": {
                 "composer-runtime-api": ">=2.1",
-                "php": ">=8.2",
+                "php": ">=8.4",
                 "symfony/config": "^7.4|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/http-foundation": "^6.4|^7.0|^8.0",
-                "symfony/http-kernel": "^6.4.13|^7.1.6|^8.0",
-                "symfony/twig-bridge": "^7.3|^8.0",
-                "twig/twig": "^3.12"
-            },
-            "conflict": {
-                "symfony/framework-bundle": "<6.4",
-                "symfony/translation": "<6.4"
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/twig-bridge": "^7.4|^8.0"
             },
             "require-dev": {
-                "symfony/asset": "^6.4|^7.0|^8.0",
-                "symfony/expression-language": "^6.4|^7.0|^8.0",
-                "symfony/finder": "^6.4|^7.0|^8.0",
-                "symfony/form": "^6.4|^7.0|^8.0",
-                "symfony/framework-bundle": "^6.4.13|^7.1.6|^8.0",
-                "symfony/routing": "^6.4|^7.0|^8.0",
-                "symfony/runtime": "^6.4.13|^7.1.6",
-                "symfony/stopwatch": "^6.4|^7.0|^8.0",
-                "symfony/translation": "^6.4|^7.0|^8.0",
-                "symfony/web-link": "^6.4|^7.0|^8.0",
-                "symfony/yaml": "^6.4|^7.0|^8.0"
+                "symfony/asset": "^7.4|^8.0",
+                "symfony/expression-language": "^7.4|^8.0",
+                "symfony/finder": "^7.4|^8.0",
+                "symfony/form": "^7.4|^8.0",
+                "symfony/framework-bundle": "^7.4|^8.0",
+                "symfony/routing": "^7.4|^8.0",
+                "symfony/runtime": "^7.4|^8.0",
+                "symfony/stopwatch": "^7.4|^8.0",
+                "symfony/translation": "^7.4|^8.0",
+                "symfony/web-link": "^7.4|^8.0",
+                "symfony/yaml": "^7.4|^8.0"
             },
             "type": "symfony-bundle",
             "autoload": {
@@ -7494,7 +7265,7 @@
             "description": "Provides a tight integration of Twig into the Symfony full-stack framework",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/twig-bundle/tree/v7.4.0"
+                "source": "https://github.com/symfony/twig-bundle/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -7514,26 +7285,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-10-02T07:41:02+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/type-info",
-            "version": "v7.4.1",
+            "version": "v8.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/type-info.git",
-                "reference": "ac5ab66b21c758df71b7210cf1033d1ac807f202"
+                "reference": "08723aceb8c3271e8cb3db8b2565728b0c88e866"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/type-info/zipball/ac5ab66b21c758df71b7210cf1033d1ac807f202",
-                "reference": "ac5ab66b21c758df71b7210cf1033d1ac807f202",
+                "url": "https://api.github.com/repos/symfony/type-info/zipball/08723aceb8c3271e8cb3db8b2565728b0c88e866",
+                "reference": "08723aceb8c3271e8cb3db8b2565728b0c88e866",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "psr/container": "^1.1|^2.0",
-                "symfony/deprecation-contracts": "^2.5|^3"
+                "php": ">=8.4",
+                "psr/container": "^1.1|^2.0"
             },
             "conflict": {
                 "phpstan/phpdoc-parser": "<1.30"
@@ -7577,7 +7347,7 @@
                 "type"
             ],
             "support": {
-                "source": "https://github.com/symfony/type-info/tree/v7.4.1"
+                "source": "https://github.com/symfony/type-info/tree/v8.0.9"
             },
             "funding": [
                 {
@@ -7597,28 +7367,28 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-05T14:04:53+00:00"
+            "time": "2026-04-29T15:02:55+00:00"
         },
         {
             "name": "symfony/uid",
-            "version": "v7.4.0",
+            "version": "v8.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/uid.git",
-                "reference": "2498e9f81b7baa206f44de583f2f48350b90142c"
+                "reference": "4d9d6510bbe88ebb4608b7200d18606cdf80825c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/uid/zipball/2498e9f81b7baa206f44de583f2f48350b90142c",
-                "reference": "2498e9f81b7baa206f44de583f2f48350b90142c",
+                "url": "https://api.github.com/repos/symfony/uid/zipball/4d9d6510bbe88ebb4608b7200d18606cdf80825c",
+                "reference": "4d9d6510bbe88ebb4608b7200d18606cdf80825c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4",
                 "symfony/polyfill-uuid": "^1.15"
             },
             "require-dev": {
-                "symfony/console": "^6.4|^7.0|^8.0"
+                "symfony/console": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -7655,7 +7425,7 @@
                 "uuid"
             ],
             "support": {
-                "source": "https://github.com/symfony/uid/tree/v7.4.0"
+                "source": "https://github.com/symfony/uid/tree/v8.0.9"
             },
             "funding": [
                 {
@@ -7675,62 +7445,53 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-25T11:02:55+00:00"
+            "time": "2026-04-30T16:10:06+00:00"
         },
         {
             "name": "symfony/validator",
-            "version": "v7.4.2",
+            "version": "v8.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/validator.git",
-                "reference": "569b71d1243ccc58e8f1d21e279669239e78f60d"
+                "reference": "12bb4be483a8626bd1b2f46f5d44c9449cf4361f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/validator/zipball/569b71d1243ccc58e8f1d21e279669239e78f60d",
-                "reference": "569b71d1243ccc58e8f1d21e279669239e78f60d",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/12bb4be483a8626bd1b2f46f5d44c9449cf4361f",
+                "reference": "12bb4be483a8626bd1b2f46f5d44c9449cf4361f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-mbstring": "~1.0",
-                "symfony/polyfill-php83": "^1.27",
+                "php": ">=8.4",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-mbstring": "^1.0",
                 "symfony/translation-contracts": "^2.5|^3"
             },
             "conflict": {
                 "doctrine/lexer": "<1.1",
-                "symfony/dependency-injection": "<6.4",
-                "symfony/doctrine-bridge": "<7.0",
-                "symfony/expression-language": "<6.4",
-                "symfony/http-kernel": "<6.4",
-                "symfony/intl": "<6.4",
-                "symfony/property-info": "<6.4",
-                "symfony/translation": "<6.4.3|>=7.0,<7.0.3",
-                "symfony/var-exporter": "<6.4.25|>=7.0,<7.3.3",
-                "symfony/yaml": "<6.4"
+                "symfony/doctrine-bridge": "<7.4",
+                "symfony/expression-language": "<7.4"
             },
             "require-dev": {
                 "egulias/email-validator": "^2.1.10|^3|^4",
-                "symfony/cache": "^6.4|^7.0|^8.0",
-                "symfony/config": "^6.4|^7.0|^8.0",
-                "symfony/console": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/expression-language": "^6.4|^7.0|^8.0",
-                "symfony/finder": "^6.4|^7.0|^8.0",
-                "symfony/http-client": "^6.4|^7.0|^8.0",
-                "symfony/http-foundation": "^6.4|^7.0|^8.0",
-                "symfony/http-kernel": "^6.4|^7.0|^8.0",
-                "symfony/intl": "^6.4|^7.0|^8.0",
-                "symfony/mime": "^6.4|^7.0|^8.0",
-                "symfony/process": "^6.4|^7.0|^8.0",
-                "symfony/property-access": "^6.4|^7.0|^8.0",
-                "symfony/property-info": "^6.4|^7.0|^8.0",
-                "symfony/string": "^6.4|^7.0|^8.0",
-                "symfony/translation": "^6.4.3|^7.0.3|^8.0",
-                "symfony/type-info": "^7.1.8",
-                "symfony/yaml": "^6.4|^7.0|^8.0"
+                "symfony/cache": "^7.4|^8.0",
+                "symfony/config": "^7.4|^8.0",
+                "symfony/console": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/expression-language": "^7.4|^8.0",
+                "symfony/finder": "^7.4|^8.0",
+                "symfony/http-client": "^7.4|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/intl": "^7.4|^8.0",
+                "symfony/mime": "^7.4|^8.0",
+                "symfony/process": "^7.4|^8.0",
+                "symfony/property-access": "^7.4|^8.0",
+                "symfony/property-info": "^7.4|^8.0",
+                "symfony/string": "^7.4|^8.0",
+                "symfony/translation": "^7.4|^8.0",
+                "symfony/type-info": "^7.4|^8.0",
+                "symfony/yaml": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -7759,7 +7520,7 @@
             "description": "Provides tools to validate values",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/validator/tree/v7.4.2"
+                "source": "https://github.com/symfony/validator/tree/v8.0.10"
             },
             "funding": [
                 {
@@ -7779,35 +7540,35 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-07T17:35:40+00:00"
+            "time": "2026-05-05T16:03:11+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v7.4.0",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "41fd6c4ae28c38b294b42af6db61446594a0dece"
+                "reference": "cfb7badd53bf4177f6e9416cfbbccc13c0e773a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/41fd6c4ae28c38b294b42af6db61446594a0dece",
-                "reference": "41fd6c4ae28c38b294b42af6db61446594a0dece",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/cfb7badd53bf4177f6e9416cfbbccc13c0e773a1",
+                "reference": "cfb7badd53bf4177f6e9416cfbbccc13c0e773a1",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-mbstring": "~1.0"
+                "php": ">=8.4",
+                "symfony/polyfill-mbstring": "^1.0"
             },
             "conflict": {
-                "symfony/console": "<6.4"
+                "symfony/console": "<7.4",
+                "symfony/error-handler": "<7.4"
             },
             "require-dev": {
-                "symfony/console": "^6.4|^7.0|^8.0",
-                "symfony/http-kernel": "^6.4|^7.0|^8.0",
-                "symfony/process": "^6.4|^7.0|^8.0",
-                "symfony/uid": "^6.4|^7.0|^8.0",
+                "symfony/console": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/process": "^7.4|^8.0",
+                "symfony/uid": "^7.4|^8.0",
                 "twig/twig": "^3.12"
             },
             "bin": [
@@ -7846,7 +7607,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v7.4.0"
+                "source": "https://github.com/symfony/var-dumper/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -7866,30 +7627,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-10-27T20:36:44+00:00"
+            "time": "2026-03-31T07:15:36+00:00"
         },
         {
             "name": "symfony/var-exporter",
-            "version": "v7.4.0",
+            "version": "v8.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-exporter.git",
-                "reference": "03a60f169c79a28513a78c967316fbc8bf17816f"
+                "reference": "24cf67be4dd0926e4413635418682f4fff831412"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/03a60f169c79a28513a78c967316fbc8bf17816f",
-                "reference": "03a60f169c79a28513a78c967316fbc8bf17816f",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/24cf67be4dd0926e4413635418682f4fff831412",
+                "reference": "24cf67be4dd0926e4413635418682f4fff831412",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "symfony/property-access": "^6.4|^7.0|^8.0",
-                "symfony/serializer": "^6.4|^7.0|^8.0",
-                "symfony/var-dumper": "^6.4|^7.0|^8.0"
+                "symfony/property-access": "^7.4|^8.0",
+                "symfony/serializer": "^7.4|^8.0",
+                "symfony/var-dumper": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -7927,7 +7687,7 @@
                 "serialize"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-exporter/tree/v7.4.0"
+                "source": "https://github.com/symfony/var-exporter/tree/v8.0.9"
             },
             "funding": [
                 {
@@ -7947,34 +7707,31 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-11T10:15:23+00:00"
+            "time": "2026-04-18T13:51:42+00:00"
         },
         {
             "name": "symfony/web-link",
-            "version": "v7.4.0",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/web-link.git",
-                "reference": "c62edd6b52e31cf2f6f38fd3386725f364f19942"
+                "reference": "f76065fd8d59284332c8beaf2d7e1449f8c532c3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/web-link/zipball/c62edd6b52e31cf2f6f38fd3386725f364f19942",
-                "reference": "c62edd6b52e31cf2f6f38fd3386725f364f19942",
+                "url": "https://api.github.com/repos/symfony/web-link/zipball/f76065fd8d59284332c8beaf2d7e1449f8c532c3",
+                "reference": "f76065fd8d59284332c8beaf2d7e1449f8c532c3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4",
                 "psr/link": "^1.1|^2.0"
-            },
-            "conflict": {
-                "symfony/http-kernel": "<6.4"
             },
             "provide": {
                 "psr/link-implementation": "1.0|2.0"
             },
             "require-dev": {
-                "symfony/http-kernel": "^6.4|^7.0|^8.0"
+                "symfony/http-kernel": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -8014,7 +7771,7 @@
                 "push"
             ],
             "support": {
-                "source": "https://github.com/symfony/web-link/tree/v7.4.0"
+                "source": "https://github.com/symfony/web-link/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -8034,32 +7791,31 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-04T07:05:15+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v7.4.1",
+            "version": "v8.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "24dd4de28d2e3988b311751ac49e684d783e2345"
+                "reference": "aa9ee60c41d9b20a2468c41ff0a32e2a7405ac05"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/24dd4de28d2e3988b311751ac49e684d783e2345",
-                "reference": "24dd4de28d2e3988b311751ac49e684d783e2345",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/aa9ee60c41d9b20a2468c41ff0a32e2a7405ac05",
+                "reference": "aa9ee60c41d9b20a2468c41ff0a32e2a7405ac05",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
+                "php": ">=8.4",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
-                "symfony/console": "<6.4"
+                "symfony/console": "<7.4"
             },
             "require-dev": {
-                "symfony/console": "^6.4|^7.0|^8.0"
+                "symfony/console": "^7.4|^8.0"
             },
             "bin": [
                 "Resources/bin/yaml-lint"
@@ -8090,7 +7846,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v7.4.1"
+                "source": "https://github.com/symfony/yaml/tree/v8.0.10"
             },
             "funding": [
                 {
@@ -8110,20 +7866,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-04T18:11:45+00:00"
+            "time": "2026-05-05T08:10:04+00:00"
         },
         {
             "name": "twig/twig",
-            "version": "v3.22.2",
+            "version": "v3.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "946ddeafa3c9f4ce279d1f34051af041db0e16f2"
+                "reference": "a6769aefb305efef849dc25c9fd1653358c148f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/946ddeafa3c9f4ce279d1f34051af041db0e16f2",
-                "reference": "946ddeafa3c9f4ce279d1f34051af041db0e16f2",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/a6769aefb305efef849dc25c9fd1653358c148f0",
+                "reference": "a6769aefb305efef849dc25c9fd1653358c148f0",
                 "shasum": ""
             },
             "require": {
@@ -8133,7 +7889,8 @@
                 "symfony/polyfill-mbstring": "^1.3"
             },
             "require-dev": {
-                "phpstan/phpstan": "^2.0",
+                "php-cs-fixer/shim": "^3.0@stable",
+                "phpstan/phpstan": "^2.0@stable",
                 "psr/container": "^1.0|^2.0",
                 "symfony/phpunit-bridge": "^5.4.9|^6.4|^7.0"
             },
@@ -8177,7 +7934,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.22.2"
+                "source": "https://github.com/twigphp/Twig/tree/v3.24.0"
             },
             "funding": [
                 {
@@ -8189,7 +7946,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-14T11:28:47+00:00"
+            "time": "2026-03-17T21:31:11+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -9499,19 +9256,20 @@
         },
         {
             "name": "symfony/maker-bundle",
-            "version": "v1.65.1",
+            "version": "v1.67.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/maker-bundle.git",
-                "reference": "eba30452d212769c9a5bcf0716959fd8ba1e54e3"
+                "reference": "6ce8b313845f16bcf385ee3cb31d8b24e30d5516"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/maker-bundle/zipball/eba30452d212769c9a5bcf0716959fd8ba1e54e3",
-                "reference": "eba30452d212769c9a5bcf0716959fd8ba1e54e3",
+                "url": "https://api.github.com/repos/symfony/maker-bundle/zipball/6ce8b313845f16bcf385ee3cb31d8b24e30d5516",
+                "reference": "6ce8b313845f16bcf385ee3cb31d8b24e30d5516",
                 "shasum": ""
             },
             "require": {
+                "composer-runtime-api": "^2.1",
                 "doctrine/inflector": "^2.0",
                 "nikic/php-parser": "^5.0",
                 "php": ">=8.1",
@@ -9531,7 +9289,7 @@
             },
             "require-dev": {
                 "composer/semver": "^3.0",
-                "doctrine/doctrine-bundle": "^2.5.0|^3.0.0",
+                "doctrine/doctrine-bundle": "^2.10|^3.0",
                 "doctrine/orm": "^2.15|^3",
                 "doctrine/persistence": "^3.1|^4.0",
                 "symfony/http-client": "^6.4|^7.0|^8.0",
@@ -9573,7 +9331,7 @@
             ],
             "support": {
                 "issues": "https://github.com/symfony/maker-bundle/issues",
-                "source": "https://github.com/symfony/maker-bundle/tree/v1.65.1"
+                "source": "https://github.com/symfony/maker-bundle/tree/v1.67.0"
             },
             "funding": [
                 {
@@ -9593,20 +9351,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-02T07:14:37+00:00"
+            "time": "2026-03-18T13:39:06+00:00"
         },
         {
             "name": "symfony/phpunit-bridge",
-            "version": "v7.4.0",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/phpunit-bridge.git",
-                "reference": "059b051b38f2138ef104dd848fa48f0cbbb7d78b"
+                "reference": "723ea96810135e776110bddb25aeb32b462134c8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/059b051b38f2138ef104dd848fa48f0cbbb7d78b",
-                "reference": "059b051b38f2138ef104dd848fa48f0cbbb7d78b",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/723ea96810135e776110bddb25aeb32b462134c8",
+                "reference": "723ea96810135e776110bddb25aeb32b462134c8",
                 "shasum": ""
             },
             "require": {
@@ -9658,7 +9416,7 @@
                 "testing"
             ],
             "support": {
-                "source": "https://github.com/symfony/phpunit-bridge/tree/v7.4.0"
+                "source": "https://github.com/symfony/phpunit-bridge/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -9678,24 +9436,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-10-28T22:44:23+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v7.4.0",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "7ca8dc2d0dcf4882658313aba8be5d9fd01026c8"
+                "reference": "cb8939aff03470d1a9d1d1b66d08c6fa71b3bbdc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/7ca8dc2d0dcf4882658313aba8be5d9fd01026c8",
-                "reference": "7ca8dc2d0dcf4882658313aba8be5d9fd01026c8",
+                "url": "https://api.github.com/repos/symfony/process/zipball/cb8939aff03470d1a9d1d1b66d08c6fa71b3bbdc",
+                "reference": "cb8939aff03470d1a9d1d1b66d08c6fa71b3bbdc",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.4"
             },
             "type": "library",
             "autoload": {
@@ -9723,7 +9481,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.4.0"
+                "source": "https://github.com/symfony/process/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -9743,7 +9501,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-10-16T11:21:06+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         }
     ],
     "aliases": [],
@@ -9754,11 +9512,11 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.2",
+        "php": ">=8.4",
         "ext-amqp": "*",
         "ext-ctype": "*",
         "ext-iconv": "*"
     },
-    "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "platform-dev": [],
+    "plugin-api-version": "2.6.0"
 }

--- a/config/packages/api_platform.yaml
+++ b/config/packages/api_platform.yaml
@@ -37,12 +37,9 @@ api_platform:
             pagination:
                 items_per_page_parameter_name: itemsPerPage
         stateless: false
-        servers: 'https://api-tx.sendmundo.com'
         cache_headers:
             vary: ['Content-Type', 'Authorization', 'Origin', 'X-AUTH-TOKEN']
         extra_properties:
             standard_put: true
             rfc_7807_compliant_errors: false
-    event_listeners_backward_compatibility_layer: false
-    keep_legacy_inflector: false
 #    enable_entrypoint: https://api-tx.sendmundo.com

--- a/config/packages/cache.yaml
+++ b/config/packages/cache.yaml
@@ -14,6 +14,8 @@ framework:
         # APCu (not recommended with heavy random-write workloads as memory fragmentation can cause perf issues)
         #app: cache.adapter.apcu
 
-        # Namespaced pools use the above "app" backend by default
-        #pools:
-            #my.dedicated.cache: null
+        pools:
+            cache.sys_config:
+                adapter: cache.app
+                default_lifetime: 3600
+                tags: true

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -8,9 +8,6 @@ doctrine:
 
         profiling_collect_backtrace: '%kernel.debug%'
     orm:
-        auto_generate_proxy_classes: true
-        enable_lazy_ghost_objects: true
-        report_fields_where_declared: true
         validate_xml_mapping: true
         naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware
         auto_mapping: true
@@ -31,8 +28,6 @@ when@test:
 when@prod:
     doctrine:
         orm:
-            auto_generate_proxy_classes: false
-            proxy_dir: '%kernel.build_dir%/doctrine/orm/Proxies'
             query_cache_driver:
                 type: pool
                 pool: doctrine.system_cache_pool

--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -97,6 +97,7 @@ framework:
              'App\Message\PromotionCreatedMessage': async_notifications_high
              'App\Message\Etecsa\SyncCatalogsMessage': async_clients_high
              'App\Message\Etecsa\SyncProductsMessage': async_clients_high
+             'App\Message\DispatchPendingEmailMessage': async_notifications_high
 
 # when@test:
 #    framework:

--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -95,6 +95,8 @@ framework:
              'App\Message\ForgotPasswordMessage': async_notifications_high
              'App\Message\AccountActivationMessage': async_notifications_high
              'App\Message\PromotionCreatedMessage': async_notifications_high
+             'App\Message\Etecsa\SyncCatalogsMessage': async_clients_high
+             'App\Message\Etecsa\SyncProductsMessage': async_clients_high
 
 # when@test:
 #    framework:

--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -1,6 +1,7 @@
 monolog:
     channels:
         - deprecation # Deprecations are logged in the dedicated "deprecation" channel when it exists
+        - etecsa
 
 when@dev:
     monolog:
@@ -27,6 +28,11 @@ when@dev:
                 path: '%kernel.logs_dir%/debug.%kernel.environment%.log'
                 level: debug
                 max_files: 10
+            etecsa_log:
+                type: stream
+                path: '%kernel.logs_dir%/etecsa.log'
+                level: debug
+                channels: [ etecsa ]
 
 
 when@test:
@@ -62,6 +68,11 @@ when@prod:
                 path: "%kernel.logs_dir%/info.%kernel.environment%.log"
                 max_files: 10
                 level: info
+            etecsa_log:
+                type: stream
+                path: '%kernel.logs_dir%/etecsa.log'
+                level: info
+                channels: [ etecsa ]
             nested:
                 type: stream
                 path: php://stderr

--- a/config/reference.php
+++ b/config/reference.php
@@ -4,6 +4,8 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Symfony\Component\Config\Loader\ParamConfigurator as Param;
+
 /**
  * This class provides array-shapes for configuring the services and bundles of an application.
  *
@@ -31,7 +33,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
  *     type?: string|null,
  *     ignore_errors?: bool,
  * }>
- * @psalm-type ParametersConfig = array<string, scalar|\UnitEnum|array<scalar|\UnitEnum|array<mixed>|null>|null>
+ * @psalm-type ParametersConfig = array<string, scalar|\UnitEnum|array<scalar|\UnitEnum|array<mixed>|Param|null>|Param|null>
  * @psalm-type ArgumentsType = list<mixed>|array<string, mixed>
  * @psalm-type CallType = array<string, ArgumentsType>|array{0:string, 1?:ArgumentsType, 2?:bool}|array{method:string, arguments?:ArgumentsType, returns_clone?:bool}
  * @psalm-type TagsType = list<string|array<string, array<string, mixed>>> // arrays inside the list must have only one element, with the tag name as the key
@@ -124,1355 +126,1320 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
  * }
  * @psalm-type ExtensionType = array<string, mixed>
  * @psalm-type FrameworkConfig = array{
- *     secret?: scalar|null,
- *     http_method_override?: bool, // Set true to enable support for the '_method' request parameter to determine the intended HTTP method on POST requests. // Default: false
- *     allowed_http_method_override?: list<string>|null,
- *     trust_x_sendfile_type_header?: scalar|null, // Set true to enable support for xsendfile in binary file responses. // Default: "%env(bool:default::SYMFONY_TRUST_X_SENDFILE_TYPE_HEADER)%"
- *     ide?: scalar|null, // Default: "%env(default::SYMFONY_IDE)%"
- *     test?: bool,
- *     default_locale?: scalar|null, // Default: "en"
- *     set_locale_from_accept_language?: bool, // Whether to use the Accept-Language HTTP header to set the Request locale (only when the "_locale" request attribute is not passed). // Default: false
- *     set_content_language_from_locale?: bool, // Whether to set the Content-Language HTTP header on the Response using the Request locale. // Default: false
- *     enabled_locales?: list<scalar|null>,
- *     trusted_hosts?: list<scalar|null>,
+ *     secret?: scalar|Param|null,
+ *     http_method_override?: bool|Param, // Set true to enable support for the '_method' request parameter to determine the intended HTTP method on POST requests. // Default: false
+ *     allowed_http_method_override?: null|list<string|Param>,
+ *     trust_x_sendfile_type_header?: scalar|Param|null, // Set true to enable support for xsendfile in binary file responses. // Default: "%env(bool:default::SYMFONY_TRUST_X_SENDFILE_TYPE_HEADER)%"
+ *     ide?: scalar|Param|null, // Default: "%env(default::SYMFONY_IDE)%"
+ *     test?: bool|Param,
+ *     default_locale?: scalar|Param|null, // Default: "en"
+ *     set_locale_from_accept_language?: bool|Param, // Whether to use the Accept-Language HTTP header to set the Request locale (only when the "_locale" request attribute is not passed). // Default: false
+ *     set_content_language_from_locale?: bool|Param, // Whether to set the Content-Language HTTP header on the Response using the Request locale. // Default: false
+ *     enabled_locales?: list<scalar|Param|null>,
+ *     trusted_hosts?: string|list<scalar|Param|null>,
  *     trusted_proxies?: mixed, // Default: ["%env(default::SYMFONY_TRUSTED_PROXIES)%"]
- *     trusted_headers?: list<scalar|null>,
- *     error_controller?: scalar|null, // Default: "error_controller"
- *     handle_all_throwables?: bool, // HttpKernel will handle all kinds of \Throwable. // Default: true
+ *     trusted_headers?: string|list<scalar|Param|null>,
+ *     error_controller?: scalar|Param|null, // Default: "error_controller"
+ *     handle_all_throwables?: bool|Param, // HttpKernel will handle all kinds of \Throwable. // Default: true
  *     csrf_protection?: bool|array{
- *         enabled?: scalar|null, // Default: null
- *         stateless_token_ids?: list<scalar|null>,
- *         check_header?: scalar|null, // Whether to check the CSRF token in a header in addition to a cookie when using stateless protection. // Default: false
- *         cookie_name?: scalar|null, // The name of the cookie to use when using stateless protection. // Default: "csrf-token"
+ *         enabled?: scalar|Param|null, // Default: null
+ *         stateless_token_ids?: list<scalar|Param|null>,
+ *         check_header?: scalar|Param|null, // Whether to check the CSRF token in a header in addition to a cookie when using stateless protection. // Default: false
+ *         cookie_name?: scalar|Param|null, // The name of the cookie to use when using stateless protection. // Default: "csrf-token"
  *     },
  *     form?: bool|array{ // Form configuration
- *         enabled?: bool, // Default: false
- *         csrf_protection?: array{
- *             enabled?: scalar|null, // Default: null
- *             token_id?: scalar|null, // Default: null
- *             field_name?: scalar|null, // Default: "_token"
- *             field_attr?: array<string, scalar|null>,
+ *         enabled?: bool|Param, // Default: false
+ *         csrf_protection?: bool|array{
+ *             enabled?: scalar|Param|null, // Default: null
+ *             token_id?: scalar|Param|null, // Default: null
+ *             field_name?: scalar|Param|null, // Default: "_token"
+ *             field_attr?: array<string, scalar|Param|null>,
  *         },
  *     },
  *     http_cache?: bool|array{ // HTTP cache configuration
- *         enabled?: bool, // Default: false
- *         debug?: bool, // Default: "%kernel.debug%"
- *         trace_level?: "none"|"short"|"full",
- *         trace_header?: scalar|null,
- *         default_ttl?: int,
- *         private_headers?: list<scalar|null>,
- *         skip_response_headers?: list<scalar|null>,
- *         allow_reload?: bool,
- *         allow_revalidate?: bool,
- *         stale_while_revalidate?: int,
- *         stale_if_error?: int,
- *         terminate_on_cache_hit?: bool,
+ *         enabled?: bool|Param, // Default: false
+ *         debug?: bool|Param, // Default: "%kernel.debug%"
+ *         trace_level?: "none"|"short"|"full"|Param,
+ *         trace_header?: scalar|Param|null,
+ *         default_ttl?: int|Param,
+ *         private_headers?: list<scalar|Param|null>,
+ *         skip_response_headers?: list<scalar|Param|null>,
+ *         allow_reload?: bool|Param,
+ *         allow_revalidate?: bool|Param,
+ *         stale_while_revalidate?: int|Param,
+ *         stale_if_error?: int|Param,
+ *         terminate_on_cache_hit?: bool|Param,
  *     },
  *     esi?: bool|array{ // ESI configuration
- *         enabled?: bool, // Default: false
+ *         enabled?: bool|Param, // Default: false
  *     },
  *     ssi?: bool|array{ // SSI configuration
- *         enabled?: bool, // Default: false
+ *         enabled?: bool|Param, // Default: false
  *     },
  *     fragments?: bool|array{ // Fragments configuration
- *         enabled?: bool, // Default: false
- *         hinclude_default_template?: scalar|null, // Default: null
- *         path?: scalar|null, // Default: "/_fragment"
+ *         enabled?: bool|Param, // Default: false
+ *         hinclude_default_template?: scalar|Param|null, // Default: null
+ *         path?: scalar|Param|null, // Default: "/_fragment"
  *     },
  *     profiler?: bool|array{ // Profiler configuration
- *         enabled?: bool, // Default: false
- *         collect?: bool, // Default: true
- *         collect_parameter?: scalar|null, // The name of the parameter to use to enable or disable collection on a per request basis. // Default: null
- *         only_exceptions?: bool, // Default: false
- *         only_main_requests?: bool, // Default: false
- *         dsn?: scalar|null, // Default: "file:%kernel.cache_dir%/profiler"
- *         collect_serializer_data?: bool, // Enables the serializer data collector and profiler panel. // Default: false
+ *         enabled?: bool|Param, // Default: false
+ *         collect?: bool|Param, // Default: true
+ *         collect_parameter?: scalar|Param|null, // The name of the parameter to use to enable or disable collection on a per request basis. // Default: null
+ *         only_exceptions?: bool|Param, // Default: false
+ *         only_main_requests?: bool|Param, // Default: false
+ *         dsn?: scalar|Param|null, // Default: "file:%kernel.cache_dir%/profiler"
+ *         collect_serializer_data?: true|Param, // Default: true
  *     },
  *     workflows?: bool|array{
- *         enabled?: bool, // Default: false
+ *         enabled?: bool|Param, // Default: false
  *         workflows?: array<string, array{ // Default: []
  *             audit_trail?: bool|array{
- *                 enabled?: bool, // Default: false
+ *                 enabled?: bool|Param, // Default: false
  *             },
- *             type?: "workflow"|"state_machine", // Default: "state_machine"
+ *             type?: "workflow"|"state_machine"|Param, // Default: "state_machine"
  *             marking_store?: array{
- *                 type?: "method",
- *                 property?: scalar|null,
- *                 service?: scalar|null,
+ *                 type?: "method"|Param,
+ *                 property?: scalar|Param|null,
+ *                 service?: scalar|Param|null,
  *             },
- *             supports?: list<scalar|null>,
- *             definition_validators?: list<scalar|null>,
- *             support_strategy?: scalar|null,
- *             initial_marking?: list<scalar|null>,
- *             events_to_dispatch?: list<string>|null,
- *             places?: list<array{ // Default: []
- *                 name: scalar|null,
- *                 metadata?: list<mixed>,
+ *             supports?: string|list<scalar|Param|null>,
+ *             definition_validators?: list<scalar|Param|null>,
+ *             support_strategy?: scalar|Param|null,
+ *             initial_marking?: \BackedEnum|string|list<scalar|Param|null>,
+ *             events_to_dispatch?: null|list<string|Param>,
+ *             places?: string|list<array{ // Default: []
+ *                 name?: scalar|Param|null,
+ *                 metadata?: array<string, mixed>,
  *             }>,
- *             transitions: list<array{ // Default: []
- *                 name: string,
- *                 guard?: string, // An expression to block the transition.
- *                 from?: list<array{ // Default: []
- *                     place: string,
- *                     weight?: int, // Default: 1
+ *             transitions?: list<array{ // Default: []
+ *                 name?: string|Param,
+ *                 guard?: string|Param, // An expression to block the transition.
+ *                 from?: \BackedEnum|string|list<array{ // Default: []
+ *                     place?: string|Param,
+ *                     weight?: int|Param, // Default: 1
  *                 }>,
- *                 to?: list<array{ // Default: []
- *                     place: string,
- *                     weight?: int, // Default: 1
+ *                 to?: \BackedEnum|string|list<array{ // Default: []
+ *                     place?: string|Param,
+ *                     weight?: int|Param, // Default: 1
  *                 }>,
- *                 weight?: int, // Default: 1
- *                 metadata?: list<mixed>,
+ *                 weight?: int|Param, // Default: 1
+ *                 metadata?: array<string, mixed>,
  *             }>,
- *             metadata?: list<mixed>,
+ *             metadata?: array<string, mixed>,
  *         }>,
  *     },
  *     router?: bool|array{ // Router configuration
- *         enabled?: bool, // Default: false
- *         resource: scalar|null,
- *         type?: scalar|null,
- *         cache_dir?: scalar|null, // Deprecated: Setting the "framework.router.cache_dir.cache_dir" configuration option is deprecated. It will be removed in version 8.0. // Default: "%kernel.build_dir%"
- *         default_uri?: scalar|null, // The default URI used to generate URLs in a non-HTTP context. // Default: null
- *         http_port?: scalar|null, // Default: 80
- *         https_port?: scalar|null, // Default: 443
- *         strict_requirements?: scalar|null, // set to true to throw an exception when a parameter does not match the requirements set to false to disable exceptions when a parameter does not match the requirements (and return null instead) set to null to disable parameter checks against requirements 'true' is the preferred configuration in development mode, while 'false' or 'null' might be preferred in production // Default: true
- *         utf8?: bool, // Default: true
+ *         enabled?: bool|Param, // Default: false
+ *         resource?: scalar|Param|null,
+ *         type?: scalar|Param|null,
+ *         default_uri?: scalar|Param|null, // The default URI used to generate URLs in a non-HTTP context. // Default: null
+ *         http_port?: scalar|Param|null, // Default: 80
+ *         https_port?: scalar|Param|null, // Default: 443
+ *         strict_requirements?: scalar|Param|null, // set to true to throw an exception when a parameter does not match the requirements set to false to disable exceptions when a parameter does not match the requirements (and return null instead) set to null to disable parameter checks against requirements 'true' is the preferred configuration in development mode, while 'false' or 'null' might be preferred in production // Default: true
+ *         utf8?: bool|Param, // Default: true
  *     },
  *     session?: bool|array{ // Session configuration
- *         enabled?: bool, // Default: false
- *         storage_factory_id?: scalar|null, // Default: "session.storage.factory.native"
- *         handler_id?: scalar|null, // Defaults to using the native session handler, or to the native *file* session handler if "save_path" is not null.
- *         name?: scalar|null,
- *         cookie_lifetime?: scalar|null,
- *         cookie_path?: scalar|null,
- *         cookie_domain?: scalar|null,
- *         cookie_secure?: true|false|"auto", // Default: "auto"
- *         cookie_httponly?: bool, // Default: true
- *         cookie_samesite?: null|"lax"|"strict"|"none", // Default: "lax"
- *         use_cookies?: bool,
- *         gc_divisor?: scalar|null,
- *         gc_probability?: scalar|null,
- *         gc_maxlifetime?: scalar|null,
- *         save_path?: scalar|null, // Defaults to "%kernel.cache_dir%/sessions" if the "handler_id" option is not null.
- *         metadata_update_threshold?: int, // Seconds to wait between 2 session metadata updates. // Default: 0
- *         sid_length?: int, // Deprecated: Setting the "framework.session.sid_length.sid_length" configuration option is deprecated. It will be removed in version 8.0. No alternative is provided as PHP 8.4 has deprecated the related option.
- *         sid_bits_per_character?: int, // Deprecated: Setting the "framework.session.sid_bits_per_character.sid_bits_per_character" configuration option is deprecated. It will be removed in version 8.0. No alternative is provided as PHP 8.4 has deprecated the related option.
+ *         enabled?: bool|Param, // Default: false
+ *         storage_factory_id?: scalar|Param|null, // Default: "session.storage.factory.native"
+ *         handler_id?: scalar|Param|null, // Defaults to using the native session handler, or to the native *file* session handler if "save_path" is not null.
+ *         name?: scalar|Param|null,
+ *         cookie_lifetime?: scalar|Param|null,
+ *         cookie_path?: scalar|Param|null,
+ *         cookie_domain?: scalar|Param|null,
+ *         cookie_secure?: true|false|"auto"|Param, // Default: "auto"
+ *         cookie_httponly?: bool|Param, // Default: true
+ *         cookie_samesite?: null|"lax"|"strict"|"none"|Param, // Default: "lax"
+ *         use_cookies?: bool|Param,
+ *         gc_divisor?: scalar|Param|null,
+ *         gc_probability?: scalar|Param|null,
+ *         gc_maxlifetime?: scalar|Param|null,
+ *         save_path?: scalar|Param|null, // Defaults to "%kernel.cache_dir%/sessions" if the "handler_id" option is not null.
+ *         metadata_update_threshold?: int|Param, // Seconds to wait between 2 session metadata updates. // Default: 0
  *     },
  *     request?: bool|array{ // Request configuration
- *         enabled?: bool, // Default: false
- *         formats?: array<string, string|list<scalar|null>>,
+ *         enabled?: bool|Param, // Default: false
+ *         formats?: array<string, string|list<scalar|Param|null>>,
  *     },
  *     assets?: bool|array{ // Assets configuration
- *         enabled?: bool, // Default: true
- *         strict_mode?: bool, // Throw an exception if an entry is missing from the manifest.json. // Default: false
- *         version_strategy?: scalar|null, // Default: null
- *         version?: scalar|null, // Default: null
- *         version_format?: scalar|null, // Default: "%%s?%%s"
- *         json_manifest_path?: scalar|null, // Default: null
- *         base_path?: scalar|null, // Default: ""
- *         base_urls?: list<scalar|null>,
+ *         enabled?: bool|Param, // Default: true
+ *         strict_mode?: bool|Param, // Throw an exception if an entry is missing from the manifest.json. // Default: false
+ *         version_strategy?: scalar|Param|null, // Default: null
+ *         version?: scalar|Param|null, // Default: null
+ *         version_format?: scalar|Param|null, // Default: "%%s?%%s"
+ *         json_manifest_path?: scalar|Param|null, // Default: null
+ *         base_path?: scalar|Param|null, // Default: ""
+ *         base_urls?: string|list<scalar|Param|null>,
  *         packages?: array<string, array{ // Default: []
- *             strict_mode?: bool, // Throw an exception if an entry is missing from the manifest.json. // Default: false
- *             version_strategy?: scalar|null, // Default: null
- *             version?: scalar|null,
- *             version_format?: scalar|null, // Default: null
- *             json_manifest_path?: scalar|null, // Default: null
- *             base_path?: scalar|null, // Default: ""
- *             base_urls?: list<scalar|null>,
+ *             strict_mode?: bool|Param, // Throw an exception if an entry is missing from the manifest.json. // Default: false
+ *             version_strategy?: scalar|Param|null, // Default: null
+ *             version?: scalar|Param|null,
+ *             version_format?: scalar|Param|null, // Default: null
+ *             json_manifest_path?: scalar|Param|null, // Default: null
+ *             base_path?: scalar|Param|null, // Default: ""
+ *             base_urls?: string|list<scalar|Param|null>,
  *         }>,
  *     },
  *     asset_mapper?: bool|array{ // Asset Mapper configuration
- *         enabled?: bool, // Default: false
- *         paths?: array<string, scalar|null>,
- *         excluded_patterns?: list<scalar|null>,
- *         exclude_dotfiles?: bool, // If true, any files starting with "." will be excluded from the asset mapper. // Default: true
- *         server?: bool, // If true, a "dev server" will return the assets from the public directory (true in "debug" mode only by default). // Default: true
- *         public_prefix?: scalar|null, // The public path where the assets will be written to (and served from when "server" is true). // Default: "/assets/"
- *         missing_import_mode?: "strict"|"warn"|"ignore", // Behavior if an asset cannot be found when imported from JavaScript or CSS files - e.g. "import './non-existent.js'". "strict" means an exception is thrown, "warn" means a warning is logged, "ignore" means the import is left as-is. // Default: "warn"
- *         extensions?: array<string, scalar|null>,
- *         importmap_path?: scalar|null, // The path of the importmap.php file. // Default: "%kernel.project_dir%/importmap.php"
- *         importmap_polyfill?: scalar|null, // The importmap name that will be used to load the polyfill. Set to false to disable. // Default: "es-module-shims"
- *         importmap_script_attributes?: array<string, scalar|null>,
- *         vendor_dir?: scalar|null, // The directory to store JavaScript vendors. // Default: "%kernel.project_dir%/assets/vendor"
+ *         enabled?: bool|Param, // Default: false
+ *         paths?: string|array<string, scalar|Param|null>,
+ *         excluded_patterns?: list<scalar|Param|null>,
+ *         exclude_dotfiles?: bool|Param, // If true, any files starting with "." will be excluded from the asset mapper. // Default: true
+ *         server?: bool|Param, // If true, a "dev server" will return the assets from the public directory (true in "debug" mode only by default). // Default: true
+ *         public_prefix?: scalar|Param|null, // The public path where the assets will be written to (and served from when "server" is true). // Default: "/assets/"
+ *         missing_import_mode?: "strict"|"warn"|"ignore"|Param, // Behavior if an asset cannot be found when imported from JavaScript or CSS files - e.g. "import './non-existent.js'". "strict" means an exception is thrown, "warn" means a warning is logged, "ignore" means the import is left as-is. // Default: "warn"
+ *         extensions?: array<string, scalar|Param|null>,
+ *         importmap_path?: scalar|Param|null, // The path of the importmap.php file. // Default: "%kernel.project_dir%/importmap.php"
+ *         importmap_polyfill?: scalar|Param|null, // The importmap name that will be used to load the polyfill. Set to false to disable. // Default: "es-module-shims"
+ *         importmap_script_attributes?: array<string, scalar|Param|null>,
+ *         vendor_dir?: scalar|Param|null, // The directory to store JavaScript vendors. // Default: "%kernel.project_dir%/assets/vendor"
  *         precompress?: bool|array{ // Precompress assets with Brotli, Zstandard and gzip.
- *             enabled?: bool, // Default: false
- *             formats?: list<scalar|null>,
- *             extensions?: list<scalar|null>,
+ *             enabled?: bool|Param, // Default: false
+ *             formats?: list<scalar|Param|null>,
+ *             extensions?: list<scalar|Param|null>,
  *         },
  *     },
  *     translator?: bool|array{ // Translator configuration
- *         enabled?: bool, // Default: false
- *         fallbacks?: list<scalar|null>,
- *         logging?: bool, // Default: false
- *         formatter?: scalar|null, // Default: "translator.formatter.default"
- *         cache_dir?: scalar|null, // Default: "%kernel.cache_dir%/translations"
- *         default_path?: scalar|null, // The default path used to load translations. // Default: "%kernel.project_dir%/translations"
- *         paths?: list<scalar|null>,
+ *         enabled?: bool|Param, // Default: false
+ *         fallbacks?: string|list<scalar|Param|null>,
+ *         logging?: bool|Param, // Default: false
+ *         formatter?: scalar|Param|null, // Default: "translator.formatter.default"
+ *         cache_dir?: scalar|Param|null, // Default: "%kernel.cache_dir%/translations"
+ *         default_path?: scalar|Param|null, // The default path used to load translations. // Default: "%kernel.project_dir%/translations"
+ *         paths?: list<scalar|Param|null>,
  *         pseudo_localization?: bool|array{
- *             enabled?: bool, // Default: false
- *             accents?: bool, // Default: true
- *             expansion_factor?: float, // Default: 1.0
- *             brackets?: bool, // Default: true
- *             parse_html?: bool, // Default: false
- *             localizable_html_attributes?: list<scalar|null>,
+ *             enabled?: bool|Param, // Default: false
+ *             accents?: bool|Param, // Default: true
+ *             expansion_factor?: float|Param, // Default: 1.0
+ *             brackets?: bool|Param, // Default: true
+ *             parse_html?: bool|Param, // Default: false
+ *             localizable_html_attributes?: list<scalar|Param|null>,
  *         },
  *         providers?: array<string, array{ // Default: []
- *             dsn?: scalar|null,
- *             domains?: list<scalar|null>,
- *             locales?: list<scalar|null>,
+ *             dsn?: scalar|Param|null,
+ *             domains?: list<scalar|Param|null>,
+ *             locales?: list<scalar|Param|null>,
  *         }>,
  *         globals?: array<string, string|array{ // Default: []
  *             value?: mixed,
- *             message?: string,
- *             parameters?: array<string, scalar|null>,
- *             domain?: string,
+ *             message?: string|Param,
+ *             parameters?: array<string, scalar|Param|null>,
+ *             domain?: string|Param,
  *         }>,
  *     },
  *     validation?: bool|array{ // Validation configuration
- *         enabled?: bool, // Default: true
- *         cache?: scalar|null, // Deprecated: Setting the "framework.validation.cache.cache" configuration option is deprecated. It will be removed in version 8.0.
- *         enable_attributes?: bool, // Default: true
- *         static_method?: list<scalar|null>,
- *         translation_domain?: scalar|null, // Default: "validators"
- *         email_validation_mode?: "html5"|"html5-allow-no-tld"|"strict"|"loose", // Default: "html5"
+ *         enabled?: bool|Param, // Default: true
+ *         enable_attributes?: bool|Param, // Default: true
+ *         static_method?: string|list<scalar|Param|null>,
+ *         translation_domain?: scalar|Param|null, // Default: "validators"
+ *         email_validation_mode?: "html5"|"html5-allow-no-tld"|"strict"|Param, // Default: "html5"
  *         mapping?: array{
- *             paths?: list<scalar|null>,
+ *             paths?: list<scalar|Param|null>,
  *         },
  *         not_compromised_password?: bool|array{
- *             enabled?: bool, // When disabled, compromised passwords will be accepted as valid. // Default: true
- *             endpoint?: scalar|null, // API endpoint for the NotCompromisedPassword Validator. // Default: null
+ *             enabled?: bool|Param, // When disabled, compromised passwords will be accepted as valid. // Default: true
+ *             endpoint?: scalar|Param|null, // API endpoint for the NotCompromisedPassword Validator. // Default: null
  *         },
- *         disable_translation?: bool, // Default: false
+ *         disable_translation?: bool|Param, // Default: false
  *         auto_mapping?: array<string, array{ // Default: []
- *             services?: list<scalar|null>,
+ *             services?: list<scalar|Param|null>,
  *         }>,
  *     },
- *     annotations?: bool|array{
- *         enabled?: bool, // Default: false
- *     },
  *     serializer?: bool|array{ // Serializer configuration
- *         enabled?: bool, // Default: true
- *         enable_attributes?: bool, // Default: true
- *         name_converter?: scalar|null,
- *         circular_reference_handler?: scalar|null,
- *         max_depth_handler?: scalar|null,
+ *         enabled?: bool|Param, // Default: true
+ *         enable_attributes?: bool|Param, // Default: true
+ *         name_converter?: scalar|Param|null,
+ *         circular_reference_handler?: scalar|Param|null,
+ *         max_depth_handler?: scalar|Param|null,
  *         mapping?: array{
- *             paths?: list<scalar|null>,
+ *             paths?: list<scalar|Param|null>,
  *         },
- *         default_context?: list<mixed>,
+ *         default_context?: array<string, mixed>,
  *         named_serializers?: array<string, array{ // Default: []
- *             name_converter?: scalar|null,
- *             default_context?: list<mixed>,
- *             include_built_in_normalizers?: bool, // Whether to include the built-in normalizers // Default: true
- *             include_built_in_encoders?: bool, // Whether to include the built-in encoders // Default: true
+ *             name_converter?: scalar|Param|null,
+ *             default_context?: array<string, mixed>,
+ *             include_built_in_normalizers?: bool|Param, // Whether to include the built-in normalizers // Default: true
+ *             include_built_in_encoders?: bool|Param, // Whether to include the built-in encoders // Default: true
  *         }>,
  *     },
  *     property_access?: bool|array{ // Property access configuration
- *         enabled?: bool, // Default: true
- *         magic_call?: bool, // Default: false
- *         magic_get?: bool, // Default: true
- *         magic_set?: bool, // Default: true
- *         throw_exception_on_invalid_index?: bool, // Default: false
- *         throw_exception_on_invalid_property_path?: bool, // Default: true
+ *         enabled?: bool|Param, // Default: true
+ *         magic_call?: bool|Param, // Default: false
+ *         magic_get?: bool|Param, // Default: true
+ *         magic_set?: bool|Param, // Default: true
+ *         throw_exception_on_invalid_index?: bool|Param, // Default: false
+ *         throw_exception_on_invalid_property_path?: bool|Param, // Default: true
  *     },
  *     type_info?: bool|array{ // Type info configuration
- *         enabled?: bool, // Default: true
- *         aliases?: array<string, scalar|null>,
+ *         enabled?: bool|Param, // Default: true
+ *         aliases?: array<string, scalar|Param|null>,
  *     },
  *     property_info?: bool|array{ // Property info configuration
- *         enabled?: bool, // Default: true
- *         with_constructor_extractor?: bool, // Registers the constructor extractor.
+ *         enabled?: bool|Param, // Default: true
+ *         with_constructor_extractor?: bool|Param, // Registers the constructor extractor. // Default: true
  *     },
  *     cache?: array{ // Cache configuration
- *         prefix_seed?: scalar|null, // Used to namespace cache keys when using several apps with the same shared backend. // Default: "_%kernel.project_dir%.%kernel.container_class%"
- *         app?: scalar|null, // App related cache pools configuration. // Default: "cache.adapter.filesystem"
- *         system?: scalar|null, // System related cache pools configuration. // Default: "cache.adapter.system"
- *         directory?: scalar|null, // Default: "%kernel.share_dir%/pools/app"
- *         default_psr6_provider?: scalar|null,
- *         default_redis_provider?: scalar|null, // Default: "redis://localhost"
- *         default_valkey_provider?: scalar|null, // Default: "valkey://localhost"
- *         default_memcached_provider?: scalar|null, // Default: "memcached://localhost"
- *         default_doctrine_dbal_provider?: scalar|null, // Default: "database_connection"
- *         default_pdo_provider?: scalar|null, // Default: null
+ *         prefix_seed?: scalar|Param|null, // Used to namespace cache keys when using several apps with the same shared backend. // Default: "_%kernel.project_dir%.%kernel.container_class%"
+ *         app?: scalar|Param|null, // App related cache pools configuration. // Default: "cache.adapter.filesystem"
+ *         system?: scalar|Param|null, // System related cache pools configuration. // Default: "cache.adapter.system"
+ *         directory?: scalar|Param|null, // Default: "%kernel.share_dir%/pools/app"
+ *         default_psr6_provider?: scalar|Param|null,
+ *         default_redis_provider?: scalar|Param|null, // Default: "redis://localhost"
+ *         default_valkey_provider?: scalar|Param|null, // Default: "valkey://localhost"
+ *         default_memcached_provider?: scalar|Param|null, // Default: "memcached://localhost"
+ *         default_doctrine_dbal_provider?: scalar|Param|null, // Default: "database_connection"
+ *         default_pdo_provider?: scalar|Param|null, // Default: null
  *         pools?: array<string, array{ // Default: []
- *             adapters?: list<scalar|null>,
- *             tags?: scalar|null, // Default: null
- *             public?: bool, // Default: false
- *             default_lifetime?: scalar|null, // Default lifetime of the pool.
- *             provider?: scalar|null, // Overwrite the setting from the default provider for this adapter.
- *             early_expiration_message_bus?: scalar|null,
- *             clearer?: scalar|null,
+ *             adapters?: string|list<scalar|Param|null>,
+ *             tags?: scalar|Param|null, // Default: null
+ *             public?: bool|Param, // Default: false
+ *             default_lifetime?: scalar|Param|null, // Default lifetime of the pool.
+ *             provider?: scalar|Param|null, // Overwrite the setting from the default provider for this adapter.
+ *             early_expiration_message_bus?: scalar|Param|null,
+ *             clearer?: scalar|Param|null,
  *         }>,
  *     },
  *     php_errors?: array{ // PHP errors handling configuration
  *         log?: mixed, // Use the application logger instead of the PHP logger for logging PHP errors. // Default: true
- *         throw?: bool, // Throw PHP errors as \ErrorException instances. // Default: true
+ *         throw?: bool|Param, // Throw PHP errors as \ErrorException instances. // Default: true
  *     },
  *     exceptions?: array<string, array{ // Default: []
- *         log_level?: scalar|null, // The level of log message. Null to let Symfony decide. // Default: null
- *         status_code?: scalar|null, // The status code of the response. Null or 0 to let Symfony decide. // Default: null
- *         log_channel?: scalar|null, // The channel of log message. Null to let Symfony decide. // Default: null
+ *         log_level?: scalar|Param|null, // The level of log message. Null to let Symfony decide. // Default: null
+ *         status_code?: scalar|Param|null, // The status code of the response. Null or 0 to let Symfony decide. // Default: null
+ *         log_channel?: scalar|Param|null, // The channel of log message. Null to let Symfony decide. // Default: null
  *     }>,
  *     web_link?: bool|array{ // Web links configuration
- *         enabled?: bool, // Default: true
+ *         enabled?: bool|Param, // Default: true
  *     },
  *     lock?: bool|string|array{ // Lock configuration
- *         enabled?: bool, // Default: false
- *         resources?: array<string, string|list<scalar|null>>,
+ *         enabled?: bool|Param, // Default: false
+ *         resources?: string|array<string, string|list<scalar|Param|null>>,
  *     },
  *     semaphore?: bool|string|array{ // Semaphore configuration
- *         enabled?: bool, // Default: false
- *         resources?: array<string, scalar|null>,
+ *         enabled?: bool|Param, // Default: false
+ *         resources?: string|array<string, scalar|Param|null>,
  *     },
  *     messenger?: bool|array{ // Messenger configuration
- *         enabled?: bool, // Default: true
- *         routing?: array<string, array{ // Default: []
- *             senders?: list<scalar|null>,
+ *         enabled?: bool|Param, // Default: true
+ *         routing?: array<string, string|array{ // Default: []
+ *             senders?: list<scalar|Param|null>,
  *         }>,
  *         serializer?: array{
- *             default_serializer?: scalar|null, // Service id to use as the default serializer for the transports. // Default: "messenger.transport.native_php_serializer"
+ *             default_serializer?: scalar|Param|null, // Service id to use as the default serializer for the transports. // Default: "messenger.transport.native_php_serializer"
  *             symfony_serializer?: array{
- *                 format?: scalar|null, // Serialization format for the messenger.transport.symfony_serializer service (which is not the serializer used by default). // Default: "json"
+ *                 format?: scalar|Param|null, // Serialization format for the messenger.transport.symfony_serializer service (which is not the serializer used by default). // Default: "json"
  *                 context?: array<string, mixed>,
  *             },
  *         },
  *         transports?: array<string, string|array{ // Default: []
- *             dsn?: scalar|null,
- *             serializer?: scalar|null, // Service id of a custom serializer to use. // Default: null
- *             options?: list<mixed>,
- *             failure_transport?: scalar|null, // Transport name to send failed messages to (after all retries have failed). // Default: null
+ *             dsn?: scalar|Param|null,
+ *             serializer?: scalar|Param|null, // Service id of a custom serializer to use. // Default: null
+ *             options?: array<string, mixed>,
+ *             failure_transport?: scalar|Param|null, // Transport name to send failed messages to (after all retries have failed). // Default: null
  *             retry_strategy?: string|array{
- *                 service?: scalar|null, // Service id to override the retry strategy entirely. // Default: null
- *                 max_retries?: int, // Default: 3
- *                 delay?: int, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
- *                 multiplier?: float, // If greater than 1, delay will grow exponentially for each retry: this delay = (delay * (multiple ^ retries)). // Default: 2
- *                 max_delay?: int, // Max time in ms that a retry should ever be delayed (0 = infinite). // Default: 0
- *                 jitter?: float, // Randomness to apply to the delay (between 0 and 1). // Default: 0.1
+ *                 service?: scalar|Param|null, // Service id to override the retry strategy entirely. // Default: null
+ *                 max_retries?: int|Param, // Default: 3
+ *                 delay?: int|Param, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
+ *                 multiplier?: float|Param, // If greater than 1, delay will grow exponentially for each retry: this delay = (delay * (multiple ^ retries)). // Default: 2
+ *                 max_delay?: int|Param, // Max time in ms that a retry should ever be delayed (0 = infinite). // Default: 0
+ *                 jitter?: float|Param, // Randomness to apply to the delay (between 0 and 1). // Default: 0.1
  *             },
- *             rate_limiter?: scalar|null, // Rate limiter name to use when processing messages. // Default: null
+ *             rate_limiter?: scalar|Param|null, // Rate limiter name to use when processing messages. // Default: null
  *         }>,
- *         failure_transport?: scalar|null, // Transport name to send failed messages to (after all retries have failed). // Default: null
- *         stop_worker_on_signals?: list<scalar|null>,
- *         default_bus?: scalar|null, // Default: null
+ *         failure_transport?: scalar|Param|null, // Transport name to send failed messages to (after all retries have failed). // Default: null
+ *         stop_worker_on_signals?: int|string|list<scalar|Param|null>,
+ *         default_bus?: scalar|Param|null, // Default: null
  *         buses?: array<string, array{ // Default: {"messenger.bus.default":{"default_middleware":{"enabled":true,"allow_no_handlers":false,"allow_no_senders":true},"middleware":[]}}
  *             default_middleware?: bool|string|array{
- *                 enabled?: bool, // Default: true
- *                 allow_no_handlers?: bool, // Default: false
- *                 allow_no_senders?: bool, // Default: true
+ *                 enabled?: bool|Param, // Default: true
+ *                 allow_no_handlers?: bool|Param, // Default: false
+ *                 allow_no_senders?: bool|Param, // Default: true
  *             },
- *             middleware?: list<string|array{ // Default: []
- *                 id: scalar|null,
+ *             middleware?: string|list<string|array{ // Default: []
+ *                 id?: scalar|Param|null,
  *                 arguments?: list<mixed>,
  *             }>,
  *         }>,
  *     },
  *     scheduler?: bool|array{ // Scheduler configuration
- *         enabled?: bool, // Default: true
+ *         enabled?: bool|Param, // Default: true
  *     },
- *     disallow_search_engine_index?: bool, // Enabled by default when debug is enabled. // Default: true
+ *     disallow_search_engine_index?: bool|Param, // Enabled by default when debug is enabled. // Default: true
  *     http_client?: bool|array{ // HTTP Client configuration
- *         enabled?: bool, // Default: true
- *         max_host_connections?: int, // The maximum number of connections to a single host.
+ *         enabled?: bool|Param, // Default: true
+ *         max_host_connections?: int|Param, // The maximum number of connections to a single host.
  *         default_options?: array{
  *             headers?: array<string, mixed>,
  *             vars?: array<string, mixed>,
- *             max_redirects?: int, // The maximum number of redirects to follow.
- *             http_version?: scalar|null, // The default HTTP version, typically 1.1 or 2.0, leave to null for the best version.
- *             resolve?: array<string, scalar|null>,
- *             proxy?: scalar|null, // The URL of the proxy to pass requests through or null for automatic detection.
- *             no_proxy?: scalar|null, // A comma separated list of hosts that do not require a proxy to be reached.
- *             timeout?: float, // The idle timeout, defaults to the "default_socket_timeout" ini parameter.
- *             max_duration?: float, // The maximum execution time for the request+response as a whole.
- *             bindto?: scalar|null, // A network interface name, IP address, a host name or a UNIX socket to bind to.
- *             verify_peer?: bool, // Indicates if the peer should be verified in a TLS context.
- *             verify_host?: bool, // Indicates if the host should exist as a certificate common name.
- *             cafile?: scalar|null, // A certificate authority file.
- *             capath?: scalar|null, // A directory that contains multiple certificate authority files.
- *             local_cert?: scalar|null, // A PEM formatted certificate file.
- *             local_pk?: scalar|null, // A private key file.
- *             passphrase?: scalar|null, // The passphrase used to encrypt the "local_pk" file.
- *             ciphers?: scalar|null, // A list of TLS ciphers separated by colons, commas or spaces (e.g. "RC3-SHA:TLS13-AES-128-GCM-SHA256"...)
+ *             max_redirects?: int|Param, // The maximum number of redirects to follow.
+ *             http_version?: scalar|Param|null, // The default HTTP version, typically 1.1 or 2.0, leave to null for the best version.
+ *             resolve?: array<string, scalar|Param|null>,
+ *             proxy?: scalar|Param|null, // The URL of the proxy to pass requests through or null for automatic detection.
+ *             no_proxy?: scalar|Param|null, // A comma separated list of hosts that do not require a proxy to be reached.
+ *             timeout?: float|Param, // The idle timeout, defaults to the "default_socket_timeout" ini parameter.
+ *             max_duration?: float|Param, // The maximum execution time for the request+response as a whole.
+ *             bindto?: scalar|Param|null, // A network interface name, IP address, a host name or a UNIX socket to bind to.
+ *             verify_peer?: bool|Param, // Indicates if the peer should be verified in a TLS context.
+ *             verify_host?: bool|Param, // Indicates if the host should exist as a certificate common name.
+ *             cafile?: scalar|Param|null, // A certificate authority file.
+ *             capath?: scalar|Param|null, // A directory that contains multiple certificate authority files.
+ *             local_cert?: scalar|Param|null, // A PEM formatted certificate file.
+ *             local_pk?: scalar|Param|null, // A private key file.
+ *             passphrase?: scalar|Param|null, // The passphrase used to encrypt the "local_pk" file.
+ *             ciphers?: scalar|Param|null, // A list of TLS ciphers separated by colons, commas or spaces (e.g. "RC3-SHA:TLS13-AES-128-GCM-SHA256"...)
  *             peer_fingerprint?: array{ // Associative array: hashing algorithm => hash(es).
  *                 sha1?: mixed,
  *                 pin-sha256?: mixed,
  *                 md5?: mixed,
  *             },
- *             crypto_method?: scalar|null, // The minimum version of TLS to accept; must be one of STREAM_CRYPTO_METHOD_TLSv*_CLIENT constants.
+ *             crypto_method?: scalar|Param|null, // The minimum version of TLS to accept; must be one of STREAM_CRYPTO_METHOD_TLSv*_CLIENT constants.
  *             extra?: array<string, mixed>,
- *             rate_limiter?: scalar|null, // Rate limiter name to use for throttling requests. // Default: null
+ *             rate_limiter?: scalar|Param|null, // Rate limiter name to use for throttling requests. // Default: null
  *             caching?: bool|array{ // Caching configuration.
- *                 enabled?: bool, // Default: false
- *                 cache_pool?: string, // The taggable cache pool to use for storing the responses. // Default: "cache.http_client"
- *                 shared?: bool, // Indicates whether the cache is shared (public) or private. // Default: true
- *                 max_ttl?: int, // The maximum TTL (in seconds) allowed for cached responses. Null means no cap. // Default: null
+ *                 enabled?: bool|Param, // Default: false
+ *                 cache_pool?: string|Param, // The taggable cache pool to use for storing the responses. // Default: "cache.http_client"
+ *                 shared?: bool|Param, // Indicates whether the cache is shared (public) or private. // Default: true
+ *                 max_ttl?: int|Param, // The maximum TTL (in seconds) allowed for cached responses. Null means no cap. // Default: null
  *             },
  *             retry_failed?: bool|array{
- *                 enabled?: bool, // Default: false
- *                 retry_strategy?: scalar|null, // service id to override the retry strategy. // Default: null
- *                 http_codes?: array<string, array{ // Default: []
- *                     code?: int,
- *                     methods?: list<string>,
+ *                 enabled?: bool|Param, // Default: false
+ *                 retry_strategy?: scalar|Param|null, // service id to override the retry strategy. // Default: null
+ *                 http_codes?: int|string|array<string, array{ // Default: []
+ *                     code?: int|Param,
+ *                     methods?: string|list<string|Param>,
  *                 }>,
- *                 max_retries?: int, // Default: 3
- *                 delay?: int, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
- *                 multiplier?: float, // If greater than 1, delay will grow exponentially for each retry: delay * (multiple ^ retries). // Default: 2
- *                 max_delay?: int, // Max time in ms that a retry should ever be delayed (0 = infinite). // Default: 0
- *                 jitter?: float, // Randomness in percent (between 0 and 1) to apply to the delay. // Default: 0.1
+ *                 max_retries?: int|Param, // Default: 3
+ *                 delay?: int|Param, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
+ *                 multiplier?: float|Param, // If greater than 1, delay will grow exponentially for each retry: delay * (multiple ^ retries). // Default: 2
+ *                 max_delay?: int|Param, // Max time in ms that a retry should ever be delayed (0 = infinite). // Default: 0
+ *                 jitter?: float|Param, // Randomness in percent (between 0 and 1) to apply to the delay. // Default: 0.1
  *             },
  *         },
- *         mock_response_factory?: scalar|null, // The id of the service that should generate mock responses. It should be either an invokable or an iterable.
+ *         mock_response_factory?: scalar|Param|null, // The id of the service that should generate mock responses. It should be either an invokable or an iterable.
  *         scoped_clients?: array<string, string|array{ // Default: []
- *             scope?: scalar|null, // The regular expression that the request URL must match before adding the other options. When none is provided, the base URI is used instead.
- *             base_uri?: scalar|null, // The URI to resolve relative URLs, following rules in RFC 3985, section 2.
- *             auth_basic?: scalar|null, // An HTTP Basic authentication "username:password".
- *             auth_bearer?: scalar|null, // A token enabling HTTP Bearer authorization.
- *             auth_ntlm?: scalar|null, // A "username:password" pair to use Microsoft NTLM authentication (requires the cURL extension).
- *             query?: array<string, scalar|null>,
+ *             scope?: scalar|Param|null, // The regular expression that the request URL must match before adding the other options. When none is provided, the base URI is used instead.
+ *             base_uri?: scalar|Param|null, // The URI to resolve relative URLs, following rules in RFC 3985, section 2.
+ *             auth_basic?: scalar|Param|null, // An HTTP Basic authentication "username:password".
+ *             auth_bearer?: scalar|Param|null, // A token enabling HTTP Bearer authorization.
+ *             auth_ntlm?: scalar|Param|null, // A "username:password" pair to use Microsoft NTLM authentication (requires the cURL extension).
+ *             query?: array<string, scalar|Param|null>,
  *             headers?: array<string, mixed>,
- *             max_redirects?: int, // The maximum number of redirects to follow.
- *             http_version?: scalar|null, // The default HTTP version, typically 1.1 or 2.0, leave to null for the best version.
- *             resolve?: array<string, scalar|null>,
- *             proxy?: scalar|null, // The URL of the proxy to pass requests through or null for automatic detection.
- *             no_proxy?: scalar|null, // A comma separated list of hosts that do not require a proxy to be reached.
- *             timeout?: float, // The idle timeout, defaults to the "default_socket_timeout" ini parameter.
- *             max_duration?: float, // The maximum execution time for the request+response as a whole.
- *             bindto?: scalar|null, // A network interface name, IP address, a host name or a UNIX socket to bind to.
- *             verify_peer?: bool, // Indicates if the peer should be verified in a TLS context.
- *             verify_host?: bool, // Indicates if the host should exist as a certificate common name.
- *             cafile?: scalar|null, // A certificate authority file.
- *             capath?: scalar|null, // A directory that contains multiple certificate authority files.
- *             local_cert?: scalar|null, // A PEM formatted certificate file.
- *             local_pk?: scalar|null, // A private key file.
- *             passphrase?: scalar|null, // The passphrase used to encrypt the "local_pk" file.
- *             ciphers?: scalar|null, // A list of TLS ciphers separated by colons, commas or spaces (e.g. "RC3-SHA:TLS13-AES-128-GCM-SHA256"...).
+ *             max_redirects?: int|Param, // The maximum number of redirects to follow.
+ *             http_version?: scalar|Param|null, // The default HTTP version, typically 1.1 or 2.0, leave to null for the best version.
+ *             resolve?: array<string, scalar|Param|null>,
+ *             proxy?: scalar|Param|null, // The URL of the proxy to pass requests through or null for automatic detection.
+ *             no_proxy?: scalar|Param|null, // A comma separated list of hosts that do not require a proxy to be reached.
+ *             timeout?: float|Param, // The idle timeout, defaults to the "default_socket_timeout" ini parameter.
+ *             max_duration?: float|Param, // The maximum execution time for the request+response as a whole.
+ *             bindto?: scalar|Param|null, // A network interface name, IP address, a host name or a UNIX socket to bind to.
+ *             verify_peer?: bool|Param, // Indicates if the peer should be verified in a TLS context.
+ *             verify_host?: bool|Param, // Indicates if the host should exist as a certificate common name.
+ *             cafile?: scalar|Param|null, // A certificate authority file.
+ *             capath?: scalar|Param|null, // A directory that contains multiple certificate authority files.
+ *             local_cert?: scalar|Param|null, // A PEM formatted certificate file.
+ *             local_pk?: scalar|Param|null, // A private key file.
+ *             passphrase?: scalar|Param|null, // The passphrase used to encrypt the "local_pk" file.
+ *             ciphers?: scalar|Param|null, // A list of TLS ciphers separated by colons, commas or spaces (e.g. "RC3-SHA:TLS13-AES-128-GCM-SHA256"...).
  *             peer_fingerprint?: array{ // Associative array: hashing algorithm => hash(es).
  *                 sha1?: mixed,
  *                 pin-sha256?: mixed,
  *                 md5?: mixed,
  *             },
- *             crypto_method?: scalar|null, // The minimum version of TLS to accept; must be one of STREAM_CRYPTO_METHOD_TLSv*_CLIENT constants.
+ *             crypto_method?: scalar|Param|null, // The minimum version of TLS to accept; must be one of STREAM_CRYPTO_METHOD_TLSv*_CLIENT constants.
  *             extra?: array<string, mixed>,
- *             rate_limiter?: scalar|null, // Rate limiter name to use for throttling requests. // Default: null
+ *             rate_limiter?: scalar|Param|null, // Rate limiter name to use for throttling requests. // Default: null
  *             caching?: bool|array{ // Caching configuration.
- *                 enabled?: bool, // Default: false
- *                 cache_pool?: string, // The taggable cache pool to use for storing the responses. // Default: "cache.http_client"
- *                 shared?: bool, // Indicates whether the cache is shared (public) or private. // Default: true
- *                 max_ttl?: int, // The maximum TTL (in seconds) allowed for cached responses. Null means no cap. // Default: null
+ *                 enabled?: bool|Param, // Default: false
+ *                 cache_pool?: string|Param, // The taggable cache pool to use for storing the responses. // Default: "cache.http_client"
+ *                 shared?: bool|Param, // Indicates whether the cache is shared (public) or private. // Default: true
+ *                 max_ttl?: int|Param, // The maximum TTL (in seconds) allowed for cached responses. Null means no cap. // Default: null
  *             },
  *             retry_failed?: bool|array{
- *                 enabled?: bool, // Default: false
- *                 retry_strategy?: scalar|null, // service id to override the retry strategy. // Default: null
- *                 http_codes?: array<string, array{ // Default: []
- *                     code?: int,
- *                     methods?: list<string>,
+ *                 enabled?: bool|Param, // Default: false
+ *                 retry_strategy?: scalar|Param|null, // service id to override the retry strategy. // Default: null
+ *                 http_codes?: int|string|array<string, array{ // Default: []
+ *                     code?: int|Param,
+ *                     methods?: string|list<string|Param>,
  *                 }>,
- *                 max_retries?: int, // Default: 3
- *                 delay?: int, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
- *                 multiplier?: float, // If greater than 1, delay will grow exponentially for each retry: delay * (multiple ^ retries). // Default: 2
- *                 max_delay?: int, // Max time in ms that a retry should ever be delayed (0 = infinite). // Default: 0
- *                 jitter?: float, // Randomness in percent (between 0 and 1) to apply to the delay. // Default: 0.1
+ *                 max_retries?: int|Param, // Default: 3
+ *                 delay?: int|Param, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
+ *                 multiplier?: float|Param, // If greater than 1, delay will grow exponentially for each retry: delay * (multiple ^ retries). // Default: 2
+ *                 max_delay?: int|Param, // Max time in ms that a retry should ever be delayed (0 = infinite). // Default: 0
+ *                 jitter?: float|Param, // Randomness in percent (between 0 and 1) to apply to the delay. // Default: 0.1
  *             },
  *         }>,
  *     },
  *     mailer?: bool|array{ // Mailer configuration
- *         enabled?: bool, // Default: true
- *         message_bus?: scalar|null, // The message bus to use. Defaults to the default bus if the Messenger component is installed. // Default: null
- *         dsn?: scalar|null, // Default: null
- *         transports?: array<string, scalar|null>,
+ *         enabled?: bool|Param, // Default: true
+ *         message_bus?: scalar|Param|null, // The message bus to use. Defaults to the default bus if the Messenger component is installed. // Default: null
+ *         dsn?: scalar|Param|null, // Default: null
+ *         transports?: array<string, scalar|Param|null>,
  *         envelope?: array{ // Mailer Envelope configuration
- *             sender?: scalar|null,
- *             recipients?: list<scalar|null>,
- *             allowed_recipients?: list<scalar|null>,
+ *             sender?: scalar|Param|null,
+ *             recipients?: string|list<scalar|Param|null>,
+ *             allowed_recipients?: string|list<scalar|Param|null>,
  *         },
  *         headers?: array<string, string|array{ // Default: []
  *             value?: mixed,
  *         }>,
  *         dkim_signer?: bool|array{ // DKIM signer configuration
- *             enabled?: bool, // Default: false
- *             key?: scalar|null, // Key content, or path to key (in PEM format with the `file://` prefix) // Default: ""
- *             domain?: scalar|null, // Default: ""
- *             select?: scalar|null, // Default: ""
- *             passphrase?: scalar|null, // The private key passphrase // Default: ""
+ *             enabled?: bool|Param, // Default: false
+ *             key?: scalar|Param|null, // Key content, or path to key (in PEM format with the `file://` prefix) // Default: ""
+ *             domain?: scalar|Param|null, // Default: ""
+ *             select?: scalar|Param|null, // Default: ""
+ *             passphrase?: scalar|Param|null, // The private key passphrase // Default: ""
  *             options?: array<string, mixed>,
  *         },
  *         smime_signer?: bool|array{ // S/MIME signer configuration
- *             enabled?: bool, // Default: false
- *             key?: scalar|null, // Path to key (in PEM format) // Default: ""
- *             certificate?: scalar|null, // Path to certificate (in PEM format without the `file://` prefix) // Default: ""
- *             passphrase?: scalar|null, // The private key passphrase // Default: null
- *             extra_certificates?: scalar|null, // Default: null
- *             sign_options?: int, // Default: null
+ *             enabled?: bool|Param, // Default: false
+ *             key?: scalar|Param|null, // Path to key (in PEM format) // Default: ""
+ *             certificate?: scalar|Param|null, // Path to certificate (in PEM format without the `file://` prefix) // Default: ""
+ *             passphrase?: scalar|Param|null, // The private key passphrase // Default: null
+ *             extra_certificates?: scalar|Param|null, // Default: null
+ *             sign_options?: int|Param, // Default: null
  *         },
  *         smime_encrypter?: bool|array{ // S/MIME encrypter configuration
- *             enabled?: bool, // Default: false
- *             repository?: scalar|null, // S/MIME certificate repository service. This service shall implement the `Symfony\Component\Mailer\EventListener\SmimeCertificateRepositoryInterface`. // Default: ""
- *             cipher?: int, // A set of algorithms used to encrypt the message // Default: null
+ *             enabled?: bool|Param, // Default: false
+ *             repository?: scalar|Param|null, // S/MIME certificate repository service. This service shall implement the `Symfony\Component\Mailer\EventListener\SmimeCertificateRepositoryInterface`. // Default: ""
+ *             cipher?: int|Param, // A set of algorithms used to encrypt the message // Default: null
  *         },
  *     },
  *     secrets?: bool|array{
- *         enabled?: bool, // Default: true
- *         vault_directory?: scalar|null, // Default: "%kernel.project_dir%/config/secrets/%kernel.runtime_environment%"
- *         local_dotenv_file?: scalar|null, // Default: "%kernel.project_dir%/.env.%kernel.runtime_environment%.local"
- *         decryption_env_var?: scalar|null, // Default: "base64:default::SYMFONY_DECRYPTION_SECRET"
+ *         enabled?: bool|Param, // Default: true
+ *         vault_directory?: scalar|Param|null, // Default: "%kernel.project_dir%/config/secrets/%kernel.runtime_environment%"
+ *         local_dotenv_file?: scalar|Param|null, // Default: "%kernel.project_dir%/.env.%kernel.environment%.local"
+ *         decryption_env_var?: scalar|Param|null, // Default: "base64:default::SYMFONY_DECRYPTION_SECRET"
  *     },
  *     notifier?: bool|array{ // Notifier configuration
- *         enabled?: bool, // Default: true
- *         message_bus?: scalar|null, // The message bus to use. Defaults to the default bus if the Messenger component is installed. // Default: null
- *         chatter_transports?: array<string, scalar|null>,
- *         texter_transports?: array<string, scalar|null>,
- *         notification_on_failed_messages?: bool, // Default: false
- *         channel_policy?: array<string, string|list<scalar|null>>,
+ *         enabled?: bool|Param, // Default: true
+ *         message_bus?: scalar|Param|null, // The message bus to use. Defaults to the default bus if the Messenger component is installed. // Default: null
+ *         chatter_transports?: array<string, scalar|Param|null>,
+ *         texter_transports?: array<string, scalar|Param|null>,
+ *         notification_on_failed_messages?: bool|Param, // Default: false
+ *         channel_policy?: array<string, string|list<scalar|Param|null>>,
  *         admin_recipients?: list<array{ // Default: []
- *             email?: scalar|null,
- *             phone?: scalar|null, // Default: ""
+ *             email?: scalar|Param|null,
+ *             phone?: scalar|Param|null, // Default: ""
  *         }>,
  *     },
  *     rate_limiter?: bool|array{ // Rate limiter configuration
- *         enabled?: bool, // Default: true
+ *         enabled?: bool|Param, // Default: true
  *         limiters?: array<string, array{ // Default: []
- *             lock_factory?: scalar|null, // The service ID of the lock factory used by this limiter (or null to disable locking). // Default: "auto"
- *             cache_pool?: scalar|null, // The cache pool to use for storing the current limiter state. // Default: "cache.rate_limiter"
- *             storage_service?: scalar|null, // The service ID of a custom storage implementation, this precedes any configured "cache_pool". // Default: null
- *             policy: "fixed_window"|"token_bucket"|"sliding_window"|"compound"|"no_limit", // The algorithm to be used by this limiter.
- *             limiters?: list<scalar|null>,
- *             limit?: int, // The maximum allowed hits in a fixed interval or burst.
- *             interval?: scalar|null, // Configures the fixed interval if "policy" is set to "fixed_window" or "sliding_window". The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).
+ *             lock_factory?: scalar|Param|null, // The service ID of the lock factory used by this limiter (or null to disable locking). // Default: "auto"
+ *             cache_pool?: scalar|Param|null, // The cache pool to use for storing the current limiter state. // Default: "cache.rate_limiter"
+ *             storage_service?: scalar|Param|null, // The service ID of a custom storage implementation, this precedes any configured "cache_pool". // Default: null
+ *             policy?: "fixed_window"|"token_bucket"|"sliding_window"|"compound"|"no_limit"|Param, // The algorithm to be used by this limiter.
+ *             limiters?: string|list<scalar|Param|null>,
+ *             limit?: int|Param, // The maximum allowed hits in a fixed interval or burst.
+ *             interval?: scalar|Param|null, // Configures the fixed interval if "policy" is set to "fixed_window" or "sliding_window". The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).
  *             rate?: array{ // Configures the fill rate if "policy" is set to "token_bucket".
- *                 interval?: scalar|null, // Configures the rate interval. The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).
- *                 amount?: int, // Amount of tokens to add each interval. // Default: 1
+ *                 interval?: scalar|Param|null, // Configures the rate interval. The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).
+ *                 amount?: int|Param, // Amount of tokens to add each interval. // Default: 1
  *             },
  *         }>,
  *     },
  *     uid?: bool|array{ // Uid configuration
- *         enabled?: bool, // Default: true
- *         default_uuid_version?: 7|6|4|1, // Default: 7
- *         name_based_uuid_version?: 5|3, // Default: 5
- *         name_based_uuid_namespace?: scalar|null,
- *         time_based_uuid_version?: 7|6|1, // Default: 7
- *         time_based_uuid_node?: scalar|null,
+ *         enabled?: bool|Param, // Default: true
+ *         default_uuid_version?: 7|6|4|1|Param, // Default: 7
+ *         name_based_uuid_version?: 5|3|Param, // Default: 5
+ *         name_based_uuid_namespace?: scalar|Param|null,
+ *         time_based_uuid_version?: 7|6|1|Param, // Default: 7
+ *         time_based_uuid_node?: scalar|Param|null,
  *     },
  *     html_sanitizer?: bool|array{ // HtmlSanitizer configuration
- *         enabled?: bool, // Default: false
+ *         enabled?: bool|Param, // Default: false
  *         sanitizers?: array<string, array{ // Default: []
- *             allow_safe_elements?: bool, // Allows "safe" elements and attributes. // Default: false
- *             allow_static_elements?: bool, // Allows all static elements and attributes from the W3C Sanitizer API standard. // Default: false
+ *             allow_safe_elements?: bool|Param, // Allows "safe" elements and attributes. // Default: false
+ *             allow_static_elements?: bool|Param, // Allows all static elements and attributes from the W3C Sanitizer API standard. // Default: false
  *             allow_elements?: array<string, mixed>,
- *             block_elements?: list<string>,
- *             drop_elements?: list<string>,
+ *             block_elements?: string|list<string|Param>,
+ *             drop_elements?: string|list<string|Param>,
  *             allow_attributes?: array<string, mixed>,
  *             drop_attributes?: array<string, mixed>,
- *             force_attributes?: array<string, array<string, string>>,
- *             force_https_urls?: bool, // Transforms URLs using the HTTP scheme to use the HTTPS scheme instead. // Default: false
- *             allowed_link_schemes?: list<string>,
- *             allowed_link_hosts?: list<string>|null,
- *             allow_relative_links?: bool, // Allows relative URLs to be used in links href attributes. // Default: false
- *             allowed_media_schemes?: list<string>,
- *             allowed_media_hosts?: list<string>|null,
- *             allow_relative_medias?: bool, // Allows relative URLs to be used in media source attributes (img, audio, video, ...). // Default: false
- *             with_attribute_sanitizers?: list<string>,
- *             without_attribute_sanitizers?: list<string>,
- *             max_input_length?: int, // The maximum length allowed for the sanitized input. // Default: 0
+ *             force_attributes?: array<string, array<string, string|Param>>,
+ *             force_https_urls?: bool|Param, // Transforms URLs using the HTTP scheme to use the HTTPS scheme instead. // Default: false
+ *             allowed_link_schemes?: string|list<string|Param>,
+ *             allowed_link_hosts?: null|string|list<string|Param>,
+ *             allow_relative_links?: bool|Param, // Allows relative URLs to be used in links href attributes. // Default: false
+ *             allowed_media_schemes?: string|list<string|Param>,
+ *             allowed_media_hosts?: null|string|list<string|Param>,
+ *             allow_relative_medias?: bool|Param, // Allows relative URLs to be used in media source attributes (img, audio, video, ...). // Default: false
+ *             with_attribute_sanitizers?: string|list<string|Param>,
+ *             without_attribute_sanitizers?: string|list<string|Param>,
+ *             max_input_length?: int|Param, // The maximum length allowed for the sanitized input. // Default: 0
  *         }>,
  *     },
  *     webhook?: bool|array{ // Webhook configuration
- *         enabled?: bool, // Default: false
- *         message_bus?: scalar|null, // The message bus to use. // Default: "messenger.default_bus"
+ *         enabled?: bool|Param, // Default: false
+ *         message_bus?: scalar|Param|null, // The message bus to use. // Default: "messenger.default_bus"
  *         routing?: array<string, array{ // Default: []
- *             service: scalar|null,
- *             secret?: scalar|null, // Default: ""
+ *             service?: scalar|Param|null,
+ *             secret?: scalar|Param|null, // Default: ""
  *         }>,
  *     },
  *     remote-event?: bool|array{ // RemoteEvent configuration
- *         enabled?: bool, // Default: false
+ *         enabled?: bool|Param, // Default: false
  *     },
  *     json_streamer?: bool|array{ // JSON streamer configuration
- *         enabled?: bool, // Default: false
+ *         enabled?: bool|Param, // Default: false
  *     },
  * }
  * @psalm-type TwigConfig = array{
- *     form_themes?: list<scalar|null>,
+ *     form_themes?: list<scalar|Param|null>,
  *     globals?: array<string, array{ // Default: []
- *         id?: scalar|null,
- *         type?: scalar|null,
+ *         id?: scalar|Param|null,
+ *         type?: scalar|Param|null,
  *         value?: mixed,
  *     }>,
- *     autoescape_service?: scalar|null, // Default: null
- *     autoescape_service_method?: scalar|null, // Default: null
- *     base_template_class?: scalar|null, // Deprecated: The child node "base_template_class" at path "twig.base_template_class" is deprecated.
- *     cache?: scalar|null, // Default: true
- *     charset?: scalar|null, // Default: "%kernel.charset%"
- *     debug?: bool, // Default: "%kernel.debug%"
- *     strict_variables?: bool, // Default: "%kernel.debug%"
- *     auto_reload?: scalar|null,
- *     optimizations?: int,
- *     default_path?: scalar|null, // The default path used to load templates. // Default: "%kernel.project_dir%/templates"
- *     file_name_pattern?: list<scalar|null>,
+ *     autoescape_service?: scalar|Param|null, // Default: null
+ *     autoescape_service_method?: scalar|Param|null, // Default: null
+ *     cache?: scalar|Param|null, // Default: true
+ *     charset?: scalar|Param|null, // Default: "%kernel.charset%"
+ *     debug?: bool|Param, // Default: "%kernel.debug%"
+ *     strict_variables?: bool|Param, // Default: "%kernel.debug%"
+ *     auto_reload?: scalar|Param|null,
+ *     optimizations?: int|Param,
+ *     default_path?: scalar|Param|null, // The default path used to load templates. // Default: "%kernel.project_dir%/templates"
+ *     file_name_pattern?: string|list<scalar|Param|null>,
  *     paths?: array<string, mixed>,
  *     date?: array{ // The default format options used by the date filter.
- *         format?: scalar|null, // Default: "F j, Y H:i"
- *         interval_format?: scalar|null, // Default: "%d days"
- *         timezone?: scalar|null, // The timezone used when formatting dates, when set to null, the timezone returned by date_default_timezone_get() is used. // Default: null
+ *         format?: scalar|Param|null, // Default: "F j, Y H:i"
+ *         interval_format?: scalar|Param|null, // Default: "%d days"
+ *         timezone?: scalar|Param|null, // The timezone used when formatting dates, when set to null, the timezone returned by date_default_timezone_get() is used. // Default: null
  *     },
  *     number_format?: array{ // The default format options for the number_format filter.
- *         decimals?: int, // Default: 0
- *         decimal_point?: scalar|null, // Default: "."
- *         thousands_separator?: scalar|null, // Default: ","
+ *         decimals?: int|Param, // Default: 0
+ *         decimal_point?: scalar|Param|null, // Default: "."
+ *         thousands_separator?: scalar|Param|null, // Default: ","
  *     },
  *     mailer?: array{
- *         html_to_text_converter?: scalar|null, // A service implementing the "Symfony\Component\Mime\HtmlToTextConverter\HtmlToTextConverterInterface". // Default: null
+ *         html_to_text_converter?: scalar|Param|null, // A service implementing the "Symfony\Component\Mime\HtmlToTextConverter\HtmlToTextConverterInterface". // Default: null
  *     },
  * }
  * @psalm-type SecurityConfig = array{
- *     access_denied_url?: scalar|null, // Default: null
- *     session_fixation_strategy?: "none"|"migrate"|"invalidate", // Default: "migrate"
- *     hide_user_not_found?: bool, // Deprecated: The "hide_user_not_found" option is deprecated and will be removed in 8.0. Use the "expose_security_errors" option instead.
- *     expose_security_errors?: \Symfony\Component\Security\Http\Authentication\ExposeSecurityLevel::None|\Symfony\Component\Security\Http\Authentication\ExposeSecurityLevel::AccountStatus|\Symfony\Component\Security\Http\Authentication\ExposeSecurityLevel::All, // Default: "none"
- *     erase_credentials?: bool, // Default: true
+ *     access_denied_url?: scalar|Param|null, // Default: null
+ *     session_fixation_strategy?: "none"|"migrate"|"invalidate"|Param, // Default: "migrate"
+ *     expose_security_errors?: \Symfony\Component\Security\Http\Authentication\ExposeSecurityLevel::None|\Symfony\Component\Security\Http\Authentication\ExposeSecurityLevel::AccountStatus|\Symfony\Component\Security\Http\Authentication\ExposeSecurityLevel::All|Param, // Default: "none"
+ *     erase_credentials?: bool|Param, // Default: true
  *     access_decision_manager?: array{
- *         strategy?: "affirmative"|"consensus"|"unanimous"|"priority",
- *         service?: scalar|null,
- *         strategy_service?: scalar|null,
- *         allow_if_all_abstain?: bool, // Default: false
- *         allow_if_equal_granted_denied?: bool, // Default: true
+ *         strategy?: "affirmative"|"consensus"|"unanimous"|"priority"|Param,
+ *         service?: scalar|Param|null,
+ *         strategy_service?: scalar|Param|null,
+ *         allow_if_all_abstain?: bool|Param, // Default: false
+ *         allow_if_equal_granted_denied?: bool|Param, // Default: true
  *     },
  *     password_hashers?: array<string, string|array{ // Default: []
- *         algorithm?: scalar|null,
- *         migrate_from?: list<scalar|null>,
- *         hash_algorithm?: scalar|null, // Name of hashing algorithm for PBKDF2 (i.e. sha256, sha512, etc..) See hash_algos() for a list of supported algorithms. // Default: "sha512"
- *         key_length?: scalar|null, // Default: 40
- *         ignore_case?: bool, // Default: false
- *         encode_as_base64?: bool, // Default: true
- *         iterations?: scalar|null, // Default: 5000
- *         cost?: int, // Default: null
- *         memory_cost?: scalar|null, // Default: null
- *         time_cost?: scalar|null, // Default: null
- *         id?: scalar|null,
+ *         algorithm?: scalar|Param|null,
+ *         migrate_from?: string|list<scalar|Param|null>,
+ *         hash_algorithm?: scalar|Param|null, // Name of hashing algorithm for PBKDF2 (i.e. sha256, sha512, etc..) See hash_algos() for a list of supported algorithms. // Default: "sha512"
+ *         key_length?: scalar|Param|null, // Default: 40
+ *         ignore_case?: bool|Param, // Default: false
+ *         encode_as_base64?: bool|Param, // Default: true
+ *         iterations?: scalar|Param|null, // Default: 5000
+ *         cost?: int|Param, // Default: null
+ *         memory_cost?: scalar|Param|null, // Default: null
+ *         time_cost?: scalar|Param|null, // Default: null
+ *         id?: scalar|Param|null,
  *     }>,
  *     providers?: array<string, array{ // Default: []
- *         id?: scalar|null,
+ *         id?: scalar|Param|null,
  *         chain?: array{
- *             providers?: list<scalar|null>,
+ *             providers?: string|list<scalar|Param|null>,
  *         },
  *         memory?: array{
  *             users?: array<string, array{ // Default: []
- *                 password?: scalar|null, // Default: null
- *                 roles?: list<scalar|null>,
+ *                 password?: scalar|Param|null, // Default: null
+ *                 roles?: string|list<scalar|Param|null>,
  *             }>,
  *         },
  *         ldap?: array{
- *             service: scalar|null,
- *             base_dn: scalar|null,
- *             search_dn?: scalar|null, // Default: null
- *             search_password?: scalar|null, // Default: null
- *             extra_fields?: list<scalar|null>,
- *             default_roles?: list<scalar|null>,
- *             role_fetcher?: scalar|null, // Default: null
- *             uid_key?: scalar|null, // Default: "sAMAccountName"
- *             filter?: scalar|null, // Default: "({uid_key}={user_identifier})"
- *             password_attribute?: scalar|null, // Default: null
+ *             service?: scalar|Param|null,
+ *             base_dn?: scalar|Param|null,
+ *             search_dn?: scalar|Param|null, // Default: null
+ *             search_password?: scalar|Param|null, // Default: null
+ *             extra_fields?: list<scalar|Param|null>,
+ *             default_roles?: string|list<scalar|Param|null>,
+ *             role_fetcher?: scalar|Param|null, // Default: null
+ *             uid_key?: scalar|Param|null, // Default: "sAMAccountName"
+ *             filter?: scalar|Param|null, // Default: "({uid_key}={user_identifier})"
+ *             password_attribute?: scalar|Param|null, // Default: null
  *         },
  *         entity?: array{
- *             class: scalar|null, // The full entity class name of your user class.
- *             property?: scalar|null, // Default: null
- *             manager_name?: scalar|null, // Default: null
+ *             class?: scalar|Param|null, // The full entity class name of your user class.
+ *             property?: scalar|Param|null, // Default: null
+ *             manager_name?: scalar|Param|null, // Default: null
  *         },
  *     }>,
- *     firewalls: array<string, array{ // Default: []
- *         pattern?: scalar|null,
- *         host?: scalar|null,
- *         methods?: list<scalar|null>,
- *         security?: bool, // Default: true
- *         user_checker?: scalar|null, // The UserChecker to use when authenticating users in this firewall. // Default: "security.user_checker"
- *         request_matcher?: scalar|null,
- *         access_denied_url?: scalar|null,
- *         access_denied_handler?: scalar|null,
- *         entry_point?: scalar|null, // An enabled authenticator name or a service id that implements "Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface".
- *         provider?: scalar|null,
- *         stateless?: bool, // Default: false
- *         lazy?: bool, // Default: false
- *         context?: scalar|null,
+ *     firewalls?: array<string, array{ // Default: []
+ *         pattern?: scalar|Param|null,
+ *         host?: scalar|Param|null,
+ *         methods?: string|list<scalar|Param|null>,
+ *         security?: bool|Param, // Default: true
+ *         user_checker?: scalar|Param|null, // The UserChecker to use when authenticating users in this firewall. // Default: "security.user_checker"
+ *         request_matcher?: scalar|Param|null,
+ *         access_denied_url?: scalar|Param|null,
+ *         access_denied_handler?: scalar|Param|null,
+ *         entry_point?: scalar|Param|null, // An enabled authenticator name or a service id that implements "Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface".
+ *         provider?: scalar|Param|null,
+ *         stateless?: bool|Param, // Default: false
+ *         lazy?: bool|Param, // Default: false
+ *         context?: scalar|Param|null,
  *         logout?: array{
- *             enable_csrf?: bool|null, // Default: null
- *             csrf_token_id?: scalar|null, // Default: "logout"
- *             csrf_parameter?: scalar|null, // Default: "_csrf_token"
- *             csrf_token_manager?: scalar|null,
- *             path?: scalar|null, // Default: "/logout"
- *             target?: scalar|null, // Default: "/"
- *             invalidate_session?: bool, // Default: true
- *             clear_site_data?: list<"*"|"cache"|"cookies"|"storage"|"executionContexts">,
- *             delete_cookies?: array<string, array{ // Default: []
- *                 path?: scalar|null, // Default: null
- *                 domain?: scalar|null, // Default: null
- *                 secure?: scalar|null, // Default: false
- *                 samesite?: scalar|null, // Default: null
- *                 partitioned?: scalar|null, // Default: false
+ *             enable_csrf?: bool|Param|null, // Default: null
+ *             csrf_token_id?: scalar|Param|null, // Default: "logout"
+ *             csrf_parameter?: scalar|Param|null, // Default: "_csrf_token"
+ *             csrf_token_manager?: scalar|Param|null,
+ *             path?: scalar|Param|null, // Default: "/logout"
+ *             target?: scalar|Param|null, // Default: "/"
+ *             invalidate_session?: bool|Param, // Default: true
+ *             clear_site_data?: string|list<"*"|"cache"|"cookies"|"storage"|"executionContexts"|Param>,
+ *             delete_cookies?: string|array<string, array{ // Default: []
+ *                 path?: scalar|Param|null, // Default: null
+ *                 domain?: scalar|Param|null, // Default: null
+ *                 secure?: scalar|Param|null, // Default: false
+ *                 samesite?: scalar|Param|null, // Default: null
+ *                 partitioned?: scalar|Param|null, // Default: false
  *             }>,
  *         },
  *         switch_user?: array{
- *             provider?: scalar|null,
- *             parameter?: scalar|null, // Default: "_switch_user"
- *             role?: scalar|null, // Default: "ROLE_ALLOWED_TO_SWITCH"
- *             target_route?: scalar|null, // Default: null
+ *             provider?: scalar|Param|null,
+ *             parameter?: scalar|Param|null, // Default: "_switch_user"
+ *             role?: scalar|Param|null, // Default: "ROLE_ALLOWED_TO_SWITCH"
+ *             target_route?: scalar|Param|null, // Default: null
  *         },
- *         required_badges?: list<scalar|null>,
- *         custom_authenticators?: list<scalar|null>,
+ *         required_badges?: list<scalar|Param|null>,
+ *         custom_authenticators?: list<scalar|Param|null>,
  *         login_throttling?: array{
- *             limiter?: scalar|null, // A service id implementing "Symfony\Component\HttpFoundation\RateLimiter\RequestRateLimiterInterface".
- *             max_attempts?: int, // Default: 5
- *             interval?: scalar|null, // Default: "1 minute"
- *             lock_factory?: scalar|null, // The service ID of the lock factory used by the login rate limiter (or null to disable locking). // Default: null
- *             cache_pool?: string, // The cache pool to use for storing the limiter state // Default: "cache.rate_limiter"
- *             storage_service?: string, // The service ID of a custom storage implementation, this precedes any configured "cache_pool" // Default: null
+ *             limiter?: scalar|Param|null, // A service id implementing "Symfony\Component\HttpFoundation\RateLimiter\RequestRateLimiterInterface".
+ *             max_attempts?: int|Param, // Default: 5
+ *             interval?: scalar|Param|null, // Default: "1 minute"
+ *             lock_factory?: scalar|Param|null, // The service ID of the lock factory used by the login rate limiter (or null to disable locking). // Default: null
+ *             cache_pool?: string|Param, // The cache pool to use for storing the limiter state // Default: "cache.rate_limiter"
+ *             storage_service?: string|Param, // The service ID of a custom storage implementation, this precedes any configured "cache_pool" // Default: null
  *         },
  *         x509?: array{
- *             provider?: scalar|null,
- *             user?: scalar|null, // Default: "SSL_CLIENT_S_DN_Email"
- *             credentials?: scalar|null, // Default: "SSL_CLIENT_S_DN"
- *             user_identifier?: scalar|null, // Default: "emailAddress"
+ *             provider?: scalar|Param|null,
+ *             user?: scalar|Param|null, // Default: "SSL_CLIENT_S_DN_Email"
+ *             credentials?: scalar|Param|null, // Default: "SSL_CLIENT_S_DN"
+ *             user_identifier?: scalar|Param|null, // Default: "emailAddress"
  *         },
  *         remote_user?: array{
- *             provider?: scalar|null,
- *             user?: scalar|null, // Default: "REMOTE_USER"
+ *             provider?: scalar|Param|null,
+ *             user?: scalar|Param|null, // Default: "REMOTE_USER"
  *         },
  *         login_link?: array{
- *             check_route: scalar|null, // Route that will validate the login link - e.g. "app_login_link_verify".
- *             check_post_only?: scalar|null, // If true, only HTTP POST requests to "check_route" will be handled by the authenticator. // Default: false
- *             signature_properties: list<scalar|null>,
- *             lifetime?: int, // The lifetime of the login link in seconds. // Default: 600
- *             max_uses?: int, // Max number of times a login link can be used - null means unlimited within lifetime. // Default: null
- *             used_link_cache?: scalar|null, // Cache service id used to expired links of max_uses is set.
- *             success_handler?: scalar|null, // A service id that implements Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface.
- *             failure_handler?: scalar|null, // A service id that implements Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface.
- *             provider?: scalar|null, // The user provider to load users from.
- *             secret?: scalar|null, // Default: "%kernel.secret%"
- *             always_use_default_target_path?: bool, // Default: false
- *             default_target_path?: scalar|null, // Default: "/"
- *             login_path?: scalar|null, // Default: "/login"
- *             target_path_parameter?: scalar|null, // Default: "_target_path"
- *             use_referer?: bool, // Default: false
- *             failure_path?: scalar|null, // Default: null
- *             failure_forward?: bool, // Default: false
- *             failure_path_parameter?: scalar|null, // Default: "_failure_path"
+ *             check_route?: scalar|Param|null, // Route that will validate the login link - e.g. "app_login_link_verify".
+ *             check_post_only?: scalar|Param|null, // If true, only HTTP POST requests to "check_route" will be handled by the authenticator. // Default: false
+ *             signature_properties?: list<scalar|Param|null>,
+ *             lifetime?: int|Param, // The lifetime of the login link in seconds. // Default: 600
+ *             max_uses?: int|Param, // Max number of times a login link can be used - null means unlimited within lifetime. // Default: null
+ *             used_link_cache?: scalar|Param|null, // Cache service id used to expired links of max_uses is set.
+ *             success_handler?: scalar|Param|null, // A service id that implements Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface.
+ *             failure_handler?: scalar|Param|null, // A service id that implements Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface.
+ *             provider?: scalar|Param|null, // The user provider to load users from.
+ *             secret?: scalar|Param|null, // Default: "%kernel.secret%"
+ *             always_use_default_target_path?: bool|Param, // Default: false
+ *             default_target_path?: scalar|Param|null, // Default: "/"
+ *             login_path?: scalar|Param|null, // Default: "/login"
+ *             target_path_parameter?: scalar|Param|null, // Default: "_target_path"
+ *             use_referer?: bool|Param, // Default: false
+ *             failure_path?: scalar|Param|null, // Default: null
+ *             failure_forward?: bool|Param, // Default: false
+ *             failure_path_parameter?: scalar|Param|null, // Default: "_failure_path"
  *         },
  *         form_login?: array{
- *             provider?: scalar|null,
- *             remember_me?: bool, // Default: true
- *             success_handler?: scalar|null,
- *             failure_handler?: scalar|null,
- *             check_path?: scalar|null, // Default: "/login_check"
- *             use_forward?: bool, // Default: false
- *             login_path?: scalar|null, // Default: "/login"
- *             username_parameter?: scalar|null, // Default: "_username"
- *             password_parameter?: scalar|null, // Default: "_password"
- *             csrf_parameter?: scalar|null, // Default: "_csrf_token"
- *             csrf_token_id?: scalar|null, // Default: "authenticate"
- *             enable_csrf?: bool, // Default: false
- *             post_only?: bool, // Default: true
- *             form_only?: bool, // Default: false
- *             always_use_default_target_path?: bool, // Default: false
- *             default_target_path?: scalar|null, // Default: "/"
- *             target_path_parameter?: scalar|null, // Default: "_target_path"
- *             use_referer?: bool, // Default: false
- *             failure_path?: scalar|null, // Default: null
- *             failure_forward?: bool, // Default: false
- *             failure_path_parameter?: scalar|null, // Default: "_failure_path"
+ *             provider?: scalar|Param|null,
+ *             remember_me?: bool|Param, // Default: true
+ *             success_handler?: scalar|Param|null,
+ *             failure_handler?: scalar|Param|null,
+ *             check_path?: scalar|Param|null, // Default: "/login_check"
+ *             use_forward?: bool|Param, // Default: false
+ *             login_path?: scalar|Param|null, // Default: "/login"
+ *             username_parameter?: scalar|Param|null, // Default: "_username"
+ *             password_parameter?: scalar|Param|null, // Default: "_password"
+ *             csrf_parameter?: scalar|Param|null, // Default: "_csrf_token"
+ *             csrf_token_id?: scalar|Param|null, // Default: "authenticate"
+ *             enable_csrf?: bool|Param, // Default: false
+ *             post_only?: bool|Param, // Default: true
+ *             form_only?: bool|Param, // Default: false
+ *             always_use_default_target_path?: bool|Param, // Default: false
+ *             default_target_path?: scalar|Param|null, // Default: "/"
+ *             target_path_parameter?: scalar|Param|null, // Default: "_target_path"
+ *             use_referer?: bool|Param, // Default: false
+ *             failure_path?: scalar|Param|null, // Default: null
+ *             failure_forward?: bool|Param, // Default: false
+ *             failure_path_parameter?: scalar|Param|null, // Default: "_failure_path"
  *         },
  *         form_login_ldap?: array{
- *             provider?: scalar|null,
- *             remember_me?: bool, // Default: true
- *             success_handler?: scalar|null,
- *             failure_handler?: scalar|null,
- *             check_path?: scalar|null, // Default: "/login_check"
- *             use_forward?: bool, // Default: false
- *             login_path?: scalar|null, // Default: "/login"
- *             username_parameter?: scalar|null, // Default: "_username"
- *             password_parameter?: scalar|null, // Default: "_password"
- *             csrf_parameter?: scalar|null, // Default: "_csrf_token"
- *             csrf_token_id?: scalar|null, // Default: "authenticate"
- *             enable_csrf?: bool, // Default: false
- *             post_only?: bool, // Default: true
- *             form_only?: bool, // Default: false
- *             always_use_default_target_path?: bool, // Default: false
- *             default_target_path?: scalar|null, // Default: "/"
- *             target_path_parameter?: scalar|null, // Default: "_target_path"
- *             use_referer?: bool, // Default: false
- *             failure_path?: scalar|null, // Default: null
- *             failure_forward?: bool, // Default: false
- *             failure_path_parameter?: scalar|null, // Default: "_failure_path"
- *             service?: scalar|null, // Default: "ldap"
- *             dn_string?: scalar|null, // Default: "{user_identifier}"
- *             query_string?: scalar|null,
- *             search_dn?: scalar|null, // Default: ""
- *             search_password?: scalar|null, // Default: ""
+ *             provider?: scalar|Param|null,
+ *             remember_me?: bool|Param, // Default: true
+ *             success_handler?: scalar|Param|null,
+ *             failure_handler?: scalar|Param|null,
+ *             check_path?: scalar|Param|null, // Default: "/login_check"
+ *             use_forward?: bool|Param, // Default: false
+ *             login_path?: scalar|Param|null, // Default: "/login"
+ *             username_parameter?: scalar|Param|null, // Default: "_username"
+ *             password_parameter?: scalar|Param|null, // Default: "_password"
+ *             csrf_parameter?: scalar|Param|null, // Default: "_csrf_token"
+ *             csrf_token_id?: scalar|Param|null, // Default: "authenticate"
+ *             enable_csrf?: bool|Param, // Default: false
+ *             post_only?: bool|Param, // Default: true
+ *             form_only?: bool|Param, // Default: false
+ *             always_use_default_target_path?: bool|Param, // Default: false
+ *             default_target_path?: scalar|Param|null, // Default: "/"
+ *             target_path_parameter?: scalar|Param|null, // Default: "_target_path"
+ *             use_referer?: bool|Param, // Default: false
+ *             failure_path?: scalar|Param|null, // Default: null
+ *             failure_forward?: bool|Param, // Default: false
+ *             failure_path_parameter?: scalar|Param|null, // Default: "_failure_path"
+ *             service?: scalar|Param|null, // Default: "ldap"
+ *             dn_string?: scalar|Param|null, // Default: "{user_identifier}"
+ *             query_string?: scalar|Param|null,
+ *             search_dn?: scalar|Param|null, // Default: ""
+ *             search_password?: scalar|Param|null, // Default: ""
  *         },
  *         json_login?: array{
- *             provider?: scalar|null,
- *             remember_me?: bool, // Default: true
- *             success_handler?: scalar|null,
- *             failure_handler?: scalar|null,
- *             check_path?: scalar|null, // Default: "/login_check"
- *             use_forward?: bool, // Default: false
- *             login_path?: scalar|null, // Default: "/login"
- *             username_path?: scalar|null, // Default: "username"
- *             password_path?: scalar|null, // Default: "password"
+ *             provider?: scalar|Param|null,
+ *             remember_me?: bool|Param, // Default: true
+ *             success_handler?: scalar|Param|null,
+ *             failure_handler?: scalar|Param|null,
+ *             check_path?: scalar|Param|null, // Default: "/login_check"
+ *             use_forward?: bool|Param, // Default: false
+ *             login_path?: scalar|Param|null, // Default: "/login"
+ *             username_path?: scalar|Param|null, // Default: "username"
+ *             password_path?: scalar|Param|null, // Default: "password"
  *         },
  *         json_login_ldap?: array{
- *             provider?: scalar|null,
- *             remember_me?: bool, // Default: true
- *             success_handler?: scalar|null,
- *             failure_handler?: scalar|null,
- *             check_path?: scalar|null, // Default: "/login_check"
- *             use_forward?: bool, // Default: false
- *             login_path?: scalar|null, // Default: "/login"
- *             username_path?: scalar|null, // Default: "username"
- *             password_path?: scalar|null, // Default: "password"
- *             service?: scalar|null, // Default: "ldap"
- *             dn_string?: scalar|null, // Default: "{user_identifier}"
- *             query_string?: scalar|null,
- *             search_dn?: scalar|null, // Default: ""
- *             search_password?: scalar|null, // Default: ""
+ *             provider?: scalar|Param|null,
+ *             remember_me?: bool|Param, // Default: true
+ *             success_handler?: scalar|Param|null,
+ *             failure_handler?: scalar|Param|null,
+ *             check_path?: scalar|Param|null, // Default: "/login_check"
+ *             use_forward?: bool|Param, // Default: false
+ *             login_path?: scalar|Param|null, // Default: "/login"
+ *             username_path?: scalar|Param|null, // Default: "username"
+ *             password_path?: scalar|Param|null, // Default: "password"
+ *             service?: scalar|Param|null, // Default: "ldap"
+ *             dn_string?: scalar|Param|null, // Default: "{user_identifier}"
+ *             query_string?: scalar|Param|null,
+ *             search_dn?: scalar|Param|null, // Default: ""
+ *             search_password?: scalar|Param|null, // Default: ""
  *         },
  *         access_token?: array{
- *             provider?: scalar|null,
- *             remember_me?: bool, // Default: true
- *             success_handler?: scalar|null,
- *             failure_handler?: scalar|null,
- *             realm?: scalar|null, // Default: null
- *             token_extractors?: list<scalar|null>,
- *             token_handler: string|array{
- *                 id?: scalar|null,
+ *             provider?: scalar|Param|null,
+ *             remember_me?: bool|Param, // Default: true
+ *             success_handler?: scalar|Param|null,
+ *             failure_handler?: scalar|Param|null,
+ *             realm?: scalar|Param|null, // Default: null
+ *             token_extractors?: string|list<scalar|Param|null>,
+ *             token_handler?: string|array{
+ *                 id?: scalar|Param|null,
  *                 oidc_user_info?: string|array{
- *                     base_uri: scalar|null, // Base URI of the userinfo endpoint on the OIDC server, or the OIDC server URI to use the discovery (require "discovery" to be configured).
+ *                     base_uri?: scalar|Param|null, // Base URI of the userinfo endpoint on the OIDC server, or the OIDC server URI to use the discovery (require "discovery" to be configured).
  *                     discovery?: array{ // Enable the OIDC discovery.
  *                         cache?: array{
- *                             id: scalar|null, // Cache service id to use to cache the OIDC discovery configuration.
+ *                             id?: scalar|Param|null, // Cache service id to use to cache the OIDC discovery configuration.
  *                         },
  *                     },
- *                     claim?: scalar|null, // Claim which contains the user identifier (e.g. sub, email, etc.). // Default: "sub"
- *                     client?: scalar|null, // HttpClient service id to use to call the OIDC server.
+ *                     claim?: scalar|Param|null, // Claim which contains the user identifier (e.g. sub, email, etc.). // Default: "sub"
+ *                     client?: scalar|Param|null, // HttpClient service id to use to call the OIDC server.
  *                 },
  *                 oidc?: array{
  *                     discovery?: array{ // Enable the OIDC discovery.
- *                         base_uri: list<scalar|null>,
+ *                         base_uri?: string|list<scalar|Param|null>,
  *                         cache?: array{
- *                             id: scalar|null, // Cache service id to use to cache the OIDC discovery configuration.
+ *                             id?: scalar|Param|null, // Cache service id to use to cache the OIDC discovery configuration.
  *                         },
  *                     },
- *                     claim?: scalar|null, // Claim which contains the user identifier (e.g.: sub, email..). // Default: "sub"
- *                     audience: scalar|null, // Audience set in the token, for validation purpose.
- *                     issuers: list<scalar|null>,
- *                     algorithm?: array<mixed>,
- *                     algorithms: list<scalar|null>,
- *                     key?: scalar|null, // Deprecated: The "key" option is deprecated and will be removed in 8.0. Use the "keyset" option instead. // JSON-encoded JWK used to sign the token (must contain a "kty" key).
- *                     keyset?: scalar|null, // JSON-encoded JWKSet used to sign the token (must contain a list of valid public keys).
+ *                     claim?: scalar|Param|null, // Claim which contains the user identifier (e.g.: sub, email..). // Default: "sub"
+ *                     audience?: scalar|Param|null, // Audience set in the token, for validation purpose.
+ *                     issuers?: list<scalar|Param|null>,
+ *                     algorithms?: list<scalar|Param|null>,
+ *                     keyset?: scalar|Param|null, // JSON-encoded JWKSet used to sign the token (must contain a list of valid public keys).
  *                     encryption?: bool|array{
- *                         enabled?: bool, // Default: false
- *                         enforce?: bool, // When enabled, the token shall be encrypted. // Default: false
- *                         algorithms: list<scalar|null>,
- *                         keyset: scalar|null, // JSON-encoded JWKSet used to decrypt the token (must contain a list of valid private keys).
+ *                         enabled?: bool|Param, // Default: false
+ *                         enforce?: bool|Param, // When enabled, the token shall be encrypted. // Default: false
+ *                         algorithms?: list<scalar|Param|null>,
+ *                         keyset?: scalar|Param|null, // JSON-encoded JWKSet used to decrypt the token (must contain a list of valid private keys).
  *                     },
  *                 },
  *                 cas?: array{
- *                     validation_url: scalar|null, // CAS server validation URL
- *                     prefix?: scalar|null, // CAS prefix // Default: "cas"
- *                     http_client?: scalar|null, // HTTP Client service // Default: null
+ *                     validation_url?: scalar|Param|null, // CAS server validation URL
+ *                     prefix?: scalar|Param|null, // CAS prefix // Default: "cas"
+ *                     http_client?: scalar|Param|null, // HTTP Client service // Default: null
  *                 },
- *                 oauth2?: scalar|null,
+ *                 oauth2?: scalar|Param|null,
  *             },
  *         },
  *         http_basic?: array{
- *             provider?: scalar|null,
- *             realm?: scalar|null, // Default: "Secured Area"
+ *             provider?: scalar|Param|null,
+ *             realm?: scalar|Param|null, // Default: "Secured Area"
  *         },
  *         http_basic_ldap?: array{
- *             provider?: scalar|null,
- *             realm?: scalar|null, // Default: "Secured Area"
- *             service?: scalar|null, // Default: "ldap"
- *             dn_string?: scalar|null, // Default: "{user_identifier}"
- *             query_string?: scalar|null,
- *             search_dn?: scalar|null, // Default: ""
- *             search_password?: scalar|null, // Default: ""
+ *             provider?: scalar|Param|null,
+ *             realm?: scalar|Param|null, // Default: "Secured Area"
+ *             service?: scalar|Param|null, // Default: "ldap"
+ *             dn_string?: scalar|Param|null, // Default: "{user_identifier}"
+ *             query_string?: scalar|Param|null,
+ *             search_dn?: scalar|Param|null, // Default: ""
+ *             search_password?: scalar|Param|null, // Default: ""
  *         },
  *         remember_me?: array{
- *             secret?: scalar|null, // Default: "%kernel.secret%"
- *             service?: scalar|null,
- *             user_providers?: list<scalar|null>,
- *             catch_exceptions?: bool, // Default: true
- *             signature_properties?: list<scalar|null>,
+ *             secret?: scalar|Param|null, // Default: "%kernel.secret%"
+ *             service?: scalar|Param|null,
+ *             user_providers?: string|list<scalar|Param|null>,
+ *             catch_exceptions?: bool|Param, // Default: true
+ *             signature_properties?: list<scalar|Param|null>,
  *             token_provider?: string|array{
- *                 service?: scalar|null, // The service ID of a custom remember-me token provider.
+ *                 service?: scalar|Param|null, // The service ID of a custom remember-me token provider.
  *                 doctrine?: bool|array{
- *                     enabled?: bool, // Default: false
- *                     connection?: scalar|null, // Default: null
+ *                     enabled?: bool|Param, // Default: false
+ *                     connection?: scalar|Param|null, // Default: null
  *                 },
  *             },
- *             token_verifier?: scalar|null, // The service ID of a custom rememberme token verifier.
- *             name?: scalar|null, // Default: "REMEMBERME"
- *             lifetime?: int, // Default: 31536000
- *             path?: scalar|null, // Default: "/"
- *             domain?: scalar|null, // Default: null
- *             secure?: true|false|"auto", // Default: null
- *             httponly?: bool, // Default: true
- *             samesite?: null|"lax"|"strict"|"none", // Default: "lax"
- *             always_remember_me?: bool, // Default: false
- *             remember_me_parameter?: scalar|null, // Default: "_remember_me"
+ *             token_verifier?: scalar|Param|null, // The service ID of a custom rememberme token verifier.
+ *             name?: scalar|Param|null, // Default: "REMEMBERME"
+ *             lifetime?: int|Param, // Default: 31536000
+ *             path?: scalar|Param|null, // Default: "/"
+ *             domain?: scalar|Param|null, // Default: null
+ *             secure?: true|false|"auto"|Param, // Default: null
+ *             httponly?: bool|Param, // Default: true
+ *             samesite?: null|"lax"|"strict"|"none"|Param, // Default: "lax"
+ *             always_remember_me?: bool|Param, // Default: false
+ *             remember_me_parameter?: scalar|Param|null, // Default: "_remember_me"
  *         },
  *     }>,
  *     access_control?: list<array{ // Default: []
- *         request_matcher?: scalar|null, // Default: null
- *         requires_channel?: scalar|null, // Default: null
- *         path?: scalar|null, // Use the urldecoded format. // Default: null
- *         host?: scalar|null, // Default: null
- *         port?: int, // Default: null
- *         ips?: list<scalar|null>,
- *         attributes?: array<string, scalar|null>,
- *         route?: scalar|null, // Default: null
- *         methods?: list<scalar|null>,
- *         allow_if?: scalar|null, // Default: null
- *         roles?: list<scalar|null>,
+ *         request_matcher?: scalar|Param|null, // Default: null
+ *         requires_channel?: scalar|Param|null, // Default: null
+ *         path?: scalar|Param|null, // Use the urldecoded format. // Default: null
+ *         host?: scalar|Param|null, // Default: null
+ *         port?: int|Param, // Default: null
+ *         ips?: string|list<scalar|Param|null>,
+ *         attributes?: array<string, scalar|Param|null>,
+ *         route?: scalar|Param|null, // Default: null
+ *         methods?: string|list<scalar|Param|null>,
+ *         allow_if?: scalar|Param|null, // Default: null
+ *         roles?: string|list<scalar|Param|null>,
  *     }>,
- *     role_hierarchy?: array<string, string|list<scalar|null>>,
+ *     role_hierarchy?: array<string, string|list<scalar|Param|null>>,
  * }
  * @psalm-type DoctrineConfig = array{
  *     dbal?: array{
- *         default_connection?: scalar|null,
+ *         default_connection?: scalar|Param|null,
  *         types?: array<string, string|array{ // Default: []
- *             class: scalar|null,
- *             commented?: bool, // Deprecated: The doctrine-bundle type commenting features were removed; the corresponding config parameter was deprecated in 2.0 and will be dropped in 3.0.
+ *             class?: scalar|Param|null,
  *         }>,
- *         driver_schemes?: array<string, scalar|null>,
+ *         driver_schemes?: array<string, scalar|Param|null>,
  *         connections?: array<string, array{ // Default: []
- *             url?: scalar|null, // A URL with connection information; any parameter value parsed from this string will override explicitly set parameters
- *             dbname?: scalar|null,
- *             host?: scalar|null, // Defaults to "localhost" at runtime.
- *             port?: scalar|null, // Defaults to null at runtime.
- *             user?: scalar|null, // Defaults to "root" at runtime.
- *             password?: scalar|null, // Defaults to null at runtime.
- *             override_url?: bool, // Deprecated: The "doctrine.dbal.override_url" configuration key is deprecated.
- *             dbname_suffix?: scalar|null, // Adds the given suffix to the configured database name, this option has no effects for the SQLite platform
- *             application_name?: scalar|null,
- *             charset?: scalar|null,
- *             path?: scalar|null,
- *             memory?: bool,
- *             unix_socket?: scalar|null, // The unix socket to use for MySQL
- *             persistent?: bool, // True to use as persistent connection for the ibm_db2 driver
- *             protocol?: scalar|null, // The protocol to use for the ibm_db2 driver (default to TCPIP if omitted)
- *             service?: bool, // True to use SERVICE_NAME as connection parameter instead of SID for Oracle
- *             servicename?: scalar|null, // Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter for Oracle depending on the service parameter.
- *             sessionMode?: scalar|null, // The session mode to use for the oci8 driver
- *             server?: scalar|null, // The name of a running database server to connect to for SQL Anywhere.
- *             default_dbname?: scalar|null, // Override the default database (postgres) to connect to for PostgreSQL connexion.
- *             sslmode?: scalar|null, // Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
- *             sslrootcert?: scalar|null, // The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
- *             sslcert?: scalar|null, // The path to the SSL client certificate file for PostgreSQL.
- *             sslkey?: scalar|null, // The path to the SSL client key file for PostgreSQL.
- *             sslcrl?: scalar|null, // The file name of the SSL certificate revocation list for PostgreSQL.
- *             pooled?: bool, // True to use a pooled server with the oci8/pdo_oracle driver
- *             MultipleActiveResultSets?: bool, // Configuring MultipleActiveResultSets for the pdo_sqlsrv driver
- *             use_savepoints?: bool, // Use savepoints for nested transactions
- *             instancename?: scalar|null, // Optional parameter, complete whether to add the INSTANCE_NAME parameter in the connection. It is generally used to connect to an Oracle RAC server to select the name of a particular instance.
- *             connectstring?: scalar|null, // Complete Easy Connect connection descriptor, see https://docs.oracle.com/database/121/NETAG/naming.htm.When using this option, you will still need to provide the user and password parameters, but the other parameters will no longer be used. Note that when using this parameter, the getHost and getPort methods from Doctrine\DBAL\Connection will no longer function as expected.
- *             driver?: scalar|null, // Default: "pdo_mysql"
- *             platform_service?: scalar|null, // Deprecated: The "platform_service" configuration key is deprecated since doctrine-bundle 2.9. DBAL 4 will not support setting a custom platform via connection params anymore.
- *             auto_commit?: bool,
- *             schema_filter?: scalar|null,
- *             logging?: bool, // Default: true
- *             profiling?: bool, // Default: true
- *             profiling_collect_backtrace?: bool, // Enables collecting backtraces when profiling is enabled // Default: false
- *             profiling_collect_schema_errors?: bool, // Enables collecting schema errors when profiling is enabled // Default: true
- *             disable_type_comments?: bool,
- *             server_version?: scalar|null,
- *             idle_connection_ttl?: int, // Default: 600
- *             driver_class?: scalar|null,
- *             wrapper_class?: scalar|null,
- *             keep_slave?: bool, // Deprecated: The "keep_slave" configuration key is deprecated since doctrine-bundle 2.2. Use the "keep_replica" configuration key instead.
- *             keep_replica?: bool,
+ *             url?: scalar|Param|null, // A URL with connection information; any parameter value parsed from this string will override explicitly set parameters
+ *             dbname?: scalar|Param|null,
+ *             host?: scalar|Param|null, // Defaults to "localhost" at runtime.
+ *             port?: scalar|Param|null, // Defaults to null at runtime.
+ *             user?: scalar|Param|null, // Defaults to "root" at runtime.
+ *             password?: scalar|Param|null, // Defaults to null at runtime.
+ *             dbname_suffix?: scalar|Param|null, // Adds the given suffix to the configured database name, this option has no effects for the SQLite platform
+ *             application_name?: scalar|Param|null,
+ *             charset?: scalar|Param|null,
+ *             path?: scalar|Param|null,
+ *             memory?: bool|Param,
+ *             unix_socket?: scalar|Param|null, // The unix socket to use for MySQL
+ *             persistent?: bool|Param, // True to use as persistent connection for the ibm_db2 driver
+ *             protocol?: scalar|Param|null, // The protocol to use for the ibm_db2 driver (default to TCPIP if omitted)
+ *             service?: bool|Param, // True to use SERVICE_NAME as connection parameter instead of SID for Oracle
+ *             servicename?: scalar|Param|null, // Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter for Oracle depending on the service parameter.
+ *             sessionMode?: scalar|Param|null, // The session mode to use for the oci8 driver
+ *             server?: scalar|Param|null, // The name of a running database server to connect to for SQL Anywhere.
+ *             default_dbname?: scalar|Param|null, // Override the default database (postgres) to connect to for PostgreSQL connexion.
+ *             sslmode?: scalar|Param|null, // Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
+ *             sslrootcert?: scalar|Param|null, // The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
+ *             sslcert?: scalar|Param|null, // The path to the SSL client certificate file for PostgreSQL.
+ *             sslkey?: scalar|Param|null, // The path to the SSL client key file for PostgreSQL.
+ *             sslcrl?: scalar|Param|null, // The file name of the SSL certificate revocation list for PostgreSQL.
+ *             pooled?: bool|Param, // True to use a pooled server with the oci8/pdo_oracle driver
+ *             MultipleActiveResultSets?: bool|Param, // Configuring MultipleActiveResultSets for the pdo_sqlsrv driver
+ *             instancename?: scalar|Param|null, // Optional parameter, complete whether to add the INSTANCE_NAME parameter in the connection. It is generally used to connect to an Oracle RAC server to select the name of a particular instance.
+ *             connectstring?: scalar|Param|null, // Complete Easy Connect connection descriptor, see https://docs.oracle.com/database/121/NETAG/naming.htm.When using this option, you will still need to provide the user and password parameters, but the other parameters will no longer be used. Note that when using this parameter, the getHost and getPort methods from Doctrine\DBAL\Connection will no longer function as expected.
+ *             driver?: scalar|Param|null, // Default: "pdo_mysql"
+ *             auto_commit?: bool|Param,
+ *             schema_filter?: scalar|Param|null,
+ *             logging?: bool|Param, // Default: true
+ *             profiling?: bool|Param, // Default: true
+ *             profiling_collect_backtrace?: bool|Param, // Enables collecting backtraces when profiling is enabled // Default: false
+ *             profiling_collect_schema_errors?: bool|Param, // Enables collecting schema errors when profiling is enabled // Default: true
+ *             server_version?: scalar|Param|null,
+ *             idle_connection_ttl?: int|Param, // Default: 600
+ *             driver_class?: scalar|Param|null,
+ *             wrapper_class?: scalar|Param|null,
+ *             keep_replica?: bool|Param,
  *             options?: array<string, mixed>,
- *             mapping_types?: array<string, scalar|null>,
- *             default_table_options?: array<string, scalar|null>,
- *             schema_manager_factory?: scalar|null, // Default: "doctrine.dbal.legacy_schema_manager_factory"
- *             result_cache?: scalar|null,
- *             slaves?: array<string, array{ // Default: []
- *                 url?: scalar|null, // A URL with connection information; any parameter value parsed from this string will override explicitly set parameters
- *                 dbname?: scalar|null,
- *                 host?: scalar|null, // Defaults to "localhost" at runtime.
- *                 port?: scalar|null, // Defaults to null at runtime.
- *                 user?: scalar|null, // Defaults to "root" at runtime.
- *                 password?: scalar|null, // Defaults to null at runtime.
- *                 override_url?: bool, // Deprecated: The "doctrine.dbal.override_url" configuration key is deprecated.
- *                 dbname_suffix?: scalar|null, // Adds the given suffix to the configured database name, this option has no effects for the SQLite platform
- *                 application_name?: scalar|null,
- *                 charset?: scalar|null,
- *                 path?: scalar|null,
- *                 memory?: bool,
- *                 unix_socket?: scalar|null, // The unix socket to use for MySQL
- *                 persistent?: bool, // True to use as persistent connection for the ibm_db2 driver
- *                 protocol?: scalar|null, // The protocol to use for the ibm_db2 driver (default to TCPIP if omitted)
- *                 service?: bool, // True to use SERVICE_NAME as connection parameter instead of SID for Oracle
- *                 servicename?: scalar|null, // Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter for Oracle depending on the service parameter.
- *                 sessionMode?: scalar|null, // The session mode to use for the oci8 driver
- *                 server?: scalar|null, // The name of a running database server to connect to for SQL Anywhere.
- *                 default_dbname?: scalar|null, // Override the default database (postgres) to connect to for PostgreSQL connexion.
- *                 sslmode?: scalar|null, // Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
- *                 sslrootcert?: scalar|null, // The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
- *                 sslcert?: scalar|null, // The path to the SSL client certificate file for PostgreSQL.
- *                 sslkey?: scalar|null, // The path to the SSL client key file for PostgreSQL.
- *                 sslcrl?: scalar|null, // The file name of the SSL certificate revocation list for PostgreSQL.
- *                 pooled?: bool, // True to use a pooled server with the oci8/pdo_oracle driver
- *                 MultipleActiveResultSets?: bool, // Configuring MultipleActiveResultSets for the pdo_sqlsrv driver
- *                 use_savepoints?: bool, // Use savepoints for nested transactions
- *                 instancename?: scalar|null, // Optional parameter, complete whether to add the INSTANCE_NAME parameter in the connection. It is generally used to connect to an Oracle RAC server to select the name of a particular instance.
- *                 connectstring?: scalar|null, // Complete Easy Connect connection descriptor, see https://docs.oracle.com/database/121/NETAG/naming.htm.When using this option, you will still need to provide the user and password parameters, but the other parameters will no longer be used. Note that when using this parameter, the getHost and getPort methods from Doctrine\DBAL\Connection will no longer function as expected.
- *             }>,
+ *             mapping_types?: array<string, scalar|Param|null>,
+ *             default_table_options?: array<string, scalar|Param|null>,
+ *             schema_manager_factory?: scalar|Param|null, // Default: "doctrine.dbal.default_schema_manager_factory"
+ *             result_cache?: scalar|Param|null,
  *             replicas?: array<string, array{ // Default: []
- *                 url?: scalar|null, // A URL with connection information; any parameter value parsed from this string will override explicitly set parameters
- *                 dbname?: scalar|null,
- *                 host?: scalar|null, // Defaults to "localhost" at runtime.
- *                 port?: scalar|null, // Defaults to null at runtime.
- *                 user?: scalar|null, // Defaults to "root" at runtime.
- *                 password?: scalar|null, // Defaults to null at runtime.
- *                 override_url?: bool, // Deprecated: The "doctrine.dbal.override_url" configuration key is deprecated.
- *                 dbname_suffix?: scalar|null, // Adds the given suffix to the configured database name, this option has no effects for the SQLite platform
- *                 application_name?: scalar|null,
- *                 charset?: scalar|null,
- *                 path?: scalar|null,
- *                 memory?: bool,
- *                 unix_socket?: scalar|null, // The unix socket to use for MySQL
- *                 persistent?: bool, // True to use as persistent connection for the ibm_db2 driver
- *                 protocol?: scalar|null, // The protocol to use for the ibm_db2 driver (default to TCPIP if omitted)
- *                 service?: bool, // True to use SERVICE_NAME as connection parameter instead of SID for Oracle
- *                 servicename?: scalar|null, // Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter for Oracle depending on the service parameter.
- *                 sessionMode?: scalar|null, // The session mode to use for the oci8 driver
- *                 server?: scalar|null, // The name of a running database server to connect to for SQL Anywhere.
- *                 default_dbname?: scalar|null, // Override the default database (postgres) to connect to for PostgreSQL connexion.
- *                 sslmode?: scalar|null, // Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
- *                 sslrootcert?: scalar|null, // The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
- *                 sslcert?: scalar|null, // The path to the SSL client certificate file for PostgreSQL.
- *                 sslkey?: scalar|null, // The path to the SSL client key file for PostgreSQL.
- *                 sslcrl?: scalar|null, // The file name of the SSL certificate revocation list for PostgreSQL.
- *                 pooled?: bool, // True to use a pooled server with the oci8/pdo_oracle driver
- *                 MultipleActiveResultSets?: bool, // Configuring MultipleActiveResultSets for the pdo_sqlsrv driver
- *                 use_savepoints?: bool, // Use savepoints for nested transactions
- *                 instancename?: scalar|null, // Optional parameter, complete whether to add the INSTANCE_NAME parameter in the connection. It is generally used to connect to an Oracle RAC server to select the name of a particular instance.
- *                 connectstring?: scalar|null, // Complete Easy Connect connection descriptor, see https://docs.oracle.com/database/121/NETAG/naming.htm.When using this option, you will still need to provide the user and password parameters, but the other parameters will no longer be used. Note that when using this parameter, the getHost and getPort methods from Doctrine\DBAL\Connection will no longer function as expected.
+ *                 url?: scalar|Param|null, // A URL with connection information; any parameter value parsed from this string will override explicitly set parameters
+ *                 dbname?: scalar|Param|null,
+ *                 host?: scalar|Param|null, // Defaults to "localhost" at runtime.
+ *                 port?: scalar|Param|null, // Defaults to null at runtime.
+ *                 user?: scalar|Param|null, // Defaults to "root" at runtime.
+ *                 password?: scalar|Param|null, // Defaults to null at runtime.
+ *                 dbname_suffix?: scalar|Param|null, // Adds the given suffix to the configured database name, this option has no effects for the SQLite platform
+ *                 application_name?: scalar|Param|null,
+ *                 charset?: scalar|Param|null,
+ *                 path?: scalar|Param|null,
+ *                 memory?: bool|Param,
+ *                 unix_socket?: scalar|Param|null, // The unix socket to use for MySQL
+ *                 persistent?: bool|Param, // True to use as persistent connection for the ibm_db2 driver
+ *                 protocol?: scalar|Param|null, // The protocol to use for the ibm_db2 driver (default to TCPIP if omitted)
+ *                 service?: bool|Param, // True to use SERVICE_NAME as connection parameter instead of SID for Oracle
+ *                 servicename?: scalar|Param|null, // Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter for Oracle depending on the service parameter.
+ *                 sessionMode?: scalar|Param|null, // The session mode to use for the oci8 driver
+ *                 server?: scalar|Param|null, // The name of a running database server to connect to for SQL Anywhere.
+ *                 default_dbname?: scalar|Param|null, // Override the default database (postgres) to connect to for PostgreSQL connexion.
+ *                 sslmode?: scalar|Param|null, // Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
+ *                 sslrootcert?: scalar|Param|null, // The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
+ *                 sslcert?: scalar|Param|null, // The path to the SSL client certificate file for PostgreSQL.
+ *                 sslkey?: scalar|Param|null, // The path to the SSL client key file for PostgreSQL.
+ *                 sslcrl?: scalar|Param|null, // The file name of the SSL certificate revocation list for PostgreSQL.
+ *                 pooled?: bool|Param, // True to use a pooled server with the oci8/pdo_oracle driver
+ *                 MultipleActiveResultSets?: bool|Param, // Configuring MultipleActiveResultSets for the pdo_sqlsrv driver
+ *                 instancename?: scalar|Param|null, // Optional parameter, complete whether to add the INSTANCE_NAME parameter in the connection. It is generally used to connect to an Oracle RAC server to select the name of a particular instance.
+ *                 connectstring?: scalar|Param|null, // Complete Easy Connect connection descriptor, see https://docs.oracle.com/database/121/NETAG/naming.htm.When using this option, you will still need to provide the user and password parameters, but the other parameters will no longer be used. Note that when using this parameter, the getHost and getPort methods from Doctrine\DBAL\Connection will no longer function as expected.
  *             }>,
  *         }>,
  *     },
  *     orm?: array{
- *         default_entity_manager?: scalar|null,
- *         auto_generate_proxy_classes?: scalar|null, // Auto generate mode possible values are: "NEVER", "ALWAYS", "FILE_NOT_EXISTS", "EVAL", "FILE_NOT_EXISTS_OR_CHANGED", this option is ignored when the "enable_native_lazy_objects" option is true // Default: false
- *         enable_lazy_ghost_objects?: bool, // Enables the new implementation of proxies based on lazy ghosts instead of using the legacy implementation // Default: true
- *         enable_native_lazy_objects?: bool, // Enables the new native implementation of PHP lazy objects instead of generated proxies // Default: false
- *         proxy_dir?: scalar|null, // Configures the path where generated proxy classes are saved when using non-native lazy objects, this option is ignored when the "enable_native_lazy_objects" option is true // Default: "%kernel.build_dir%/doctrine/orm/Proxies"
- *         proxy_namespace?: scalar|null, // Defines the root namespace for generated proxy classes when using non-native lazy objects, this option is ignored when the "enable_native_lazy_objects" option is true // Default: "Proxies"
+ *         default_entity_manager?: scalar|Param|null,
+ *         enable_native_lazy_objects?: bool|Param, // Deprecated: The "enable_native_lazy_objects" option is deprecated and will be removed in DoctrineBundle 4.0, as native lazy objects are now always enabled. // Default: true
  *         controller_resolver?: bool|array{
- *             enabled?: bool, // Default: true
- *             auto_mapping?: bool|null, // Set to false to disable using route placeholders as lookup criteria when the primary key doesn't match the argument name // Default: null
- *             evict_cache?: bool, // Set to true to fetch the entity from the database instead of using the cache, if any // Default: false
+ *             enabled?: bool|Param, // Default: true
+ *             auto_mapping?: bool|Param, // Deprecated: The "doctrine.orm.controller_resolver.auto_mapping.auto_mapping" option is deprecated and will be removed in DoctrineBundle 4.0, as it only accepts `false` since 3.0. // Set to true to enable using route placeholders as lookup criteria when the primary key doesn't match the argument name // Default: false
+ *             evict_cache?: bool|Param, // Set to true to fetch the entity from the database instead of using the cache, if any // Default: false
  *         },
  *         entity_managers?: array<string, array{ // Default: []
  *             query_cache_driver?: string|array{
- *                 type?: scalar|null, // Default: null
- *                 id?: scalar|null,
- *                 pool?: scalar|null,
+ *                 type?: scalar|Param|null, // Default: null
+ *                 id?: scalar|Param|null,
+ *                 pool?: scalar|Param|null,
  *             },
  *             metadata_cache_driver?: string|array{
- *                 type?: scalar|null, // Default: null
- *                 id?: scalar|null,
- *                 pool?: scalar|null,
+ *                 type?: scalar|Param|null, // Default: null
+ *                 id?: scalar|Param|null,
+ *                 pool?: scalar|Param|null,
  *             },
  *             result_cache_driver?: string|array{
- *                 type?: scalar|null, // Default: null
- *                 id?: scalar|null,
- *                 pool?: scalar|null,
+ *                 type?: scalar|Param|null, // Default: null
+ *                 id?: scalar|Param|null,
+ *                 pool?: scalar|Param|null,
  *             },
  *             entity_listeners?: array{
  *                 entities?: array<string, array{ // Default: []
  *                     listeners?: array<string, array{ // Default: []
  *                         events?: list<array{ // Default: []
- *                             type?: scalar|null,
- *                             method?: scalar|null, // Default: null
+ *                             type?: scalar|Param|null,
+ *                             method?: scalar|Param|null, // Default: null
  *                         }>,
  *                     }>,
  *                 }>,
  *             },
- *             connection?: scalar|null,
- *             class_metadata_factory_name?: scalar|null, // Default: "Doctrine\\ORM\\Mapping\\ClassMetadataFactory"
- *             default_repository_class?: scalar|null, // Default: "Doctrine\\ORM\\EntityRepository"
- *             auto_mapping?: scalar|null, // Default: false
- *             naming_strategy?: scalar|null, // Default: "doctrine.orm.naming_strategy.default"
- *             quote_strategy?: scalar|null, // Default: "doctrine.orm.quote_strategy.default"
- *             typed_field_mapper?: scalar|null, // Default: "doctrine.orm.typed_field_mapper.default"
- *             entity_listener_resolver?: scalar|null, // Default: null
- *             fetch_mode_subselect_batch_size?: scalar|null,
- *             repository_factory?: scalar|null, // Default: "doctrine.orm.container_repository_factory"
- *             schema_ignore_classes?: list<scalar|null>,
- *             report_fields_where_declared?: bool, // Set to "true" to opt-in to the new mapping driver mode that was added in Doctrine ORM 2.16 and will be mandatory in ORM 3.0. See https://github.com/doctrine/orm/pull/10455. // Default: true
- *             validate_xml_mapping?: bool, // Set to "true" to opt-in to the new mapping driver mode that was added in Doctrine ORM 2.14. See https://github.com/doctrine/orm/pull/6728. // Default: false
+ *             connection?: scalar|Param|null,
+ *             class_metadata_factory_name?: scalar|Param|null, // Default: "Doctrine\\ORM\\Mapping\\ClassMetadataFactory"
+ *             default_repository_class?: scalar|Param|null, // Default: "Doctrine\\ORM\\EntityRepository"
+ *             auto_mapping?: scalar|Param|null, // Default: false
+ *             naming_strategy?: scalar|Param|null, // Default: "doctrine.orm.naming_strategy.default"
+ *             quote_strategy?: scalar|Param|null, // Default: "doctrine.orm.quote_strategy.default"
+ *             typed_field_mapper?: scalar|Param|null, // Default: "doctrine.orm.typed_field_mapper.default"
+ *             entity_listener_resolver?: scalar|Param|null, // Default: null
+ *             fetch_mode_subselect_batch_size?: scalar|Param|null,
+ *             repository_factory?: scalar|Param|null, // Default: "doctrine.orm.container_repository_factory"
+ *             schema_ignore_classes?: list<scalar|Param|null>,
+ *             validate_xml_mapping?: bool|Param, // Set to "true" to opt-in to the new mapping driver mode that was added in Doctrine ORM 2.14 and will be mandatory in ORM 3.0. See https://github.com/doctrine/orm/pull/6728. // Default: false
  *             second_level_cache?: array{
  *                 region_cache_driver?: string|array{
- *                     type?: scalar|null, // Default: null
- *                     id?: scalar|null,
- *                     pool?: scalar|null,
+ *                     type?: scalar|Param|null, // Default: null
+ *                     id?: scalar|Param|null,
+ *                     pool?: scalar|Param|null,
  *                 },
- *                 region_lock_lifetime?: scalar|null, // Default: 60
- *                 log_enabled?: bool, // Default: true
- *                 region_lifetime?: scalar|null, // Default: 3600
- *                 enabled?: bool, // Default: true
- *                 factory?: scalar|null,
+ *                 region_lock_lifetime?: scalar|Param|null, // Default: 60
+ *                 log_enabled?: bool|Param, // Default: true
+ *                 region_lifetime?: scalar|Param|null, // Default: 3600
+ *                 enabled?: bool|Param, // Default: true
+ *                 factory?: scalar|Param|null,
  *                 regions?: array<string, array{ // Default: []
  *                     cache_driver?: string|array{
- *                         type?: scalar|null, // Default: null
- *                         id?: scalar|null,
- *                         pool?: scalar|null,
+ *                         type?: scalar|Param|null, // Default: null
+ *                         id?: scalar|Param|null,
+ *                         pool?: scalar|Param|null,
  *                     },
- *                     lock_path?: scalar|null, // Default: "%kernel.cache_dir%/doctrine/orm/slc/filelock"
- *                     lock_lifetime?: scalar|null, // Default: 60
- *                     type?: scalar|null, // Default: "default"
- *                     lifetime?: scalar|null, // Default: 0
- *                     service?: scalar|null,
- *                     name?: scalar|null,
+ *                     lock_path?: scalar|Param|null, // Default: "%kernel.cache_dir%/doctrine/orm/slc/filelock"
+ *                     lock_lifetime?: scalar|Param|null, // Default: 60
+ *                     type?: scalar|Param|null, // Default: "default"
+ *                     lifetime?: scalar|Param|null, // Default: 0
+ *                     service?: scalar|Param|null,
+ *                     name?: scalar|Param|null,
  *                 }>,
  *                 loggers?: array<string, array{ // Default: []
- *                     name?: scalar|null,
- *                     service?: scalar|null,
+ *                     name?: scalar|Param|null,
+ *                     service?: scalar|Param|null,
  *                 }>,
  *             },
- *             hydrators?: array<string, scalar|null>,
+ *             hydrators?: array<string, scalar|Param|null>,
  *             mappings?: array<string, bool|string|array{ // Default: []
- *                 mapping?: scalar|null, // Default: true
- *                 type?: scalar|null,
- *                 dir?: scalar|null,
- *                 alias?: scalar|null,
- *                 prefix?: scalar|null,
- *                 is_bundle?: bool,
+ *                 mapping?: scalar|Param|null, // Default: true
+ *                 type?: scalar|Param|null,
+ *                 dir?: scalar|Param|null,
+ *                 alias?: scalar|Param|null,
+ *                 prefix?: scalar|Param|null,
+ *                 is_bundle?: bool|Param,
  *             }>,
  *             dql?: array{
- *                 string_functions?: array<string, scalar|null>,
- *                 numeric_functions?: array<string, scalar|null>,
- *                 datetime_functions?: array<string, scalar|null>,
+ *                 string_functions?: array<string, scalar|Param|null>,
+ *                 numeric_functions?: array<string, scalar|Param|null>,
+ *                 datetime_functions?: array<string, scalar|Param|null>,
  *             },
  *             filters?: array<string, string|array{ // Default: []
- *                 class: scalar|null,
- *                 enabled?: bool, // Default: false
+ *                 class?: scalar|Param|null,
+ *                 enabled?: bool|Param, // Default: false
  *                 parameters?: array<string, mixed>,
  *             }>,
- *             identity_generation_preferences?: array<string, scalar|null>,
+ *             identity_generation_preferences?: array<string, scalar|Param|null>,
  *         }>,
- *         resolve_target_entities?: array<string, scalar|null>,
+ *         resolve_target_entities?: array<string, scalar|Param|null>,
  *     },
  * }
  * @psalm-type DoctrineMigrationsConfig = array{
- *     enable_service_migrations?: bool, // Whether to enable fetching migrations from the service container. // Default: false
- *     migrations_paths?: array<string, scalar|null>,
- *     services?: array<string, scalar|null>,
- *     factories?: array<string, scalar|null>,
+ *     enable_service_migrations?: bool|Param, // Whether to enable fetching migrations from the service container. // Default: false
+ *     migrations_paths?: array<string, scalar|Param|null>,
+ *     services?: array<string, scalar|Param|null>,
+ *     factories?: array<string, scalar|Param|null>,
  *     storage?: array{ // Storage to use for migration status metadata.
  *         table_storage?: array{ // The default metadata storage, implemented as a table in the database.
- *             table_name?: scalar|null, // Default: null
- *             version_column_name?: scalar|null, // Default: null
- *             version_column_length?: scalar|null, // Default: null
- *             executed_at_column_name?: scalar|null, // Default: null
- *             execution_time_column_name?: scalar|null, // Default: null
+ *             table_name?: scalar|Param|null, // Default: null
+ *             version_column_name?: scalar|Param|null, // Default: null
+ *             version_column_length?: scalar|Param|null, // Default: null
+ *             executed_at_column_name?: scalar|Param|null, // Default: null
+ *             execution_time_column_name?: scalar|Param|null, // Default: null
  *         },
  *     },
- *     migrations?: list<scalar|null>,
- *     connection?: scalar|null, // Connection name to use for the migrations database. // Default: null
- *     em?: scalar|null, // Entity manager name to use for the migrations database (available when doctrine/orm is installed). // Default: null
- *     all_or_nothing?: scalar|null, // Run all migrations in a transaction. // Default: false
- *     check_database_platform?: scalar|null, // Adds an extra check in the generated migrations to allow execution only on the same platform as they were initially generated on. // Default: true
- *     custom_template?: scalar|null, // Custom template path for generated migration classes. // Default: null
- *     organize_migrations?: scalar|null, // Organize migrations mode. Possible values are: "BY_YEAR", "BY_YEAR_AND_MONTH", false // Default: false
- *     enable_profiler?: bool, // Whether or not to enable the profiler collector to calculate and visualize migration status. This adds some queries overhead. // Default: false
- *     transactional?: bool, // Whether or not to wrap migrations in a single transaction. // Default: true
+ *     migrations?: list<scalar|Param|null>,
+ *     connection?: scalar|Param|null, // Connection name to use for the migrations database. // Default: null
+ *     em?: scalar|Param|null, // Entity manager name to use for the migrations database (available when doctrine/orm is installed). // Default: null
+ *     all_or_nothing?: scalar|Param|null, // Run all migrations in a transaction. // Default: false
+ *     check_database_platform?: scalar|Param|null, // Adds an extra check in the generated migrations to allow execution only on the same platform as they were initially generated on. // Default: true
+ *     custom_template?: scalar|Param|null, // Custom template path for generated migration classes. // Default: null
+ *     organize_migrations?: scalar|Param|null, // Organize migrations mode. Possible values are: "BY_YEAR", "BY_YEAR_AND_MONTH", false // Default: false
+ *     enable_profiler?: bool|Param, // Whether or not to enable the profiler collector to calculate and visualize migration status. This adds some queries overhead. // Default: false
+ *     transactional?: bool|Param, // Whether or not to wrap migrations in a single transaction. // Default: true
  * }
  * @psalm-type NelmioCorsConfig = array{
  *     defaults?: array{
- *         allow_credentials?: bool, // Default: false
- *         allow_origin?: list<scalar|null>,
- *         allow_headers?: list<scalar|null>,
- *         allow_methods?: list<scalar|null>,
- *         allow_private_network?: bool, // Default: false
- *         expose_headers?: list<scalar|null>,
- *         max_age?: scalar|null, // Default: 0
- *         hosts?: list<scalar|null>,
- *         origin_regex?: bool, // Default: false
- *         forced_allow_origin_value?: scalar|null, // Default: null
- *         skip_same_as_origin?: bool, // Default: true
+ *         allow_credentials?: bool|Param, // Default: false
+ *         allow_origin?: list<scalar|Param|null>,
+ *         allow_headers?: list<scalar|Param|null>,
+ *         allow_methods?: list<scalar|Param|null>,
+ *         allow_private_network?: bool|Param, // Default: false
+ *         expose_headers?: list<scalar|Param|null>,
+ *         max_age?: scalar|Param|null, // Default: 0
+ *         hosts?: list<scalar|Param|null>,
+ *         origin_regex?: bool|Param, // Default: false
+ *         forced_allow_origin_value?: scalar|Param|null, // Default: null
+ *         skip_same_as_origin?: bool|Param, // Default: true
  *     },
  *     paths?: array<string, array{ // Default: []
- *         allow_credentials?: bool,
- *         allow_origin?: list<scalar|null>,
- *         allow_headers?: list<scalar|null>,
- *         allow_methods?: list<scalar|null>,
- *         allow_private_network?: bool,
- *         expose_headers?: list<scalar|null>,
- *         max_age?: scalar|null, // Default: 0
- *         hosts?: list<scalar|null>,
- *         origin_regex?: bool,
- *         forced_allow_origin_value?: scalar|null, // Default: null
- *         skip_same_as_origin?: bool,
+ *         allow_credentials?: bool|Param,
+ *         allow_origin?: list<scalar|Param|null>,
+ *         allow_headers?: list<scalar|Param|null>,
+ *         allow_methods?: list<scalar|Param|null>,
+ *         allow_private_network?: bool|Param,
+ *         expose_headers?: list<scalar|Param|null>,
+ *         max_age?: scalar|Param|null, // Default: 0
+ *         hosts?: list<scalar|Param|null>,
+ *         origin_regex?: bool|Param,
+ *         forced_allow_origin_value?: scalar|Param|null, // Default: null
+ *         skip_same_as_origin?: bool|Param,
  *     }>,
  * }
  * @psalm-type ApiPlatformConfig = array{
- *     title?: scalar|null, // The title of the API. // Default: ""
- *     description?: scalar|null, // The description of the API. // Default: ""
- *     version?: scalar|null, // The version of the API. // Default: "0.0.0"
- *     show_webby?: bool, // If true, show Webby on the documentation page // Default: true
- *     event_listeners_backward_compatibility_layer?: bool|null, // If true API Platform uses Symfony event listeners instead of providers and processors. // Default: null
- *     use_deprecated_json_schema_type_factory?: bool|null, // Use the deprecated type factory, this option will be removed in 4.0. // Default: null
- *     use_symfony_listeners?: bool|null, // Uses Symfony event listeners instead of the ApiPlatform\Symfony\Controller\MainController. // Default: null
- *     name_converter?: scalar|null, // Specify a name converter to use. // Default: null
- *     asset_package?: scalar|null, // Specify an asset package name to use. // Default: null
- *     path_segment_name_generator?: scalar|null, // Specify a path name generator to use. // Default: "api_platform.metadata.path_segment_name_generator.underscore"
- *     inflector?: scalar|null, // Specify an inflector to use. // Default: "api_platform.metadata.inflector"
+ *     title?: scalar|Param|null, // The title of the API. // Default: ""
+ *     description?: scalar|Param|null, // The description of the API. // Default: ""
+ *     version?: scalar|Param|null, // The version of the API. // Default: "0.0.0"
+ *     show_webby?: bool|Param, // If true, show Webby on the documentation page // Default: true
+ *     use_symfony_listeners?: bool|Param, // Uses Symfony event listeners instead of the ApiPlatform\Symfony\Controller\MainController. // Default: false
+ *     name_converter?: scalar|Param|null, // Specify a name converter to use. // Default: null
+ *     asset_package?: scalar|Param|null, // Specify an asset package name to use. // Default: null
+ *     path_segment_name_generator?: scalar|Param|null, // Specify a path name generator to use. // Default: "api_platform.metadata.path_segment_name_generator.underscore"
+ *     inflector?: scalar|Param|null, // Specify an inflector to use. // Default: "api_platform.metadata.inflector"
  *     validator?: array{
  *         serialize_payload_fields?: mixed, // Set to null to serialize all payload fields when a validation error is thrown, or set the fields you want to include explicitly. // Default: []
- *         query_parameter_validation?: bool, // Default: true
- *         legacy_validation_exception?: bool, // Uses the legacy "%s" instead of "%s". // Default: true
- *         legacy_query_parameter_validation?: bool, // Use the legacy query validation system. // Default: true
+ *         query_parameter_validation?: bool|Param, // Deprecated: Will be removed in API Platform 5.0. // Default: true
+ *     },
+ *     jsonapi?: array{
+ *         use_iri_as_id?: bool|Param, // Set to false to use entity identifiers instead of IRIs as the "id" field in JSON:API responses. // Default: true
  *     },
  *     eager_loading?: bool|array{
- *         enabled?: bool, // Default: true
- *         fetch_partial?: bool, // Fetch only partial data according to serialization groups. If enabled, Doctrine ORM entities will not work as expected if any of the other fields are used. // Default: false
- *         max_joins?: int, // Max number of joined relations before EagerLoading throws a RuntimeException // Default: 30
- *         force_eager?: bool, // Force join on every relation. If disabled, it will only join relations having the EAGER fetch mode. // Default: true
+ *         enabled?: bool|Param, // Default: true
+ *         fetch_partial?: bool|Param, // Fetch only partial data according to serialization groups. If enabled, Doctrine ORM entities will not work as expected if any of the other fields are used. // Default: false
+ *         max_joins?: int|Param, // Max number of joined relations before EagerLoading throws a RuntimeException // Default: 30
+ *         force_eager?: bool|Param, // Force join on every relation. If disabled, it will only join relations having the EAGER fetch mode. // Default: true
  *     },
- *     handle_symfony_errors?: bool, // Allows to handle symfony exceptions. // Default: false
- *     enable_swagger?: bool, // Enable the Swagger documentation and export. // Default: true
- *     enable_swagger_ui?: bool, // Enable Swagger UI // Default: true
- *     enable_re_doc?: bool, // Enable ReDoc // Default: true
- *     enable_entrypoint?: bool, // Enable the entrypoint // Default: true
- *     enable_docs?: bool, // Enable the docs // Default: true
- *     enable_profiler?: bool, // Enable the data collector and the WebProfilerBundle integration. // Default: true
- *     keep_legacy_inflector?: bool, // Keep doctrine/inflector instead of symfony/string to generate plurals for routes. // Default: true
- *     enable_link_security?: bool, // Enable security for Links (sub resources) // Default: false
+ *     handle_symfony_errors?: bool|Param, // Allows to handle symfony exceptions. // Default: false
+ *     enable_swagger?: bool|Param, // Enable the Swagger documentation and export. // Default: true
+ *     enable_json_streamer?: bool|Param, // Enable json streamer. // Default: false
+ *     enable_swagger_ui?: bool|Param, // Enable Swagger UI // Default: true
+ *     enable_re_doc?: bool|Param, // Enable ReDoc // Default: true
+ *     enable_scalar?: bool|Param, // Enable Scalar API Reference // Default: true
+ *     enable_entrypoint?: bool|Param, // Enable the entrypoint // Default: true
+ *     enable_docs?: bool|Param, // Enable the docs // Default: true
+ *     enable_profiler?: bool|Param, // Enable the data collector and the WebProfilerBundle integration. // Default: true
+ *     enable_phpdoc_parser?: bool|Param, // Enable resource metadata collector using PHPStan PhpDocParser. // Default: true
+ *     enable_link_security?: bool|Param, // Deprecated: This option is always enabled and will be removed in API Platform 5.0. // Enable security for Links (sub resources). // Default: true
  *     collection?: array{
- *         exists_parameter_name?: scalar|null, // The name of the query parameter to filter on nullable field values. // Default: "exists"
- *         order?: scalar|null, // The default order of results. // Default: "ASC"
- *         order_parameter_name?: scalar|null, // The name of the query parameter to order results. // Default: "order"
- *         order_nulls_comparison?: "nulls_smallest"|"nulls_largest"|"nulls_always_first"|"nulls_always_last"|null, // The nulls comparison strategy. // Default: null
+ *         exists_parameter_name?: scalar|Param|null, // The name of the query parameter to filter on nullable field values. // Default: "exists"
+ *         order?: scalar|Param|null, // The default order of results. // Default: "ASC"
+ *         order_parameter_name?: scalar|Param|null, // The name of the query parameter to order results. // Default: "order"
+ *         order_nulls_comparison?: "nulls_smallest"|"nulls_largest"|"nulls_always_first"|"nulls_always_last"|Param|null, // The nulls comparison strategy. // Default: null
  *         pagination?: bool|array{
- *             enabled?: bool, // Default: true
- *             page_parameter_name?: scalar|null, // The default name of the parameter handling the page number. // Default: "page"
- *             enabled_parameter_name?: scalar|null, // The name of the query parameter to enable or disable pagination. // Default: "pagination"
- *             items_per_page_parameter_name?: scalar|null, // The name of the query parameter to set the number of items per page. // Default: "itemsPerPage"
- *             partial_parameter_name?: scalar|null, // The name of the query parameter to enable or disable partial pagination. // Default: "partial"
+ *             enabled?: bool|Param, // Default: true
+ *             page_parameter_name?: scalar|Param|null, // The default name of the parameter handling the page number. // Default: "page"
+ *             enabled_parameter_name?: scalar|Param|null, // The name of the query parameter to enable or disable pagination. // Default: "pagination"
+ *             items_per_page_parameter_name?: scalar|Param|null, // The name of the query parameter to set the number of items per page. // Default: "itemsPerPage"
+ *             partial_parameter_name?: scalar|Param|null, // The name of the query parameter to enable or disable partial pagination. // Default: "partial"
  *         },
  *     },
  *     mapping?: array{
- *         paths?: list<scalar|null>,
+ *         imports?: list<scalar|Param|null>,
+ *         paths?: list<scalar|Param|null>,
  *     },
- *     resource_class_directories?: list<scalar|null>,
+ *     resource_class_directories?: list<scalar|Param|null>,
  *     serializer?: array{
- *         hydra_prefix?: bool|null, // Use the "hydra:" prefix. // Default: null
+ *         hydra_prefix?: bool|Param, // Use the "hydra:" prefix. // Default: false
  *     },
  *     doctrine?: bool|array{
- *         enabled?: bool, // Default: true
+ *         enabled?: bool|Param, // Default: true
  *     },
  *     doctrine_mongodb_odm?: bool|array{
- *         enabled?: bool, // Default: false
+ *         enabled?: bool|Param, // Default: false
  *     },
  *     oauth?: bool|array{
- *         enabled?: bool, // Default: false
- *         clientId?: scalar|null, // The oauth client id. // Default: ""
- *         clientSecret?: scalar|null, // The OAuth client secret. Never use this parameter in your production environment. It exposes crucial security information. This feature is intended for dev/test environments only. Enable "oauth.pkce" instead // Default: ""
- *         pkce?: bool, // Enable the oauth PKCE. // Default: false
- *         type?: scalar|null, // The oauth type. // Default: "oauth2"
- *         flow?: scalar|null, // The oauth flow grant type. // Default: "application"
- *         tokenUrl?: scalar|null, // The oauth token url. // Default: ""
- *         authorizationUrl?: scalar|null, // The oauth authentication url. // Default: ""
- *         refreshUrl?: scalar|null, // The oauth refresh url. // Default: ""
- *         scopes?: list<scalar|null>,
+ *         enabled?: bool|Param, // Default: false
+ *         clientId?: scalar|Param|null, // The oauth client id. // Default: ""
+ *         clientSecret?: scalar|Param|null, // The OAuth client secret. Never use this parameter in your production environment. It exposes crucial security information. This feature is intended for dev/test environments only. Enable "oauth.pkce" instead // Default: ""
+ *         pkce?: bool|Param, // Enable the oauth PKCE. // Default: false
+ *         type?: scalar|Param|null, // The oauth type. // Default: "oauth2"
+ *         flow?: scalar|Param|null, // The oauth flow grant type. // Default: "application"
+ *         tokenUrl?: scalar|Param|null, // The oauth token url. // Default: ""
+ *         authorizationUrl?: scalar|Param|null, // The oauth authentication url. // Default: ""
+ *         refreshUrl?: scalar|Param|null, // The oauth refresh url. // Default: ""
+ *         scopes?: list<scalar|Param|null>,
  *     },
  *     graphql?: bool|array{
- *         enabled?: bool, // Default: false
- *         default_ide?: scalar|null, // Default: "graphiql"
+ *         enabled?: bool|Param, // Default: false
+ *         default_ide?: scalar|Param|null, // Default: "graphiql"
  *         graphiql?: bool|array{
- *             enabled?: bool, // Default: false
- *         },
- *         graphql_playground?: bool|array{
- *             enabled?: bool, // Default: false
+ *             enabled?: bool|Param, // Default: false
  *         },
  *         introspection?: bool|array{
- *             enabled?: bool, // Default: true
+ *             enabled?: bool|Param, // Default: true
  *         },
- *         nesting_separator?: scalar|null, // The separator to use to filter nested fields. // Default: "_"
+ *         max_query_depth?: int|Param, // Default: 20
+ *         graphql_playground?: bool|array{ // Deprecated: The "graphql_playground" configuration is deprecated and will be ignored.
+ *             enabled?: bool|Param, // Default: false
+ *         },
+ *         max_query_complexity?: int|Param, // Default: 500
+ *         nesting_separator?: scalar|Param|null, // The separator to use to filter nested fields. // Default: "_"
  *         collection?: array{
  *             pagination?: bool|array{
- *                 enabled?: bool, // Default: true
+ *                 enabled?: bool|Param, // Default: true
  *             },
  *         },
  *     },
  *     swagger?: array{
- *         versions?: list<scalar|null>,
+ *         persist_authorization?: bool|Param, // Persist the SwaggerUI Authorization in the localStorage. // Default: false
+ *         versions?: list<scalar|Param|null>,
  *         api_keys?: array<string, array{ // Default: []
- *             name?: scalar|null, // The name of the header or query parameter containing the api key.
- *             type?: "query"|"header", // Whether the api key should be a query parameter or a header.
+ *             name?: scalar|Param|null, // The name of the header or query parameter containing the api key.
+ *             type?: "query"|"header"|Param, // Whether the api key should be a query parameter or a header.
+ *         }>,
+ *         http_auth?: array<string, array{ // Default: []
+ *             scheme?: scalar|Param|null, // The OpenAPI HTTP auth scheme, for example "bearer"
+ *             bearerFormat?: scalar|Param|null, // The OpenAPI HTTP bearer format
  *         }>,
  *         swagger_ui_extra_configuration?: mixed, // To pass extra configuration to Swagger UI, like docExpansion or filter. // Default: []
  *     },
  *     http_cache?: array{
- *         public?: bool|null, // To make all responses public by default. // Default: null
+ *         public?: bool|Param|null, // To make all responses public by default. // Default: null
  *         invalidation?: bool|array{ // Enable the tags-based cache invalidation system.
- *             enabled?: bool, // Default: false
- *             varnish_urls?: list<scalar|null>,
- *             urls?: list<scalar|null>,
- *             scoped_clients?: list<scalar|null>,
- *             max_header_length?: int, // Max header length supported by the cache server. // Default: 7500
+ *             enabled?: bool|Param, // Default: false
+ *             varnish_urls?: list<scalar|Param|null>,
+ *             urls?: list<scalar|Param|null>,
+ *             scoped_clients?: list<scalar|Param|null>,
+ *             max_header_length?: int|Param, // Max header length supported by the cache server. // Default: 7500
  *             request_options?: mixed, // To pass options to the client charged with the request. // Default: []
- *             purger?: scalar|null, // Specify a purger to use (available values: "api_platform.http_cache.purger.varnish.ban", "api_platform.http_cache.purger.varnish.xkey", "api_platform.http_cache.purger.souin"). // Default: "api_platform.http_cache.purger.varnish"
- *             xkey?: array{ // Deprecated: The "xkey" configuration is deprecated, use your own purger to customize surrogate keys or the appropriate paramters.
- *                 glue?: scalar|null, // xkey glue between keys // Default: " "
+ *             purger?: scalar|Param|null, // Specify a purger to use (available values: "api_platform.http_cache.purger.varnish.ban", "api_platform.http_cache.purger.varnish.xkey", "api_platform.http_cache.purger.souin"). // Default: "api_platform.http_cache.purger.varnish"
+ *             xkey?: array{ // Deprecated: The "xkey" configuration is deprecated, use your own purger to customize surrogate keys or the appropriate parameters.
+ *                 glue?: scalar|Param|null, // xkey glue between keys // Default: " "
  *             },
  *         },
  *     },
  *     mercure?: bool|array{
- *         enabled?: bool, // Default: false
- *         hub_url?: scalar|null, // The URL sent in the Link HTTP header. If not set, will default to the URL for MercureBundle's default hub. // Default: null
- *         include_type?: bool, // Always include @type in updates (including delete ones). // Default: false
+ *         enabled?: bool|Param, // Default: false
+ *         hub_url?: scalar|Param|null, // The URL sent in the Link HTTP header. If not set, will default to the URL for MercureBundle's default hub. // Default: null
+ *         include_type?: bool|Param, // Always include @type in updates (including delete ones). // Default: false
  *     },
  *     messenger?: bool|array{
- *         enabled?: bool, // Default: true
+ *         enabled?: bool|Param, // Default: true
  *     },
  *     elasticsearch?: bool|array{
- *         enabled?: bool, // Default: false
- *         hosts?: list<scalar|null>,
- *         mapping?: array<string, array{ // Default: []
- *             index?: scalar|null, // Default: null
- *             type?: scalar|null, // Default: "_doc"
- *         }>,
+ *         enabled?: bool|Param, // Default: false
+ *         hosts?: list<scalar|Param|null>,
+ *         ssl_ca_bundle?: scalar|Param|null, // Path to the SSL CA bundle file for Elasticsearch SSL verification. // Default: null
+ *         ssl_verification?: bool|Param, // Enable or disable SSL verification for Elasticsearch connections. // Default: true
+ *         client?: "elasticsearch"|"opensearch"|Param, // The search engine client to use: "elasticsearch" or "opensearch". // Default: "elasticsearch"
  *     },
  *     openapi?: array{
  *         contact?: array{
- *             name?: scalar|null, // The identifying name of the contact person/organization. // Default: null
- *             url?: scalar|null, // The URL pointing to the contact information. MUST be in the format of a URL. // Default: null
- *             email?: scalar|null, // The email address of the contact person/organization. MUST be in the format of an email address. // Default: null
+ *             name?: scalar|Param|null, // The identifying name of the contact person/organization. // Default: null
+ *             url?: scalar|Param|null, // The URL pointing to the contact information. MUST be in the format of a URL. // Default: null
+ *             email?: scalar|Param|null, // The email address of the contact person/organization. MUST be in the format of an email address. // Default: null
  *         },
- *         termsOfService?: scalar|null, // A URL to the Terms of Service for the API. MUST be in the format of a URL. // Default: null
+ *         termsOfService?: scalar|Param|null, // A URL to the Terms of Service for the API. MUST be in the format of a URL. // Default: null
+ *         tags?: list<array{ // Default: []
+ *             name?: scalar|Param|null,
+ *             description?: scalar|Param|null, // Default: null
+ *         }>,
  *         license?: array{
- *             name?: scalar|null, // The license name used for the API. // Default: null
- *             url?: scalar|null, // URL to the license used for the API. MUST be in the format of a URL. // Default: null
+ *             name?: scalar|Param|null, // The license name used for the API. // Default: null
+ *             url?: scalar|Param|null, // URL to the license used for the API. MUST be in the format of a URL. // Default: null
+ *             identifier?: scalar|Param|null, // An SPDX license expression for the API. The identifier field is mutually exclusive of the url field. // Default: null
  *         },
  *         swagger_ui_extra_configuration?: mixed, // To pass extra configuration to Swagger UI, like docExpansion or filter. // Default: []
- *         overrideResponses?: bool, // Whether API Platform adds automatic responses to the OpenAPI documentation. // Default: true
+ *         scalar_extra_configuration?: mixed, // To pass extra configuration to Scalar API Reference, like theme or darkMode. // Default: []
+ *         overrideResponses?: bool|Param, // Whether API Platform adds automatic responses to the OpenAPI documentation. // Default: true
+ *         error_resource_class?: scalar|Param|null, // The class used to represent errors in the OpenAPI documentation. // Default: null
+ *         validation_error_resource_class?: scalar|Param|null, // The class used to represent validation errors in the OpenAPI documentation. // Default: null
  *     },
  *     maker?: bool|array{
- *         enabled?: bool, // Default: true
+ *         enabled?: bool|Param, // Default: true
+ *         namespace_prefix?: scalar|Param|null, // Add a prefix to all maker generated classes. e.g set it to "Api" to set the maker namespace to "App\Api\" (if the maker.root_namespace config is App). e.g. App\Api\State\MyStateProcessor // Default: ""
  *     },
- *     exception_to_status?: array<string, int>,
- *     formats?: array<string, array{ // Default: []
- *         mime_types?: list<scalar|null>,
+ *     mcp?: bool|array{
+ *         enabled?: bool|Param, // Default: true
+ *         format?: scalar|Param|null, // The serialization format used for MCP tool input/output. Must be a format registered in api_platform.formats (e.g. "jsonld", "json", "jsonapi"). // Default: "jsonld"
+ *     },
+ *     exception_to_status?: array<string, int|Param>,
+ *     formats?: array<string, array{ // Default: {"jsonld":{"mime_types":["application/ld+json"]}}
+ *         mime_types?: list<scalar|Param|null>,
  *     }>,
  *     patch_formats?: array<string, array{ // Default: {"json":{"mime_types":["application/merge-patch+json"]}}
- *         mime_types?: list<scalar|null>,
+ *         mime_types?: list<scalar|Param|null>,
  *     }>,
- *     docs_formats?: array<string, array{ // Default: {"jsonopenapi":{"mime_types":["application/vnd.openapi+json"]},"yamlopenapi":{"mime_types":["application/vnd.openapi+yaml"]},"json":{"mime_types":["application/json"]},"jsonld":{"mime_types":["application/ld+json"]},"html":{"mime_types":["text/html"]}}
- *         mime_types?: list<scalar|null>,
+ *     docs_formats?: array<string, array{ // Default: {"jsonld":{"mime_types":["application/ld+json"]},"jsonopenapi":{"mime_types":["application/vnd.openapi+json"]},"html":{"mime_types":["text/html"]},"yamlopenapi":{"mime_types":["application/vnd.openapi+yaml"]}}
+ *         mime_types?: list<scalar|Param|null>,
  *     }>,
  *     error_formats?: array<string, array{ // Default: {"jsonld":{"mime_types":["application/ld+json"]},"jsonproblem":{"mime_types":["application/problem+json"]},"json":{"mime_types":["application/problem+json","application/json"]}}
- *         mime_types?: list<scalar|null>,
+ *         mime_types?: list<scalar|Param|null>,
  *     }>,
- *     jsonschema_formats?: list<scalar|null>,
+ *     jsonschema_formats?: list<scalar|Param|null>,
  *     defaults?: array{
  *         uri_template?: mixed,
  *         short_name?: mixed,
@@ -1504,11 +1471,9 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
  *         denormalization_context?: mixed,
  *         collect_denormalization_errors?: mixed,
  *         hydra_context?: mixed,
- *         openapi_context?: mixed,
  *         openapi?: mixed,
  *         validation_context?: mixed,
  *         filters?: mixed,
- *         elasticsearch?: mixed,
  *         mercure?: mixed,
  *         messenger?: mixed,
  *         input?: mixed,
@@ -1541,8 +1506,40 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
  *         provider?: mixed,
  *         processor?: mixed,
  *         state_options?: mixed,
- *         parameters?: mixed,
+ *         rules?: mixed,
+ *         policy?: mixed,
+ *         middleware?: mixed,
+ *         parameters?: array<string, array{ // Default: []
+ *             key?: mixed,
+ *             schema?: mixed,
+ *             open_api?: mixed,
+ *             provider?: mixed,
+ *             filter?: mixed,
+ *             property?: mixed,
+ *             description?: mixed,
+ *             properties?: mixed,
+ *             required?: mixed,
+ *             priority?: mixed,
+ *             hydra?: mixed,
+ *             constraints?: mixed,
+ *             security?: mixed,
+ *             security_message?: mixed,
+ *             extra_properties?: mixed,
+ *             filter_context?: mixed,
+ *             native_type?: mixed,
+ *             cast_to_array?: mixed,
+ *             cast_to_native_type?: mixed,
+ *             cast_fn?: mixed,
+ *             default?: mixed,
+ *             filter_class?: mixed,
+ *             ...<string, mixed>
+ *         }>,
+ *         strict_query_parameter_validation?: mixed,
+ *         hide_hydra_operation?: mixed,
+ *         json_stream?: mixed,
  *         extra_properties?: mixed,
+ *         map?: mixed,
+ *         mcp?: mixed,
  *         route_name?: mixed,
  *         errors?: mixed,
  *         read?: mixed,
@@ -1550,158 +1547,159 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
  *         validate?: mixed,
  *         write?: mixed,
  *         serialize?: mixed,
+ *         content_negotiation?: mixed,
  *         priority?: mixed,
  *         name?: mixed,
  *         allow_create?: mixed,
  *         item_uri_template?: mixed,
- *         ...<mixed>
+ *         ...<string, mixed>
  *     },
  * }
  * @psalm-type MakerConfig = array{
- *     root_namespace?: scalar|null, // Default: "App"
- *     generate_final_classes?: bool, // Default: true
- *     generate_final_entities?: bool, // Default: false
+ *     root_namespace?: scalar|Param|null, // Default: "App"
+ *     generate_final_classes?: bool|Param, // Default: true
+ *     generate_final_entities?: bool|Param, // Default: false
  * }
  * @psalm-type MonologConfig = array{
- *     use_microseconds?: scalar|null, // Default: true
- *     channels?: list<scalar|null>,
+ *     use_microseconds?: scalar|Param|null, // Default: true
+ *     channels?: list<scalar|Param|null>,
  *     handlers?: array<string, array{ // Default: []
- *         type: scalar|null,
- *         id?: scalar|null,
- *         enabled?: bool, // Default: true
- *         priority?: scalar|null, // Default: 0
- *         level?: scalar|null, // Default: "DEBUG"
- *         bubble?: bool, // Default: true
- *         interactive_only?: bool, // Default: false
- *         app_name?: scalar|null, // Default: null
- *         include_stacktraces?: bool, // Default: false
+ *         type?: scalar|Param|null,
+ *         id?: scalar|Param|null,
+ *         enabled?: bool|Param, // Default: true
+ *         priority?: scalar|Param|null, // Default: 0
+ *         level?: scalar|Param|null, // Default: "DEBUG"
+ *         bubble?: bool|Param, // Default: true
+ *         interactive_only?: bool|Param, // Default: false
+ *         app_name?: scalar|Param|null, // Default: null
+ *         include_stacktraces?: bool|Param, // Default: false
  *         process_psr_3_messages?: array{
- *             enabled?: bool|null, // Default: null
- *             date_format?: scalar|null,
- *             remove_used_context_fields?: bool,
+ *             enabled?: bool|Param|null, // Default: null
+ *             date_format?: scalar|Param|null,
+ *             remove_used_context_fields?: bool|Param,
  *         },
- *         path?: scalar|null, // Default: "%kernel.logs_dir%/%kernel.environment%.log"
- *         file_permission?: scalar|null, // Default: null
- *         use_locking?: bool, // Default: false
- *         filename_format?: scalar|null, // Default: "{filename}-{date}"
- *         date_format?: scalar|null, // Default: "Y-m-d"
- *         ident?: scalar|null, // Default: false
- *         logopts?: scalar|null, // Default: 1
- *         facility?: scalar|null, // Default: "user"
- *         max_files?: scalar|null, // Default: 0
- *         action_level?: scalar|null, // Default: "WARNING"
- *         activation_strategy?: scalar|null, // Default: null
- *         stop_buffering?: bool, // Default: true
- *         passthru_level?: scalar|null, // Default: null
+ *         path?: scalar|Param|null, // Default: "%kernel.logs_dir%/%kernel.environment%.log"
+ *         file_permission?: scalar|Param|null, // Default: null
+ *         use_locking?: bool|Param, // Default: false
+ *         filename_format?: scalar|Param|null, // Default: "{filename}-{date}"
+ *         date_format?: scalar|Param|null, // Default: "Y-m-d"
+ *         ident?: scalar|Param|null, // Default: false
+ *         logopts?: scalar|Param|null, // Default: 1
+ *         facility?: scalar|Param|null, // Default: "user"
+ *         max_files?: scalar|Param|null, // Default: 0
+ *         action_level?: scalar|Param|null, // Default: "WARNING"
+ *         activation_strategy?: scalar|Param|null, // Default: null
+ *         stop_buffering?: bool|Param, // Default: true
+ *         passthru_level?: scalar|Param|null, // Default: null
  *         excluded_http_codes?: list<array{ // Default: []
- *             code?: scalar|null,
- *             urls?: list<scalar|null>,
+ *             code?: scalar|Param|null,
+ *             urls?: list<scalar|Param|null>,
  *         }>,
- *         accepted_levels?: list<scalar|null>,
- *         min_level?: scalar|null, // Default: "DEBUG"
- *         max_level?: scalar|null, // Default: "EMERGENCY"
- *         buffer_size?: scalar|null, // Default: 0
- *         flush_on_overflow?: bool, // Default: false
- *         handler?: scalar|null,
- *         url?: scalar|null,
- *         exchange?: scalar|null,
- *         exchange_name?: scalar|null, // Default: "log"
- *         channel?: scalar|null, // Default: null
- *         bot_name?: scalar|null, // Default: "Monolog"
- *         use_attachment?: scalar|null, // Default: true
- *         use_short_attachment?: scalar|null, // Default: false
- *         include_extra?: scalar|null, // Default: false
- *         icon_emoji?: scalar|null, // Default: null
- *         webhook_url?: scalar|null,
- *         exclude_fields?: list<scalar|null>,
- *         token?: scalar|null,
- *         region?: scalar|null,
- *         source?: scalar|null,
- *         use_ssl?: bool, // Default: true
+ *         accepted_levels?: list<scalar|Param|null>,
+ *         min_level?: scalar|Param|null, // Default: "DEBUG"
+ *         max_level?: scalar|Param|null, // Default: "EMERGENCY"
+ *         buffer_size?: scalar|Param|null, // Default: 0
+ *         flush_on_overflow?: bool|Param, // Default: false
+ *         handler?: scalar|Param|null,
+ *         url?: scalar|Param|null,
+ *         exchange?: scalar|Param|null,
+ *         exchange_name?: scalar|Param|null, // Default: "log"
+ *         channel?: scalar|Param|null, // Default: null
+ *         bot_name?: scalar|Param|null, // Default: "Monolog"
+ *         use_attachment?: scalar|Param|null, // Default: true
+ *         use_short_attachment?: scalar|Param|null, // Default: false
+ *         include_extra?: scalar|Param|null, // Default: false
+ *         icon_emoji?: scalar|Param|null, // Default: null
+ *         webhook_url?: scalar|Param|null,
+ *         exclude_fields?: list<scalar|Param|null>,
+ *         token?: scalar|Param|null,
+ *         region?: scalar|Param|null,
+ *         source?: scalar|Param|null,
+ *         use_ssl?: bool|Param, // Default: true
  *         user?: mixed,
- *         title?: scalar|null, // Default: null
- *         host?: scalar|null, // Default: null
- *         port?: scalar|null, // Default: 514
- *         config?: list<scalar|null>,
- *         members?: list<scalar|null>,
- *         connection_string?: scalar|null,
- *         timeout?: scalar|null,
- *         time?: scalar|null, // Default: 60
- *         deduplication_level?: scalar|null, // Default: 400
- *         store?: scalar|null, // Default: null
- *         connection_timeout?: scalar|null,
- *         persistent?: bool,
- *         message_type?: scalar|null, // Default: 0
- *         parse_mode?: scalar|null, // Default: null
- *         disable_webpage_preview?: bool|null, // Default: null
- *         disable_notification?: bool|null, // Default: null
- *         split_long_messages?: bool, // Default: false
- *         delay_between_messages?: bool, // Default: false
- *         topic?: int, // Default: null
- *         factor?: int, // Default: 1
- *         tags?: list<scalar|null>,
+ *         title?: scalar|Param|null, // Default: null
+ *         host?: scalar|Param|null, // Default: null
+ *         port?: scalar|Param|null, // Default: 514
+ *         config?: list<scalar|Param|null>,
+ *         members?: list<scalar|Param|null>,
+ *         connection_string?: scalar|Param|null,
+ *         timeout?: scalar|Param|null,
+ *         time?: scalar|Param|null, // Default: 60
+ *         deduplication_level?: scalar|Param|null, // Default: 400
+ *         store?: scalar|Param|null, // Default: null
+ *         connection_timeout?: scalar|Param|null,
+ *         persistent?: bool|Param,
+ *         message_type?: scalar|Param|null, // Default: 0
+ *         parse_mode?: scalar|Param|null, // Default: null
+ *         disable_webpage_preview?: bool|Param|null, // Default: null
+ *         disable_notification?: bool|Param|null, // Default: null
+ *         split_long_messages?: bool|Param, // Default: false
+ *         delay_between_messages?: bool|Param, // Default: false
+ *         topic?: int|Param, // Default: null
+ *         factor?: int|Param, // Default: 1
+ *         tags?: string|list<scalar|Param|null>,
  *         console_formatter_options?: mixed, // Default: []
- *         formatter?: scalar|null,
- *         nested?: bool, // Default: false
+ *         formatter?: scalar|Param|null,
+ *         nested?: bool|Param, // Default: false
  *         publisher?: string|array{
- *             id?: scalar|null,
- *             hostname?: scalar|null,
- *             port?: scalar|null, // Default: 12201
- *             chunk_size?: scalar|null, // Default: 1420
- *             encoder?: "json"|"compressed_json",
+ *             id?: scalar|Param|null,
+ *             hostname?: scalar|Param|null,
+ *             port?: scalar|Param|null, // Default: 12201
+ *             chunk_size?: scalar|Param|null, // Default: 1420
+ *             encoder?: "json"|"compressed_json"|Param,
  *         },
  *         mongodb?: string|array{
- *             id?: scalar|null, // ID of a MongoDB\Client service
- *             uri?: scalar|null,
- *             username?: scalar|null,
- *             password?: scalar|null,
- *             database?: scalar|null, // Default: "monolog"
- *             collection?: scalar|null, // Default: "logs"
+ *             id?: scalar|Param|null, // ID of a MongoDB\Client service
+ *             uri?: scalar|Param|null,
+ *             username?: scalar|Param|null,
+ *             password?: scalar|Param|null,
+ *             database?: scalar|Param|null, // Default: "monolog"
+ *             collection?: scalar|Param|null, // Default: "logs"
  *         },
  *         elasticsearch?: string|array{
- *             id?: scalar|null,
- *             hosts?: list<scalar|null>,
- *             host?: scalar|null,
- *             port?: scalar|null, // Default: 9200
- *             transport?: scalar|null, // Default: "Http"
- *             user?: scalar|null, // Default: null
- *             password?: scalar|null, // Default: null
+ *             id?: scalar|Param|null,
+ *             hosts?: list<scalar|Param|null>,
+ *             host?: scalar|Param|null,
+ *             port?: scalar|Param|null, // Default: 9200
+ *             transport?: scalar|Param|null, // Default: "Http"
+ *             user?: scalar|Param|null, // Default: null
+ *             password?: scalar|Param|null, // Default: null
  *         },
- *         index?: scalar|null, // Default: "monolog"
- *         document_type?: scalar|null, // Default: "logs"
- *         ignore_error?: scalar|null, // Default: false
+ *         index?: scalar|Param|null, // Default: "monolog"
+ *         document_type?: scalar|Param|null, // Default: "logs"
+ *         ignore_error?: scalar|Param|null, // Default: false
  *         redis?: string|array{
- *             id?: scalar|null,
- *             host?: scalar|null,
- *             password?: scalar|null, // Default: null
- *             port?: scalar|null, // Default: 6379
- *             database?: scalar|null, // Default: 0
- *             key_name?: scalar|null, // Default: "monolog_redis"
+ *             id?: scalar|Param|null,
+ *             host?: scalar|Param|null,
+ *             password?: scalar|Param|null, // Default: null
+ *             port?: scalar|Param|null, // Default: 6379
+ *             database?: scalar|Param|null, // Default: 0
+ *             key_name?: scalar|Param|null, // Default: "monolog_redis"
  *         },
  *         predis?: string|array{
- *             id?: scalar|null,
- *             host?: scalar|null,
+ *             id?: scalar|Param|null,
+ *             host?: scalar|Param|null,
  *         },
- *         from_email?: scalar|null,
- *         to_email?: list<scalar|null>,
- *         subject?: scalar|null,
- *         content_type?: scalar|null, // Default: null
- *         headers?: list<scalar|null>,
- *         mailer?: scalar|null, // Default: null
+ *         from_email?: scalar|Param|null,
+ *         to_email?: string|list<scalar|Param|null>,
+ *         subject?: scalar|Param|null,
+ *         content_type?: scalar|Param|null, // Default: null
+ *         headers?: list<scalar|Param|null>,
+ *         mailer?: scalar|Param|null, // Default: null
  *         email_prototype?: string|array{
- *             id: scalar|null,
- *             method?: scalar|null, // Default: null
+ *             id?: scalar|Param|null,
+ *             method?: scalar|Param|null, // Default: null
  *         },
  *         verbosity_levels?: array{
- *             VERBOSITY_QUIET?: scalar|null, // Default: "ERROR"
- *             VERBOSITY_NORMAL?: scalar|null, // Default: "WARNING"
- *             VERBOSITY_VERBOSE?: scalar|null, // Default: "NOTICE"
- *             VERBOSITY_VERY_VERBOSE?: scalar|null, // Default: "INFO"
- *             VERBOSITY_DEBUG?: scalar|null, // Default: "DEBUG"
+ *             VERBOSITY_QUIET?: scalar|Param|null, // Default: "ERROR"
+ *             VERBOSITY_NORMAL?: scalar|Param|null, // Default: "WARNING"
+ *             VERBOSITY_VERBOSE?: scalar|Param|null, // Default: "NOTICE"
+ *             VERBOSITY_VERY_VERBOSE?: scalar|Param|null, // Default: "INFO"
+ *             VERBOSITY_DEBUG?: scalar|Param|null, // Default: "DEBUG"
  *         },
  *         channels?: string|array{
- *             type?: scalar|null,
- *             elements?: list<scalar|null>,
+ *             type?: scalar|Param|null,
+ *             elements?: list<scalar|Param|null>,
  *         },
  *     }>,
  * }
@@ -1774,7 +1772,10 @@ final class App
      */
     public static function config(array $config): array
     {
-        return AppReference::config($config);
+        /** @var ConfigType $config */
+        $config = AppReference::config($config);
+
+        return $config;
     }
 }
 

--- a/config/routes/framework.yaml
+++ b/config/routes/framework.yaml
@@ -1,4 +1,4 @@
 when@dev:
     _errors:
-        resource: '@FrameworkBundle/Resources/config/routing/errors.xml'
+        resource: '@FrameworkBundle/Resources/config/routing/errors.php'
         prefix: /_error

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -14,8 +14,8 @@ parameters:
     app.jwt.expired: '%env(JWT_TIMEOUT)%'
     app.jwt.issuer: '%env(default:jwt_iss_default:JWT_ISSUER)%'
     app.jwt.audience: '%env(default:jwt_aud_default:JWT_AUDIENCE)%'
-    jwt_iss_default: 'https://api-tx.sendmundo.com'
-    jwt_aud_default: 'https://dashboard.sendmundo.com'
+    jwt_iss_default: 'https://api.prod.comremit.com'
+    jwt_aud_default: 'https://dashboard.comremit.com'
     phrase_key: '%env(JWT_PHRASE_KEY)%'
 
 

--- a/docker-compose.vps.prod.yaml
+++ b/docker-compose.vps.prod.yaml
@@ -27,6 +27,7 @@ x-worker-base: &worker-base
     APP_MAILER_FROM: ${APP_MAILER_FROM}
     COMREMIT_DASHBOARD_URL: ${COMREMIT_DASHBOARD_URL}
     SENDMUNDO_DASHBOARD_URL: ${SENDMUNDO_DASHBOARD_URL}
+    SYS_CONFIG_ENCRYPTION_KEY: ${SYS_CONFIG_ENCRYPTION_KEY}
   depends_on:
     database:
       condition: service_healthy

--- a/docker-compose.vps.staging.yaml
+++ b/docker-compose.vps.staging.yaml
@@ -86,6 +86,7 @@ services:
       APP_MAILER_FROM: ${APP_MAILER_FROM}
       COMREMIT_DASHBOARD_URL: ${COMREMIT_DASHBOARD_URL}
       SENDMUNDO_DASHBOARD_URL: ${SENDMUNDO_DASHBOARD_URL}
+      SYS_CONFIG_ENCRYPTION_KEY: ${SYS_CONFIG_ENCRYPTION_KEY}
     depends_on:
       database:
         condition: service_healthy

--- a/docker-compose.vps.yaml
+++ b/docker-compose.vps.yaml
@@ -67,6 +67,7 @@ services:
       APP_MAILER_FROM: ${APP_MAILER_FROM}
       COMREMIT_DASHBOARD_URL: ${COMREMIT_DASHBOARD_URL}
       SENDMUNDO_DASHBOARD_URL: ${SENDMUNDO_DASHBOARD_URL}
+      SYS_CONFIG_ENCRYPTION_KEY: ${SYS_CONFIG_ENCRYPTION_KEY}
     depends_on:
       database:
         condition: service_healthy

--- a/docker/php-fpm/Dockerfile
+++ b/docker/php-fpm/Dockerfile
@@ -5,9 +5,11 @@ WORKDIR /app
 
 COPY composer.json composer.lock ./
 
-RUN composer install --no-scripts --no-autoloader --prefer-dist --no-progress --ignore-platform-reqs
+# ext-amqp is not present in the composer image but IS installed in php-base.
+# Only ignore that extension; let composer enforce the php>=8.4 requirement.
+RUN composer install --no-scripts --no-autoloader --prefer-dist --no-progress --ignore-platform-req=ext-amqp
 
-# Stage 2: PHP base (used for development)
+# Stage 2: PHP base (used for development) — requires PHP 8.4+
 FROM php:8.4-fpm-alpine AS php-base
 
 RUN apk add --no-cache \

--- a/migrations/Version20260512100000.php
+++ b/migrations/Version20260512100000.php
@@ -16,14 +16,60 @@ final class Version20260512100000 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        // DBAL 4 removes Types::ARRAY. The column was stored as PHP-serialized text.
-        // Converting to JSON: existing rows with serialized data must be migrated manually
-        // before running this migration, or the column must be empty.
-        $this->addSql('ALTER TABLE report_marked ALTER COLUMN data_array TYPE JSON USING data_array::json');
+        // Postgres cannot deserialize PHP's serialize() format, so we convert each row in PHP first.
+        $rows = $this->connection->fetchAllAssociative(
+            'SELECT id, data_array FROM report_marked WHERE data_array IS NOT NULL'
+        );
+
+        foreach ($rows as $row) {
+            $value = (string) $row['data_array'];
+
+            // Already valid JSON (idempotent re-run guard)
+            json_decode($value);
+            if (json_last_error() === JSON_ERROR_NONE) {
+                continue;
+            }
+
+            $decoded = @unserialize($value, ['allowed_classes' => false]);
+            $this->abortIf(
+                $decoded === false && $value !== 'b:0;',
+                sprintf('report_marked row #%d: data_array is neither valid PHP-serialized nor JSON — manual inspection required', $row['id'])
+            );
+
+            $this->connection->executeStatement(
+                'UPDATE report_marked SET data_array = :json WHERE id = :id',
+                ['json' => json_encode($decoded, JSON_UNESCAPED_UNICODE), 'id' => $row['id']]
+            );
+        }
+
+        // All non-null values are now valid JSON — safe to change the column type.
+        $this->connection->executeStatement(
+            'ALTER TABLE report_marked ALTER COLUMN data_array TYPE JSON USING data_array::json'
+        );
     }
 
     public function down(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE report_marked ALTER COLUMN data_array TYPE TEXT');
+        // Revert column type to TEXT first (JSON values become their text representation).
+        $this->connection->executeStatement(
+            'ALTER TABLE report_marked ALTER COLUMN data_array TYPE TEXT'
+        );
+
+        // Re-serialize JSON values back to PHP serialized format for symmetry.
+        $rows = $this->connection->fetchAllAssociative(
+            'SELECT id, data_array FROM report_marked WHERE data_array IS NOT NULL'
+        );
+
+        foreach ($rows as $row) {
+            $decoded = json_decode((string) $row['data_array'], true);
+            if ($decoded === null && json_last_error() !== JSON_ERROR_NONE) {
+                continue;
+            }
+
+            $this->connection->executeStatement(
+                'UPDATE report_marked SET data_array = :serialized WHERE id = :id',
+                ['serialized' => serialize($decoded), 'id' => $row['id']]
+            );
+        }
     }
 }

--- a/migrations/Version20260512100000.php
+++ b/migrations/Version20260512100000.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260512100000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Migrate report_marked.data_array column from PHP-serialized TEXT (DBAL Types::ARRAY) to JSON (DBAL Types::JSON)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // DBAL 4 removes Types::ARRAY. The column was stored as PHP-serialized text.
+        // Converting to JSON: existing rows with serialized data must be migrated manually
+        // before running this migration, or the column must be empty.
+        $this->addSql('ALTER TABLE report_marked ALTER COLUMN data_array TYPE JSON USING data_array::json');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE report_marked ALTER COLUMN data_array TYPE TEXT');
+    }
+}

--- a/migrations/Version20260515000000.php
+++ b/migrations/Version20260515000000.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260515000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add is_encrypted column to sys_config to support encrypted property values';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE sys_config
+                ADD COLUMN IF NOT EXISTS is_encrypted BOOLEAN NOT NULL DEFAULT FALSE
+        SQL);
+        // Drop the DB-level default — Doctrine manages it in PHP
+        $this->addSql('ALTER TABLE sys_config ALTER COLUMN is_encrypted DROP DEFAULT');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE sys_config DROP COLUMN IF EXISTS is_encrypted');
+    }
+}

--- a/src/ApiResource/Calculator.php
+++ b/src/ApiResource/Calculator.php
@@ -7,7 +7,7 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\Post;
 use App\State\CalculatorProcessor;
-use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[ApiResource(

--- a/src/ApiResource/RotateToken.php
+++ b/src/ApiResource/RotateToken.php
@@ -6,7 +6,7 @@ use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Post;
 use App\State\RotateTokenProcessor;
-use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Serializer\Attribute\Groups;
 
 #[ApiResource(
     operations: [

--- a/src/Command/DispatchPendingCommunicationsCommand.php
+++ b/src/Command/DispatchPendingCommunicationsCommand.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Command;
+
+use App\Exception\MyCurrentException;
+use App\Service\CommunicationsDispatchService;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:dispatch-pending-communications',
+    description: 'Encola en RabbitMQ las ventas que quedaron pendientes mientras el dispatch estaba deshabilitado.',
+)]
+class DispatchPendingCommunicationsCommand extends Command
+{
+    public function __construct(
+        private readonly CommunicationsDispatchService $dispatchService,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        try {
+            $result = $this->dispatchService->dispatchPending();
+        } catch (MyCurrentException $e) {
+            $io->error($e->getMessage());
+            return Command::FAILURE;
+        }
+
+        if ($result['total'] === 0) {
+            $io->success('No hay ventas pendientes de despacho.');
+            return Command::SUCCESS;
+        }
+
+        $io->success(sprintf(
+            'Despachadas %d recarga(s) y %d venta(s) de paquete. Total: %d.',
+            $result['recharges'],
+            $result['packages'],
+            $result['total'],
+        ));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Command/Etecsa/FetchBalanceCommand.php
+++ b/src/Command/Etecsa/FetchBalanceCommand.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Command\Etecsa;
+
+use App\Entity\Environment;
+use App\Repository\EnvironmentRepository;
+use App\Service\Etecsa\EtecsaGatewayClient;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:etecsa:fetch-balance',
+    description: 'Consulta el saldo disponible (CUP y USD) para un entorno ETECSA.',
+)]
+class FetchBalanceCommand extends Command
+{
+    public function __construct(
+        private readonly EtecsaGatewayClient $client,
+        private readonly EnvironmentRepository $environmentRepository,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption('environment-id', null, InputOption::VALUE_REQUIRED, 'ID del Environment a consultar');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $envId = (int) $input->getOption('environment-id');
+        $env = $this->environmentRepository->find($envId);
+
+        if (!$env instanceof Environment) {
+            $io->error("Environment con ID {$envId} no encontrado.");
+            return Command::FAILURE;
+        }
+
+        $balance = $this->client->getBalance($env);
+
+        $io->success("Saldo para entorno [{$env->getType()}] (ID {$env->getId()})");
+        $io->table(['Campo', 'Valor'], [
+            ['CUP', number_format($balance->cupAmount, 2)],
+            ['USD', number_format($balance->usdAmount, 2)],
+            ['Consultado', $balance->fetchedAt->format('Y-m-d H:i:s')],
+        ]);
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Command/Etecsa/SyncCatalogsCommand.php
+++ b/src/Command/Etecsa/SyncCatalogsCommand.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Command\Etecsa;
+
+use App\Entity\Environment;
+use App\Message\Etecsa\SyncCatalogsMessage;
+use App\MessageHandler\Etecsa\SyncCatalogsMessageHandler;
+use App\Repository\EnvironmentRepository;
+use App\Service\Etecsa\EtecsaCatalogSyncService;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+#[AsCommand(
+    name: 'app:etecsa:sync-catalogs',
+    description: 'Sincroniza los catálogos ETECSA (nationalities, provinces, offices) contra la BD local.',
+)]
+class SyncCatalogsCommand extends Command
+{
+    public function __construct(
+        private readonly EtecsaCatalogSyncService $syncService,
+        private readonly EnvironmentRepository $environmentRepository,
+        private readonly MessageBusInterface $bus,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption('environment-id', null, InputOption::VALUE_REQUIRED, 'ID del Environment a sincronizar');
+        $this->addOption('sync', null, InputOption::VALUE_NONE, 'Ejecutar de forma síncrona (sin messenger). Sin esta opción despacha el mensaje al bus.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $envId = (int) $input->getOption('environment-id');
+        $env = $this->environmentRepository->find($envId);
+
+        if (!$env instanceof Environment) {
+            $io->error("Environment con ID {$envId} no encontrado.");
+            return Command::FAILURE;
+        }
+
+        if ($input->getOption('sync')) {
+            $nat = $this->syncService->syncNationalities($env);
+            $prv = $this->syncService->syncProvinces($env);
+            $off = $this->syncService->syncOffices($env);
+
+            $io->success("Sync completado para entorno [{$env->getType()}]");
+            $io->table(
+                ['Catálogo', 'Creados', 'Actualizados', 'Omitidos'],
+                [
+                    ['Nationalidades', $nat->created, $nat->updated, $nat->skipped],
+                    ['Provincias',     $prv->created, $prv->updated, $prv->skipped],
+                    ['Oficinas',       $off->created, $off->updated, $off->skipped],
+                ]
+            );
+        } else {
+            $this->bus->dispatch(new SyncCatalogsMessage($envId));
+            $io->success("Mensaje SyncCatalogsMessage({$envId}) despachado al bus.");
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Command/Etecsa/SyncProductsCommand.php
+++ b/src/Command/Etecsa/SyncProductsCommand.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Command\Etecsa;
+
+use App\Entity\Environment;
+use App\Message\Etecsa\SyncProductsMessage;
+use App\Repository\EnvironmentRepository;
+use App\Service\Etecsa\EtecsaCatalogSyncService;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+#[AsCommand(
+    name: 'app:etecsa:sync-products',
+    description: 'Sincroniza el catálogo de productos ETECSA contra la BD local.',
+)]
+class SyncProductsCommand extends Command
+{
+    public function __construct(
+        private readonly EtecsaCatalogSyncService $syncService,
+        private readonly EnvironmentRepository $environmentRepository,
+        private readonly MessageBusInterface $bus,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption('environment-id', null, InputOption::VALUE_REQUIRED, 'ID del Environment a sincronizar');
+        $this->addOption('sync', null, InputOption::VALUE_NONE, 'Ejecutar de forma síncrona (sin messenger). Sin esta opción despacha el mensaje al bus.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $envId = (int) $input->getOption('environment-id');
+        $env = $this->environmentRepository->find($envId);
+
+        if (!$env instanceof Environment) {
+            $io->error("Environment con ID {$envId} no encontrado.");
+            return Command::FAILURE;
+        }
+
+        if ($input->getOption('sync')) {
+            $result = $this->syncService->syncProducts($env);
+
+            $io->success("Sync de productos completado para entorno [{$env->getType()}]");
+            $io->table(
+                ['Creados', 'Actualizados', 'Omitidos'],
+                [[$result->created, $result->updated, $result->skipped]]
+            );
+        } else {
+            $this->bus->dispatch(new SyncProductsMessage($envId));
+            $io->success("Mensaje SyncProductsMessage({$envId}) despachado al bus.");
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Command/TestDispatchPendingEmailCommand.php
+++ b/src/Command/TestDispatchPendingEmailCommand.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
+
+#[AsCommand(
+    name: 'app:test-dispatch-pending-email',
+    description: 'Envía un correo de prueba del resumen de despacho de pendientes',
+)]
+class TestDispatchPendingEmailCommand extends Command
+{
+    public function __construct(
+        private readonly MailerInterface $mailer,
+        private readonly ParameterBagInterface $parameterBag,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $from = $this->parameterBag->get('app.email.from');
+
+        $triggeredBy = 'afonsecac1984@gmail.com';
+
+        $mail = (new TemplatedEmail())
+            ->from(new Address($from, 'Sistema — Comremit'))
+            ->to(new Address($triggeredBy))
+            ->cc(
+                new Address('alexander.afonsecac@gmail.com', 'A. Fonseca'),
+                new Address('aportela7@gmail.com', 'A. Portela'),
+            )
+            ->priority(Email::PRIORITY_HIGH)
+            ->subject('[Dispatch] 3 mensaje(s) encolado(s) al API de comunicaciones — TEST')
+            ->htmlTemplate('emails/communications/dispatch-pending.html.twig')
+            ->context([
+                'recharges'      => 2,
+                'packages'       => 1,
+                'total'          => 3,
+                'dispatchedAt'   => (new \DateTimeImmutable('now'))->format(\DateTimeInterface::ATOM),
+                'triggeredBy'    => $triggeredBy,
+                'transactionIds' => ['TXN-001-TEST', 'TXN-002-TEST', 'TXN-003-TEST'],
+            ]);
+
+        $this->mailer->send($mail);
+        $output->writeln(sprintf('<info>Correo de prueba de dispatch enviado a %s (CC: alexander.afonsecac@gmail.com, aportela7@gmail.com)</info>', $triggeredBy));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Controller/AdminUserController.php
+++ b/src/Controller/AdminUserController.php
@@ -16,6 +16,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -26,6 +27,7 @@ class AdminUserController extends AbstractController
 {
     public function __construct(
         private readonly UserService $userService,
+        #[Autowire('limiter.resend_activation')]
         private readonly RateLimiterFactory $resendActivationLimiter,
     ) {
     }

--- a/src/Controller/AdminUserController.php
+++ b/src/Controller/AdminUserController.php
@@ -27,7 +27,7 @@ class AdminUserController extends AbstractController
 {
     public function __construct(
         private readonly UserService $userService,
-        #[Autowire('limiter.resend_activation')]
+        #[Autowire(service: 'limiter.resend_activation')]
         private readonly RateLimiterFactory $resendActivationLimiter,
     ) {
     }

--- a/src/Controller/ApiLoginController.php
+++ b/src/Controller/ApiLoginController.php
@@ -18,8 +18,9 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\CurrentUser;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -30,10 +31,15 @@ class ApiLoginController extends AbstractController
         private readonly NormalizerInterface $serializer,
         private readonly RefreshTokenService $refreshTokenService,
         private readonly TwoFactorService   $twoFactorService,
+        #[Autowire('limiter.dashboard_login')]
         private readonly RateLimiterFactory $dashboardLoginLimiter,
+        #[Autowire('limiter.dashboard_login_ip')]
         private readonly RateLimiterFactory $dashboardLoginIpLimiter,
+        #[Autowire('limiter.forgot_password')]
         private readonly RateLimiterFactory $forgotPasswordLimiter,
+        #[Autowire('limiter.reset_password')]
         private readonly RateLimiterFactory $resetPasswordLimiter,
+        #[Autowire('limiter.activate_account')]
         private readonly RateLimiterFactory $activateAccountLimiter,
     ) {
     }

--- a/src/Controller/ApiLoginController.php
+++ b/src/Controller/ApiLoginController.php
@@ -31,15 +31,15 @@ class ApiLoginController extends AbstractController
         private readonly NormalizerInterface $serializer,
         private readonly RefreshTokenService $refreshTokenService,
         private readonly TwoFactorService   $twoFactorService,
-        #[Autowire('limiter.dashboard_login')]
+        #[Autowire(service: 'limiter.dashboard_login')]
         private readonly RateLimiterFactory $dashboardLoginLimiter,
-        #[Autowire('limiter.dashboard_login_ip')]
+        #[Autowire(service: 'limiter.dashboard_login_ip')]
         private readonly RateLimiterFactory $dashboardLoginIpLimiter,
-        #[Autowire('limiter.forgot_password')]
+        #[Autowire(service: 'limiter.forgot_password')]
         private readonly RateLimiterFactory $forgotPasswordLimiter,
-        #[Autowire('limiter.reset_password')]
+        #[Autowire(service: 'limiter.reset_password')]
         private readonly RateLimiterFactory $resetPasswordLimiter,
-        #[Autowire('limiter.activate_account')]
+        #[Autowire(service: 'limiter.activate_account')]
         private readonly RateLimiterFactory $activateAccountLimiter,
     ) {
     }

--- a/src/Controller/AzTokenController.php
+++ b/src/Controller/AzTokenController.php
@@ -6,7 +6,7 @@ use App\OpenApi\Attribute\DashboardEndpoint;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 #[Route('/azToken')]
 class AzTokenController extends AbstractController

--- a/src/Controller/DashboardCommunicationsDispatchController.php
+++ b/src/Controller/DashboardCommunicationsDispatchController.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace App\Controller;
+
+use App\DTO\DispatchConfigDto;
+use App\DTO\Out\DispatchConfigOutDto;
+use App\DTO\Out\DispatchPendingOutDto;
+use App\Exception\MyCurrentException;
+use App\OpenApi\Attribute\DashboardEndpoint;
+use App\Service\CommunicationsDispatchService;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[IsGranted('ROLE_ADMIN')]
+class DashboardCommunicationsDispatchController extends AbstractController
+{
+    public function __construct(
+        private readonly CommunicationsDispatchService $dispatchService,
+        private readonly EntityManagerInterface $em,
+    ) {}
+
+    #[Route('/communications/dispatch-config', name: 'dashboard_communications_dispatch_config_get', methods: ['GET'])]
+    #[DashboardEndpoint(summary: 'Estado del dispatch de comunicaciones', tag: 'Communications Dispatch', responseDto: DispatchConfigOutDto::class)]
+    public function getConfig(): JsonResponse
+    {
+        return $this->json($this->buildResponse());
+    }
+
+    #[Route('/communications/dispatch-config', name: 'dashboard_communications_dispatch_config_patch', methods: ['PATCH'])]
+    #[DashboardEndpoint(summary: 'Habilitar o pausar el dispatch de comunicaciones', tag: 'Communications Dispatch', responseDto: DispatchConfigOutDto::class)]
+    public function updateConfig(DispatchConfigDto $dto): JsonResponse
+    {
+        try {
+            $this->dispatchService->setEnabled($dto->getDispatchEnabled());
+        } catch (\Exception $e) {
+            throw new MyCurrentException('DISPATCH_CONFIG_ERROR', $e->getMessage(), Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+
+        return $this->json($this->buildResponse());
+    }
+
+    #[Route('/communications/dispatch-config/dispatch-pending', name: 'dashboard_communications_dispatch_pending', methods: ['POST'])]
+    #[DashboardEndpoint(summary: 'Encolar ventas pendientes de despacho', tag: 'Communications Dispatch', responseDto: DispatchPendingOutDto::class, responseStatusCode: 200)]
+    public function dispatchPending(): JsonResponse
+    {
+        $user        = $this->getUser();
+        $triggeredBy = $user instanceof UserInterface ? $user->getUserIdentifier() : null;
+
+        try {
+            $result = $this->dispatchService->dispatchPending($triggeredBy);
+        } catch (MyCurrentException $e) {
+            return $this->json(['error' => ['message' => $e->getMessage()]], $e->getCode());
+        }
+
+        return $this->json($result);
+    }
+
+    #[Route('/communications/dispatch-config/pending-stream', name: 'dashboard_communications_dispatch_pending_stream', methods: ['GET'])]
+    public function pendingStream(): StreamedResponse
+    {
+        $response = new StreamedResponse(function () {
+            set_time_limit(0);
+
+            $lastCount   = -1;
+            $lastEnabled = null;
+            $deadline    = time() + 270; // cierra antes de que el proxy corte (< 5 min)
+
+            while (time() < $deadline && !connection_aborted()) {
+                // Limpia la identity map para forzar lectura fresca de BD
+                $this->em->clear();
+                $this->dispatchService->invalidateCache();
+
+                $count   = $this->dispatchService->countPendingUndispatched();
+                $enabled = $this->dispatchService->isEnabled();
+
+                if ($count !== $lastCount || $enabled !== $lastEnabled) {
+                    $lastCount   = $count;
+                    $lastEnabled = $enabled;
+
+                    echo 'data: ' . json_encode([
+                        'pendingCount'    => $count,
+                        'dispatchEnabled' => $enabled,
+                    ]) . "\n\n";
+                    ob_flush();
+                    flush();
+                }
+
+                // Heartbeat cada ciclo para mantener la conexión viva
+                echo ": ping\n\n";
+                ob_flush();
+                flush();
+
+                sleep(3);
+            }
+
+            echo "event: close\ndata: {}\n\n";
+            ob_flush();
+            flush();
+        });
+
+        $response->headers->set('Content-Type', 'text/event-stream');
+        $response->headers->set('Cache-Control', 'no-cache');
+        $response->headers->set('X-Accel-Buffering', 'no');
+        $response->headers->set('Connection', 'keep-alive');
+
+        return $response;
+    }
+
+    private function buildResponse(): array
+    {
+        return [
+            'dispatchEnabled'  => $this->dispatchService->isEnabled(),
+            'pendingCount'     => $this->dispatchService->countPendingUndispatched(),
+        ];
+    }
+}

--- a/src/Controller/DashboardSysConfigController.php
+++ b/src/Controller/DashboardSysConfigController.php
@@ -168,7 +168,8 @@ class DashboardSysConfigController extends AbstractController
         return [
             'id'            => $config->getId(),
             'propertyName'  => $config->getPropertyName(),
-            'propertyValue' => $config->getPropertyValue(),
+            'propertyValue' => $config->isEncrypted() ? '***' : $config->getPropertyValue(),
+            'isEncrypted'   => $config->isEncrypted(),
             'isActive'      => $config->isActive(),
             'clients'       => $config->getClients(),
             'createdAt'     => $config->getCreatedAt()?->format('c'),

--- a/src/Controller/DashboardSysConfigController.php
+++ b/src/Controller/DashboardSysConfigController.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace App\Controller;
+
+use App\DTO\CreateSysConfigDto;
+use App\DTO\UpdateSysConfigDto;
+use App\DTO\Out\DeletedOutDto;
+use App\DTO\Out\PaginatedListOutDto;
+use App\DTO\Out\SysConfigOutDto;
+use App\DTO\Out\ToggleOutDto;
+use App\Entity\SysConfig;
+use App\Exception\MyCurrentException;
+use App\OpenApi\Attribute\DashboardEndpoint;
+use App\Repository\SysConfigRepository;
+use App\Service\SysConfigAdminService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[IsGranted('ROLE_SUPER_ADMIN')]
+#[Route('/admin/sys-config')]
+class DashboardSysConfigController extends AbstractController
+{
+    private const SORTABLE = [
+        'id'           => 'sc.id',
+        'propertyName' => 'sc.propertyName',
+        'updatedAt'    => 'sc.updatedAt',
+        'createdAt'    => 'sc.createdAt',
+    ];
+
+    public function __construct(
+        private readonly SysConfigRepository $sysConfigRepo,
+        private readonly SysConfigAdminService $sysConfigAdminService,
+    ) {}
+
+    #[Route('', name: 'dashboard_sys_config_list', methods: ['GET'])]
+    #[DashboardEndpoint(summary: 'Listar variables de configuración del sistema', tag: 'Sys Config', responseDto: PaginatedListOutDto::class, itemDto: SysConfigOutDto::class)]
+    public function list(Request $request): JsonResponse
+    {
+        $page    = max(0, (int) $request->query->get('page', 0));
+        $limit   = min(100, max(1, (int) $request->query->get('limit', 20)));
+        $orderBy = $request->query->get('orderBy', 'id DESC');
+        $search  = $request->query->get('search');
+
+        $qb = $this->sysConfigRepo->createQueryBuilder('sc')
+            ->andWhere('sc.removedAt IS NULL');
+
+        if ($search !== null && $search !== '') {
+            $qb->andWhere('sc.propertyName LIKE :search')
+               ->setParameter('search', '%' . $search . '%');
+        }
+
+        if ($request->query->has('isActive')) {
+            $qb->andWhere('sc.isActive = :isActive')
+               ->setParameter('isActive', filter_var($request->query->get('isActive'), FILTER_VALIDATE_BOOLEAN));
+        }
+
+        $orderParts = explode(' ', $orderBy);
+        $field      = self::SORTABLE[$orderParts[0]] ?? 'sc.id';
+        $direction  = strtoupper($orderParts[1] ?? 'DESC') === 'ASC' ? 'ASC' : 'DESC';
+        $qb->orderBy($field, $direction);
+
+        $results = $qb->setMaxResults($limit + 1)
+            ->setFirstResult($page * $limit)
+            ->getQuery()
+            ->getResult();
+
+        $hasNext = count($results) > $limit;
+        if ($hasNext) {
+            array_pop($results);
+        }
+
+        return $this->json([
+            'limit'       => $limit,
+            'currentPage' => $page,
+            'hasNext'     => $hasNext,
+            'hasPrevious' => $page > 0,
+            'results'     => array_map(fn($sc) => $this->serialize($sc), $results),
+        ]);
+    }
+
+    #[Route('/{id}', name: 'dashboard_sys_config_show', methods: ['GET'], requirements: ['id' => '\d+'])]
+    #[DashboardEndpoint(summary: 'Obtener variable de configuración', tag: 'Sys Config', responseDto: SysConfigOutDto::class)]
+    public function show(int $id): JsonResponse
+    {
+        $config = $this->findOrFail($id);
+        if ($config instanceof JsonResponse) {
+            return $config;
+        }
+
+        return $this->json($this->serialize($config));
+    }
+
+    #[Route('', name: 'dashboard_sys_config_create', methods: ['POST'])]
+    #[DashboardEndpoint(summary: 'Crear variable de configuración', tag: 'Sys Config', responseDto: SysConfigOutDto::class, responseStatusCode: 201)]
+    public function create(CreateSysConfigDto $dto): JsonResponse
+    {
+        try {
+            $config = $this->sysConfigAdminService->create($dto);
+        } catch (MyCurrentException $e) {
+            return $this->json(['error' => ['message' => $e->getMessage()]], $e->getCode());
+        }
+
+        return $this->json($this->serialize($config), Response::HTTP_CREATED);
+    }
+
+    #[Route('/{id}', name: 'dashboard_sys_config_update', methods: ['PATCH'], requirements: ['id' => '\d+'])]
+    #[DashboardEndpoint(summary: 'Actualizar variable de configuración', tag: 'Sys Config', responseDto: SysConfigOutDto::class)]
+    public function update(int $id, UpdateSysConfigDto $dto): JsonResponse
+    {
+        $config = $this->findOrFail($id);
+        if ($config instanceof JsonResponse) {
+            return $config;
+        }
+
+        try {
+            $config = $this->sysConfigAdminService->update($config, $dto);
+        } catch (MyCurrentException $e) {
+            return $this->json(['error' => ['message' => $e->getMessage()]], $e->getCode());
+        }
+
+        return $this->json($this->serialize($config));
+    }
+
+    #[Route('/{id}/toggle', name: 'dashboard_sys_config_toggle', methods: ['PATCH'], requirements: ['id' => '\d+'])]
+    #[DashboardEndpoint(summary: 'Activar o desactivar variable de configuración', tag: 'Sys Config', responseDto: ToggleOutDto::class)]
+    public function toggle(int $id): JsonResponse
+    {
+        $config = $this->findOrFail($id);
+        if ($config instanceof JsonResponse) {
+            return $config;
+        }
+
+        $this->sysConfigAdminService->toggle($config);
+
+        return $this->json(['id' => $config->getId(), 'isActive' => $config->isActive()]);
+    }
+
+    #[Route('/{id}', name: 'dashboard_sys_config_delete', methods: ['DELETE'], requirements: ['id' => '\d+'])]
+    #[DashboardEndpoint(summary: 'Eliminar variable de configuración (soft-delete)', tag: 'Sys Config', responseDto: DeletedOutDto::class)]
+    public function delete(int $id): JsonResponse
+    {
+        $config = $this->findOrFail($id);
+        if ($config instanceof JsonResponse) {
+            return $config;
+        }
+
+        $this->sysConfigAdminService->delete($config);
+
+        return $this->json(['deleted' => true]);
+    }
+
+    private function findOrFail(int $id): SysConfig|JsonResponse
+    {
+        $config = $this->sysConfigRepo->find($id);
+        if ($config === null || $config->getRemovedAt() !== null) {
+            return $this->json(['error' => ['message' => 'Not found']], Response::HTTP_NOT_FOUND);
+        }
+
+        return $config;
+    }
+
+    private function serialize(SysConfig $config): array
+    {
+        return [
+            'id'            => $config->getId(),
+            'propertyName'  => $config->getPropertyName(),
+            'propertyValue' => $config->getPropertyValue(),
+            'isActive'      => $config->isActive(),
+            'clients'       => $config->getClients(),
+            'createdAt'     => $config->getCreatedAt()?->format('c'),
+            'updatedAt'     => $config->getUpdatedAt()?->format('c'),
+            'removedAt'     => $config->getRemovedAt()?->format('c'),
+        ];
+    }
+}

--- a/src/DTO/CreateOperationDto.php
+++ b/src/DTO/CreateOperationDto.php
@@ -3,7 +3,7 @@
 namespace App\DTO;
 
 use ApiPlatform\Metadata\ApiProperty;
-use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
 
 final class CreateOperationDto

--- a/src/DTO/CreateSysConfigDto.php
+++ b/src/DTO/CreateSysConfigDto.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\DTO;
+
+use App\OpenApi\Attribute\OAProperty;
+use Symfony\Component\Validator\Constraints as Assert;
+
+class CreateSysConfigDto implements IInput
+{
+    #[OAProperty(description: 'Clave única de la variable (ej: communications.dispatch.enabled)')]
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 255)]
+    protected ?string $propertyName;
+
+    #[OAProperty(description: 'Valor de la variable (siempre almacenado como string)')]
+    #[Assert\NotBlank]
+    protected ?string $propertyValue;
+
+    #[OAProperty(description: 'Indica si la variable está activa. Por defecto true')]
+    protected ?bool $isActive;
+
+    #[OAProperty(schema: ['type' => 'array', 'items' => ['type' => 'integer'], 'nullable' => true], description: 'IDs de clientes a los que aplica esta variable. null significa que aplica a todos')]
+    protected ?array $clients;
+
+    public function __construct(
+        ?string $propertyName = null,
+        ?string $propertyValue = null,
+        ?bool $isActive = null,
+        ?array $clients = null,
+    ) {
+        $this->propertyName  = $propertyName;
+        $this->propertyValue = $propertyValue;
+        $this->isActive      = $isActive;
+        $this->clients       = $clients;
+    }
+
+    public function getPropertyName(): ?string { return $this->propertyName; }
+    public function setPropertyName(?string $v): void { $this->propertyName = $v; }
+
+    public function getPropertyValue(): ?string { return $this->propertyValue; }
+    public function setPropertyValue(?string $v): void { $this->propertyValue = $v; }
+
+    public function getIsActive(): ?bool { return $this->isActive; }
+    public function setIsActive(?bool $v): void { $this->isActive = $v; }
+
+    public function getClients(): ?array { return $this->clients; }
+    public function setClients(?array $v): void { $this->clients = $v; }
+}

--- a/src/DTO/CreateSysConfigDto.php
+++ b/src/DTO/CreateSysConfigDto.php
@@ -22,16 +22,21 @@ class CreateSysConfigDto implements IInput
     #[OAProperty(schema: ['type' => 'array', 'items' => ['type' => 'integer'], 'nullable' => true], description: 'IDs de clientes a los que aplica esta variable. null significa que aplica a todos')]
     protected ?array $clients;
 
+    #[OAProperty(description: 'Si true, el valor se almacena cifrado en la BD y sólo se expone como "***" en la API')]
+    protected ?bool $isEncrypted;
+
     public function __construct(
         ?string $propertyName = null,
         ?string $propertyValue = null,
         ?bool $isActive = null,
         ?array $clients = null,
+        ?bool $isEncrypted = null,
     ) {
         $this->propertyName  = $propertyName;
         $this->propertyValue = $propertyValue;
         $this->isActive      = $isActive;
         $this->clients       = $clients;
+        $this->isEncrypted   = $isEncrypted;
     }
 
     public function getPropertyName(): ?string { return $this->propertyName; }
@@ -45,4 +50,7 @@ class CreateSysConfigDto implements IInput
 
     public function getClients(): ?array { return $this->clients; }
     public function setClients(?array $v): void { $this->clients = $v; }
+
+    public function getIsEncrypted(): ?bool { return $this->isEncrypted; }
+    public function setIsEncrypted(?bool $v): void { $this->isEncrypted = $v; }
 }

--- a/src/DTO/DispatchConfigDto.php
+++ b/src/DTO/DispatchConfigDto.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\DTO;
+
+use App\OpenApi\Attribute\OAProperty;
+use Symfony\Component\Validator\Constraints as Assert;
+
+class DispatchConfigDto implements IInput
+{
+    #[OAProperty(description: 'true para habilitar el dispatch a comunicaciones, false para pausarlo')]
+    #[Assert\NotNull]
+    protected ?bool $dispatchEnabled;
+
+    public function __construct(?bool $dispatchEnabled = null)
+    {
+        $this->dispatchEnabled = $dispatchEnabled;
+    }
+
+    public function getDispatchEnabled(): ?bool
+    {
+        return $this->dispatchEnabled;
+    }
+
+    public function setDispatchEnabled(?bool $v): void
+    {
+        $this->dispatchEnabled = $v;
+    }
+}

--- a/src/DTO/Etecsa/EtecsaBalanceDto.php
+++ b/src/DTO/Etecsa/EtecsaBalanceDto.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\DTO\Etecsa;
+
+final class EtecsaBalanceDto
+{
+    public function __construct(
+        public readonly float $cupAmount,
+        public readonly float $usdAmount,
+        public readonly \DateTimeImmutable $fetchedAt,
+    ) {
+    }
+}

--- a/src/DTO/Out/DispatchConfigOutDto.php
+++ b/src/DTO/Out/DispatchConfigOutDto.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\DTO\Out;
+
+use App\OpenApi\Attribute\OAProperty;
+
+final class DispatchConfigOutDto
+{
+    #[OAProperty(description: 'true si el dispatch a comunicaciones está activo, false si está pausado')]
+    public bool $dispatchEnabled;
+
+    #[OAProperty(description: 'Número de ventas persistidas pero pendientes de encolar (stateProcess=Created, state=Pending)')]
+    public int $pendingCount;
+}

--- a/src/DTO/Out/DispatchPendingOutDto.php
+++ b/src/DTO/Out/DispatchPendingOutDto.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\DTO\Out;
+
+use App\OpenApi\Attribute\OAProperty;
+
+final class DispatchPendingOutDto
+{
+    #[OAProperty(description: 'Recargas encoladas en esta operación')]
+    public int $recharges;
+
+    #[OAProperty(description: 'Ventas de paquete encoladas en esta operación')]
+    public int $packages;
+
+    #[OAProperty(description: 'Total de mensajes encolados')]
+    public int $total;
+}

--- a/src/DTO/Out/SysConfigOutDto.php
+++ b/src/DTO/Out/SysConfigOutDto.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\DTO\Out;
+
+use App\OpenApi\Attribute\OAProperty;
+
+final class SysConfigOutDto
+{
+    public int $id;
+
+    #[OAProperty(description: 'Clave única de la variable')]
+    public string $propertyName;
+
+    #[OAProperty(description: 'Valor de la variable')]
+    public string $propertyValue;
+
+    #[OAProperty(description: 'Indica si la variable está activa')]
+    public ?bool $isActive = null;
+
+    #[OAProperty(schema: ['type' => 'array', 'items' => ['type' => 'integer'], 'nullable' => true], description: 'IDs de clientes a los que aplica. null significa que aplica a todos')]
+    public ?array $clients = null;
+
+    public ?string $createdAt = null;
+    public ?string $updatedAt = null;
+
+    #[OAProperty(description: 'Fecha de borrado lógico. null si la variable sigue activa')]
+    public ?string $removedAt = null;
+}

--- a/src/DTO/Out/SysConfigOutDto.php
+++ b/src/DTO/Out/SysConfigOutDto.php
@@ -11,8 +11,11 @@ final class SysConfigOutDto
     #[OAProperty(description: 'Clave única de la variable')]
     public string $propertyName;
 
-    #[OAProperty(description: 'Valor de la variable')]
+    #[OAProperty(description: 'Valor de la variable. "***" cuando isEncrypted es true')]
     public string $propertyValue;
+
+    #[OAProperty(description: 'Indica si el valor está cifrado en la BD. La API devuelve "***" en propertyValue cuando es true')]
+    public bool $isEncrypted = false;
 
     #[OAProperty(description: 'Indica si la variable está activa')]
     public ?bool $isActive = null;

--- a/src/DTO/UpdateSysConfigDto.php
+++ b/src/DTO/UpdateSysConfigDto.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\DTO;
+
+use App\OpenApi\Attribute\OAProperty;
+use Symfony\Component\Validator\Constraints as Assert;
+
+class UpdateSysConfigDto implements IInput
+{
+    #[OAProperty(description: 'Nueva clave de la variable. Debe ser única')]
+    #[Assert\Length(max: 255)]
+    protected ?string $propertyName;
+
+    #[OAProperty(description: 'Nuevo valor de la variable')]
+    protected ?string $propertyValue;
+
+    #[OAProperty(description: 'Activar o desactivar la variable')]
+    protected ?bool $isActive;
+
+    #[OAProperty(schema: ['type' => 'array', 'items' => ['type' => 'integer'], 'nullable' => true], description: 'IDs de clientes a los que aplica. null significa que aplica a todos')]
+    protected ?array $clients;
+
+    public function __construct(
+        ?string $propertyName = null,
+        ?string $propertyValue = null,
+        ?bool $isActive = null,
+        ?array $clients = null,
+    ) {
+        $this->propertyName  = $propertyName;
+        $this->propertyValue = $propertyValue;
+        $this->isActive      = $isActive;
+        $this->clients       = $clients;
+    }
+
+    public function getPropertyName(): ?string { return $this->propertyName; }
+    public function setPropertyName(?string $v): void { $this->propertyName = $v; }
+
+    public function getPropertyValue(): ?string { return $this->propertyValue; }
+    public function setPropertyValue(?string $v): void { $this->propertyValue = $v; }
+
+    public function getIsActive(): ?bool { return $this->isActive; }
+    public function setIsActive(?bool $v): void { $this->isActive = $v; }
+
+    public function getClients(): ?array { return $this->clients; }
+    public function setClients(?array $v): void { $this->clients = $v; }
+}

--- a/src/DTO/UpdateSysConfigDto.php
+++ b/src/DTO/UpdateSysConfigDto.php
@@ -20,16 +20,21 @@ class UpdateSysConfigDto implements IInput
     #[OAProperty(schema: ['type' => 'array', 'items' => ['type' => 'integer'], 'nullable' => true], description: 'IDs de clientes a los que aplica. null significa que aplica a todos')]
     protected ?array $clients;
 
+    #[OAProperty(description: 'Cambiar el modo de cifrado del valor')]
+    protected ?bool $isEncrypted;
+
     public function __construct(
         ?string $propertyName = null,
         ?string $propertyValue = null,
         ?bool $isActive = null,
         ?array $clients = null,
+        ?bool $isEncrypted = null,
     ) {
         $this->propertyName  = $propertyName;
         $this->propertyValue = $propertyValue;
         $this->isActive      = $isActive;
         $this->clients       = $clients;
+        $this->isEncrypted   = $isEncrypted;
     }
 
     public function getPropertyName(): ?string { return $this->propertyName; }
@@ -43,4 +48,7 @@ class UpdateSysConfigDto implements IInput
 
     public function getClients(): ?array { return $this->clients; }
     public function setClients(?array $v): void { $this->clients = $v; }
+
+    public function getIsEncrypted(): ?bool { return $this->isEncrypted; }
+    public function setIsEncrypted(?bool $v): void { $this->isEncrypted = $v; }
 }

--- a/src/Entity/Account.php
+++ b/src/Entity/Account.php
@@ -20,7 +20,7 @@ use Symfony\Component\Uid\Uuid;
 class Account implements UserInterface
 {
     #[ORM\Id]
-    #[ORM\GeneratedValue]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
     #[ORM\Column]
     #[Groups(['balance:reading', 'profile', 'accounts:read'])]
     private ?int $id = null;

--- a/src/Entity/Account.php
+++ b/src/Entity/Account.php
@@ -7,7 +7,7 @@ use DateTimeImmutable;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Bridge\Doctrine\Types\UuidType;
 use Symfony\Component\Security\Core\User\UserInterface;
-use Symfony\Component\Serializer\Annotation\Ignore;
+use Symfony\Component\Serializer\Attribute\Ignore;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Serializer\Attribute\MaxDepth;
 use Symfony\Component\Uid\Uuid;
@@ -135,15 +135,6 @@ class Account implements UserInterface
         $this->roles = $roles;
 
         return $this;
-    }
-
-    /**
-     * @see UserInterface
-     */
-    public function eraseCredentials(): void
-    {
-        // If you store any temporary, sensitive data on the user, clear it here
-        // $this->plainPassword = null;
     }
 
     public function getAccessToken(): ?Uuid

--- a/src/Entity/BalanceOperation.php
+++ b/src/Entity/BalanceOperation.php
@@ -66,7 +66,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 class BalanceOperation
 {
     #[ORM\Id]
-    #[ORM\GeneratedValue]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
     #[ORM\Column]
     #[ApiProperty(identifier: true)]
     #[Groups(['balance:read', 'balance:reading'])]

--- a/src/Entity/BankCard.php
+++ b/src/Entity/BankCard.php
@@ -59,7 +59,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 class BankCard
 {
     #[ORM\Id]
-    #[ORM\GeneratedValue]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
     #[ORM\Column]
     #[ApiProperty(identifier: true)]
     #[Groups(['bankCard:read'])]

--- a/src/Entity/BankCard.php
+++ b/src/Entity/BankCard.php
@@ -14,7 +14,7 @@ use App\State\CreateBeneficiaryCardProcessor;
 use App\State\SoftDeleteBankCardProcessor;
 use DateTimeImmutable;
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: BankCardRepository::class)]

--- a/src/Entity/Beneficiary.php
+++ b/src/Entity/Beneficiary.php
@@ -18,7 +18,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: BeneficiaryRepository::class)]

--- a/src/Entity/Beneficiary.php
+++ b/src/Entity/Beneficiary.php
@@ -44,7 +44,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 class Beneficiary
 {
     #[ORM\Id]
-    #[ORM\GeneratedValue]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
     #[ORM\Column]
     #[Groups(['beneficiary:read'])]
     #[ApiProperty(identifier: true)]

--- a/src/Entity/City.php
+++ b/src/Entity/City.php
@@ -22,7 +22,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 class City
 {
     #[ORM\Id]
-    #[ORM\GeneratedValue]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
     #[ORM\Column]
     #[Groups(['city:read'])]
     #[ApiProperty(identifier: true)]

--- a/src/Entity/City.php
+++ b/src/Entity/City.php
@@ -7,7 +7,7 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\GetCollection;
 use App\Repository\CityRepository;
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: CityRepository::class)]

--- a/src/Entity/Client.php
+++ b/src/Entity/Client.php
@@ -21,7 +21,7 @@ use Symfony\Component\Serializer\Attribute\Groups;
 class Client
 {
     #[ORM\Id]
-    #[ORM\GeneratedValue]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
     #[ORM\Column]
     #[Groups(['balance:reading', 'profile', 'accounts:read', 'reports:list', 'report:read', 'client:list', 'permission:read'])]
     private ?int $id = null;

--- a/src/Entity/CommunicationClientPackage.php
+++ b/src/Entity/CommunicationClientPackage.php
@@ -54,7 +54,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 class CommunicationClientPackage
 {
     #[ORM\Id]
-    #[ORM\GeneratedValue]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
     #[ORM\Column]
     #[Groups(['comPackage:read', 'comProm:read'])]
     #[ApiProperty(identifier: true)]

--- a/src/Entity/CommunicationNationality.php
+++ b/src/Entity/CommunicationNationality.php
@@ -25,7 +25,7 @@ use Symfony\Component\Serializer\Attribute\Groups;
 class CommunicationNationality
 {
     #[ORM\Id]
-    #[ORM\GeneratedValue]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
     #[ORM\Column]
     #[ApiProperty(identifier: true)]
     #[Groups(['comNationality:read'])]

--- a/src/Entity/CommunicationOffice.php
+++ b/src/Entity/CommunicationOffice.php
@@ -32,7 +32,7 @@ use Symfony\Component\Serializer\Attribute\Groups;
 class CommunicationOffice
 {
     #[ORM\Id]
-    #[ORM\GeneratedValue]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
     #[ORM\Column]
     #[ApiProperty(identifier: true)]
     #[Groups(['comOffices:read'])]

--- a/src/Entity/CommunicationPrice.php
+++ b/src/Entity/CommunicationPrice.php
@@ -11,7 +11,7 @@ use phpDocumentor\Reflection\Types\Void_;
 class CommunicationPrice
 {
     #[ORM\Id]
-    #[ORM\GeneratedValue]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
     #[ORM\Column]
     private ?int $id = null;
 

--- a/src/Entity/CommunicationPricePackage.php
+++ b/src/Entity/CommunicationPricePackage.php
@@ -12,7 +12,7 @@ use Doctrine\ORM\Mapping as ORM;
 class CommunicationPricePackage
 {
     #[ORM\Id]
-    #[ORM\GeneratedValue]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
     #[ORM\Column]
     private ?int $id = null;
 

--- a/src/Entity/CommunicationProduct.php
+++ b/src/Entity/CommunicationProduct.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Attribute\Groups;
 class CommunicationProduct
 {
     #[ORM\Id]
-    #[ORM\GeneratedValue]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
     #[ORM\Column]
     #[Groups(['product:read'])]
     private ?int $id = null;

--- a/src/Entity/CommunicationPromotions.php
+++ b/src/Entity/CommunicationPromotions.php
@@ -39,7 +39,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 class CommunicationPromotions
 {
     #[ORM\Id]
-    #[ORM\GeneratedValue]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
     #[ORM\Column]
     #[Groups(['comProm:read', 'comPackage:read', 'promotion:list', 'promotion:detail'])]
     #[ApiProperty(identifier: true)]

--- a/src/Entity/CommunicationProvinces.php
+++ b/src/Entity/CommunicationProvinces.php
@@ -22,7 +22,7 @@ use Symfony\Component\Serializer\Attribute\Groups;
 class CommunicationProvinces
 {
     #[ORM\Id]
-    #[ORM\GeneratedValue]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
     #[ORM\Column]
     #[ApiProperty(identifier: true)]
     #[Groups(['comProvinces:read'])]

--- a/src/Entity/CommunicationSaleHistory.php
+++ b/src/Entity/CommunicationSaleHistory.php
@@ -14,7 +14,7 @@ use Symfony\Component\Serializer\Attribute\Groups;
 class CommunicationSaleHistory
 {
     #[ORM\Id]
-    #[ORM\GeneratedValue]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
     #[ORM\Column]
     private ?int $id = null;
 

--- a/src/Entity/CommunicationSaleHistory.php
+++ b/src/Entity/CommunicationSaleHistory.php
@@ -7,7 +7,7 @@ use App\Enums\CommunicationStateEnum;
 use App\Repository\CommunicationSaleHistoryRepository;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Serializer\Attribute\Groups;
 
 #[ORM\Entity(repositoryClass: CommunicationSaleHistoryRepository::class)]
 #[ORM\HasLifecycleCallbacks]

--- a/src/Entity/CommunicationSaleInfo.php
+++ b/src/Entity/CommunicationSaleInfo.php
@@ -77,7 +77,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 class CommunicationSaleInfo
 {
     #[ORM\Id]
-    #[ORM\GeneratedValue]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
     #[ORM\Column]
     #[ApiProperty(
         identifier: true

--- a/src/Entity/CommunicationSaleInfo.php
+++ b/src/Entity/CommunicationSaleInfo.php
@@ -20,7 +20,7 @@ use App\State\CreateSaleInfoProcessor;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: CommunicationSaleInfoRepository::class)]

--- a/src/Entity/CommunicationSalePackage.php
+++ b/src/Entity/CommunicationSalePackage.php
@@ -6,7 +6,7 @@ use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use App\Repository\CommunicationSalePackageRepository;
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: CommunicationSalePackageRepository::class)]

--- a/src/Entity/CommunicationSaleRecharge.php
+++ b/src/Entity/CommunicationSaleRecharge.php
@@ -8,7 +8,7 @@ use App\Enums\CommunicationStateEnum;
 use App\Repository\CommunicationSaleRechargeRepository;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: CommunicationSaleRechargeRepository::class)]

--- a/src/Entity/ConfigureSequence.php
+++ b/src/Entity/ConfigureSequence.php
@@ -13,7 +13,7 @@ use Doctrine\ORM\Mapping as ORM;
 class ConfigureSequence
 {
     #[ORM\Id]
-    #[ORM\GeneratedValue]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
     #[ORM\Column]
     private ?int $id = null;
 

--- a/src/Entity/Country.php
+++ b/src/Entity/Country.php
@@ -10,7 +10,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Bridge\Doctrine\Types\UuidType;
-use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Validator\Constraints as Assert;
 

--- a/src/Entity/Country.php
+++ b/src/Entity/Country.php
@@ -36,7 +36,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 class Country
 {
     #[ORM\Id]
-    #[ORM\GeneratedValue]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
     #[ORM\Column]
     #[Groups(['country:read'])]
     #[ApiProperty(identifier: true)]

--- a/src/Entity/EmailNotification.php
+++ b/src/Entity/EmailNotification.php
@@ -10,7 +10,7 @@ use Doctrine\ORM\Mapping as ORM;
 class EmailNotification
 {
     #[ORM\Id]
-    #[ORM\GeneratedValue]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
     #[ORM\Column]
     private ?int $id = null;
 

--- a/src/Entity/EnvAuth.php
+++ b/src/Entity/EnvAuth.php
@@ -12,7 +12,7 @@ use Doctrine\ORM\Mapping as ORM;
 class EnvAuth
 {
     #[ORM\Id]
-    #[ORM\GeneratedValue]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
     #[ORM\Column]
     private ?int $id = null;
 

--- a/src/Entity/Environment.php
+++ b/src/Entity/Environment.php
@@ -24,7 +24,7 @@ use Symfony\Component\Uid\Uuid;
 class Environment
 {
     #[ORM\Id]
-    #[ORM\GeneratedValue]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
     #[ORM\Column]
     #[Groups(['balance:reading', 'profile', 'accounts:read', 'promotion:list', 'promotion:detail', 'product:read', 'env:list'])]
     private ?int $id = null;

--- a/src/Entity/JobPosition.php
+++ b/src/Entity/JobPosition.php
@@ -14,7 +14,7 @@ use Symfony\Component\Serializer\Attribute\Groups;
 class JobPosition
 {
     #[ORM\Id]
-    #[ORM\GeneratedValue]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
     #[ORM\Column]
     #[Groups(['job_position:list', 'job_position:detail', 'user:job_position'])]
     private ?int $id = null;

--- a/src/Entity/NavigationItem.php
+++ b/src/Entity/NavigationItem.php
@@ -13,7 +13,7 @@ use Symfony\Component\Serializer\Attribute\Groups;
 class NavigationItem
 {
     #[ORM\Id]
-    #[ORM\GeneratedValue]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
     #[ORM\Column]
     #[Groups(['navigation', 'navItem:read'])]
     private ?int $id = null;

--- a/src/Entity/ProductComm.php
+++ b/src/Entity/ProductComm.php
@@ -9,7 +9,7 @@ use Doctrine\ORM\Mapping as ORM;
 class ProductComm
 {
     #[ORM\Id]
-    #[ORM\GeneratedValue]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
     #[ORM\Column]
     private ?int $id = null;
 

--- a/src/Entity/ProductCommBenefits.php
+++ b/src/Entity/ProductCommBenefits.php
@@ -9,7 +9,7 @@ use Doctrine\ORM\Mapping as ORM;
 class ProductCommBenefits
 {
     #[ORM\Id]
-    #[ORM\GeneratedValue]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
     #[ORM\Column]
     private ?int $id = null;
 

--- a/src/Entity/Province.php
+++ b/src/Entity/Province.php
@@ -26,7 +26,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 class Province
 {
     #[ORM\Id]
-    #[ORM\GeneratedValue]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
     #[ORM\Column]
     #[Groups(['province:read'])]
     #[ApiProperty(identifier: true)]

--- a/src/Entity/Province.php
+++ b/src/Entity/Province.php
@@ -10,7 +10,7 @@ use ApiPlatform\Metadata\Link;
 use App\Repository\ProvinceRepository;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Bridge\Doctrine\Types\UuidType;
-use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Validator\Constraints as Assert;
 

--- a/src/Entity/RefreshToken.php
+++ b/src/Entity/RefreshToken.php
@@ -13,7 +13,7 @@ use Doctrine\ORM\Mapping as ORM;
 class RefreshToken
 {
     #[ORM\Id]
-    #[ORM\GeneratedValue]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
     #[ORM\Column]
     private ?int $id = null;
 

--- a/src/Entity/ReportMarked.php
+++ b/src/Entity/ReportMarked.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Attribute\Groups;
 class ReportMarked
 {
     #[ORM\Id]
-    #[ORM\GeneratedValue]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
     #[ORM\Column]
     #[Groups(['reports:list', 'report:read'])]
     private ?int $id = null;

--- a/src/Entity/ReportMarked.php
+++ b/src/Entity/ReportMarked.php
@@ -37,7 +37,7 @@ class ReportMarked
     #[ORM\JoinColumn(nullable: false)]
     private ?Account $account = null;
 
-    #[ORM\Column(type: Types::ARRAY, nullable: true)]
+    #[ORM\Column(type: Types::JSON, nullable: true)]
     #[Groups(['report:read'])]
     private ?array $dataArray = null;
 

--- a/src/Entity/Sender.php
+++ b/src/Entity/Sender.php
@@ -18,7 +18,7 @@ use App\State\SoftDeleteSenderProcessor;
 use DateTimeInterface;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: SenderRepository::class)]

--- a/src/Entity/Sender.php
+++ b/src/Entity/Sender.php
@@ -57,7 +57,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 class Sender
 {
     #[ORM\Id]
-    #[ORM\GeneratedValue]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
     #[ORM\Column]
     #[Groups(['sender:read'])]
     #[ApiProperty(identifier: true)]

--- a/src/Entity/SysConfig.php
+++ b/src/Entity/SysConfig.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\Mapping as ORM;
 class SysConfig
 {
     #[ORM\Id]
-    #[ORM\GeneratedValue]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
     #[ORM\Column]
     private ?int $id = null;
 

--- a/src/Entity/SysConfig.php
+++ b/src/Entity/SysConfig.php
@@ -36,6 +36,9 @@ class SysConfig
     #[ORM\Column(type: Types::JSON, nullable: true)]
     private ?array $clients = null;
 
+    #[ORM\Column]
+    private bool $isEncrypted = false;
+
     public function getId(): ?int
     {
         return $this->id;
@@ -121,6 +124,18 @@ class SysConfig
     public function setClients(?array $clients): static
     {
         $this->clients = $clients;
+
+        return $this;
+    }
+
+    public function isEncrypted(): bool
+    {
+        return $this->isEncrypted;
+    }
+
+    public function setIsEncrypted(bool $isEncrypted): static
+    {
+        $this->isEncrypted = $isEncrypted;
 
         return $this;
     }

--- a/src/Entity/Transfer.php
+++ b/src/Entity/Transfer.php
@@ -46,7 +46,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 class Transfer
 {
     #[ORM\Id]
-    #[ORM\GeneratedValue]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
     #[ORM\Column]
     #[ApiProperty(identifier: true)]
     #[Groups(['tx:read', 'balance:reading'])]

--- a/src/Entity/Transfer.php
+++ b/src/Entity/Transfer.php
@@ -14,7 +14,7 @@ use App\State\TransferProvider;
 use DateTimeImmutable;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: TransferRepository::class)]

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -19,7 +19,7 @@ use Symfony\Component\Serializer\Attribute\Groups;
 class User implements UserInterface, PasswordAuthenticatedUserInterface, IInput
 {
     #[ORM\Id]
-    #[ORM\GeneratedValue]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
     #[ORM\Column]
     #[Groups(['profile', 'permission:read'])]
     private ?int $id = null;

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -194,6 +194,8 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, IInput
         return $this;
     }
 
+    public function eraseCredentials(): void {}
+
     public function getCompany(): ?Client
     {
         return $this->company;

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -194,15 +194,6 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, IInput
         return $this;
     }
 
-    /**
-     * @see UserInterface
-     */
-    public function eraseCredentials(): void
-    {
-        // If you store any temporary, sensitive data on the user, clear it here
-        // $this->plainPassword = null;
-    }
-
     public function getCompany(): ?Client
     {
         return $this->company;

--- a/src/Entity/UserCode.php
+++ b/src/Entity/UserCode.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\Mapping as ORM;
 class UserCode
 {
     #[ORM\Id]
-    #[ORM\GeneratedValue]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
     #[ORM\Column]
     private ?int $id = null;
 

--- a/src/Entity/UserPassword.php
+++ b/src/Entity/UserPassword.php
@@ -12,7 +12,7 @@ use Symfony\Component\Uid\Uuid;
 class UserPassword
 {
     #[ORM\Id]
-    #[ORM\GeneratedValue]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
     #[ORM\Column]
     private ?int $id = null;
 

--- a/src/Entity/UserPermission.php
+++ b/src/Entity/UserPermission.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Attribute\Groups;
 class UserPermission
 {
     #[ORM\Id]
-    #[ORM\GeneratedValue]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
     #[ORM\Column]
     #[Groups(['permission:read'])]
     private ?int $id = null;

--- a/src/Entity/UserSession.php
+++ b/src/Entity/UserSession.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\Mapping as ORM;
 class UserSession
 {
     #[ORM\Id]
-    #[ORM\GeneratedValue]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
     #[ORM\Column]
     private ?int $id = null;
 

--- a/src/EventListener/ApiControllerListener.php
+++ b/src/EventListener/ApiControllerListener.php
@@ -27,7 +27,7 @@ class ApiControllerListener
     public function __invoke(ControllerEvent $event): void {
         $request = $event->getRequest();
         $language = $request->getLocale();
-        $pathTo = $request->get('_route');
+        $pathTo = $request->attributes->get('_route');
 
         if ($pathTo === 'app_api_login' || $pathTo === 'app_offer') {
             return;

--- a/src/EventListener/SysConfigCacheListener.php
+++ b/src/EventListener/SysConfigCacheListener.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\EventListener;
+
+use App\Entity\SysConfig;
+use App\Repository\SysConfigRepository;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
+use Doctrine\ORM\Events;
+use Doctrine\ORM\Event\PostPersistEventArgs;
+use Doctrine\ORM\Event\PostRemoveEventArgs;
+use Doctrine\ORM\Event\PostUpdateEventArgs;
+
+#[AsDoctrineListener(event: Events::postPersist)]
+#[AsDoctrineListener(event: Events::postUpdate)]
+#[AsDoctrineListener(event: Events::postRemove)]
+class SysConfigCacheListener
+{
+    public function __construct(private readonly SysConfigRepository $sysConfigRepo) {}
+
+    public function postPersist(PostPersistEventArgs $args): void
+    {
+        $this->maybeInvalidate($args->getObject());
+    }
+
+    public function postUpdate(PostUpdateEventArgs $args): void
+    {
+        $this->maybeInvalidate($args->getObject());
+    }
+
+    public function postRemove(PostRemoveEventArgs $args): void
+    {
+        $this->maybeInvalidate($args->getObject());
+    }
+
+    private function maybeInvalidate(object $entity): void
+    {
+        if ($entity instanceof SysConfig) {
+            $this->sysConfigRepo->invalidateCache();
+        }
+    }
+}

--- a/src/Message/DispatchPendingEmailMessage.php
+++ b/src/Message/DispatchPendingEmailMessage.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Message;
+
+class DispatchPendingEmailMessage
+{
+    public function __construct(
+        private readonly int $recharges,
+        private readonly int $packages,
+        private readonly int $total,
+        private readonly string $dispatchedAt,
+        private readonly ?string $triggeredBy,
+        private readonly array $transactionIds,
+    ) {}
+
+    public function getRecharges(): int { return $this->recharges; }
+    public function getPackages(): int { return $this->packages; }
+    public function getTotal(): int { return $this->total; }
+    public function getDispatchedAt(): string { return $this->dispatchedAt; }
+    public function getTriggeredBy(): ?string { return $this->triggeredBy; }
+    public function getTransactionIds(): array { return $this->transactionIds; }
+}

--- a/src/Message/Etecsa/SyncCatalogsMessage.php
+++ b/src/Message/Etecsa/SyncCatalogsMessage.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Message\Etecsa;
+
+final readonly class SyncCatalogsMessage
+{
+    public function __construct(
+        public int $environmentId,
+    ) {
+    }
+}

--- a/src/Message/Etecsa/SyncProductsMessage.php
+++ b/src/Message/Etecsa/SyncProductsMessage.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Message\Etecsa;
+
+final readonly class SyncProductsMessage
+{
+    public function __construct(
+        public int $environmentId,
+    ) {
+    }
+}

--- a/src/MessageHandler/DispatchPendingEmailHandler.php
+++ b/src/MessageHandler/DispatchPendingEmailHandler.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\MessageHandler;
+
+use App\Message\DispatchPendingEmailMessage;
+use Psr\Log\LoggerInterface;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
+
+#[AsMessageHandler(fromTransport: 'async_notifications_high')]
+class DispatchPendingEmailHandler
+{
+    public function __construct(
+        private readonly MailerInterface $mailer,
+        private readonly ParameterBagInterface $parameterBag,
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    public function __invoke(DispatchPendingEmailMessage $message): void
+    {
+        try {
+            $from = $this->parameterBag->get('app.email.from');
+
+            $triggeredBy = $message->getTriggeredBy();
+            $isUserEmail = $triggeredBy !== null && filter_var($triggeredBy, FILTER_VALIDATE_EMAIL);
+            $toAddress   = $isUserEmail ? new Address($triggeredBy) : new Address($from, 'Administración');
+
+            $mail = (new TemplatedEmail())
+                ->from(new Address($from, 'Sistema — Comremit'))
+                ->to($toAddress)
+                ->cc(
+                    new Address('alexander.afonsecac@gmail.com', 'A. Fonseca'),
+                    new Address('aportela7@gmail.com', 'A. Portela'),
+                )
+                ->priority(Email::PRIORITY_HIGH)
+                ->subject(sprintf('[Dispatch] %d mensaje(s) encolado(s) al API de comunicaciones', $message->getTotal()))
+                ->htmlTemplate('emails/communications/dispatch-pending.html.twig')
+                ->context([
+                    'recharges'      => $message->getRecharges(),
+                    'packages'       => $message->getPackages(),
+                    'total'          => $message->getTotal(),
+                    'dispatchedAt'   => $message->getDispatchedAt(),
+                    'triggeredBy'    => $triggeredBy ?? 'CLI / Tarea programada',
+                    'transactionIds' => $message->getTransactionIds(),
+                ]);
+
+            $this->mailer->send($mail);
+        } catch (\Exception $e) {
+            $this->logger->error('DispatchPendingEmailHandler: ' . $e->getMessage());
+        }
+    }
+}

--- a/src/MessageHandler/Etecsa/SyncCatalogsMessageHandler.php
+++ b/src/MessageHandler/Etecsa/SyncCatalogsMessageHandler.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\MessageHandler\Etecsa;
+
+use App\Entity\Environment;
+use App\Message\Etecsa\SyncCatalogsMessage;
+use App\Repository\EnvironmentRepository;
+use App\Service\Etecsa\EtecsaCatalogSyncService;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+final class SyncCatalogsMessageHandler
+{
+    public function __construct(
+        private readonly EtecsaCatalogSyncService $syncService,
+        private readonly EnvironmentRepository $environmentRepository,
+        #[Autowire('@monolog.logger.etecsa')] private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public function __invoke(SyncCatalogsMessage $message): void
+    {
+        $env = $this->environmentRepository->find($message->environmentId);
+
+        if (!$env instanceof Environment) {
+            $this->logger->warning('SyncCatalogs: environment not found', ['id' => $message->environmentId]);
+            return;
+        }
+
+        $nat = $this->syncService->syncNationalities($env);
+        $prv = $this->syncService->syncProvinces($env);
+        $off = $this->syncService->syncOffices($env);
+
+        $this->logger->info('SyncCatalogs completed', [
+            'environment' => $env->getType(),
+            'nationalities' => (string) $nat,
+            'provinces' => (string) $prv,
+            'offices' => (string) $off,
+        ]);
+    }
+}

--- a/src/MessageHandler/Etecsa/SyncProductsMessageHandler.php
+++ b/src/MessageHandler/Etecsa/SyncProductsMessageHandler.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\MessageHandler\Etecsa;
+
+use App\Entity\Environment;
+use App\Message\Etecsa\SyncProductsMessage;
+use App\Repository\EnvironmentRepository;
+use App\Service\Etecsa\EtecsaCatalogSyncService;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+final class SyncProductsMessageHandler
+{
+    public function __construct(
+        private readonly EtecsaCatalogSyncService $syncService,
+        private readonly EnvironmentRepository $environmentRepository,
+        #[Autowire('@monolog.logger.etecsa')] private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public function __invoke(SyncProductsMessage $message): void
+    {
+        $env = $this->environmentRepository->find($message->environmentId);
+
+        if (!$env instanceof Environment) {
+            $this->logger->warning('SyncProducts: environment not found', ['id' => $message->environmentId]);
+            return;
+        }
+
+        $result = $this->syncService->syncProducts($env);
+
+        $this->logger->info('SyncProducts completed', [
+            'environment' => $env->getType(),
+            'products' => (string) $result,
+        ]);
+    }
+}

--- a/src/OpenApi/DtoSchemaReflector.php
+++ b/src/OpenApi/DtoSchemaReflector.php
@@ -19,16 +19,23 @@ final class DtoSchemaReflector
      */
     public function reflect(string $className, \ArrayObject $schemas, ?string $itemDto = null): array
     {
-        if (isset($this->visited[$className])) {
-            return ['$ref' => '#/components/schemas/' . (new \ReflectionClass($className))->getShortName()];
-        }
-        $this->visited[$className] = true;
-
         if (!class_exists($className)) {
             return ['type' => 'object'];
         }
 
         $rc = new \ReflectionClass($className);
+        // When the same wrapper DTO is used with different item types (e.g. PaginatedListOutDto<User>
+        // vs PaginatedListOutDto<SysConfig>), generate a unique schema name per combination so
+        // they don't overwrite each other in the shared $schemas map.
+        $schemaName = $itemDto !== null
+            ? $rc->getShortName() . 'Of' . (new \ReflectionClass($itemDto))->getShortName()
+            : $rc->getShortName();
+
+        $cacheKey = $className . ($itemDto !== null ? '::' . $itemDto : '');
+        if (isset($this->visited[$cacheKey])) {
+            return ['$ref' => '#/components/schemas/' . $schemaName];
+        }
+        $this->visited[$cacheKey] = true;
         $allProps = [];
 
         // Incluir propiedades heredadas (para ClientPackageDetailOutDto → ClientPackageOutDto)
@@ -100,7 +107,6 @@ final class DtoSchemaReflector
             $schema['required'] = array_values(array_unique($required));
         }
 
-        $schemaName = $rc->getShortName();
         $schemas[$schemaName] = $schema;
 
         return ['$ref' => '#/components/schemas/' . $schemaName];

--- a/src/Repository/CommunicationSaleInfoRepository.php
+++ b/src/Repository/CommunicationSaleInfoRepository.php
@@ -23,6 +23,36 @@ class CommunicationSaleInfoRepository extends ServiceEntityRepository
     }
 
     /**
+     * Ventas en estado PENDING con stateProcess=CREATED: fueron persistidas pero nunca encoladas
+     * (porque el dispatch estaba deshabilitado cuando se crearon).
+     *
+     * @return CommunicationSaleInfo[]
+     */
+    public function findPendingUndispatched(): array
+    {
+        return $this->createQueryBuilder('s')
+            ->andWhere('s.state = :state')
+            ->andWhere('s.stateProcess = :stateProcess')
+            ->setParameter('state', CommunicationStateEnum::PENDING)
+            ->setParameter('stateProcess', CommunicationStateEnum::CREATED->value)
+            ->orderBy('s.createdAt', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    public function countPendingUndispatched(): int
+    {
+        return (int) $this->createQueryBuilder('s')
+            ->select('COUNT(s.id)')
+            ->andWhere('s.state = :state')
+            ->andWhere('s.stateProcess = :stateProcess')
+            ->setParameter('state', CommunicationStateEnum::PENDING)
+            ->setParameter('stateProcess', CommunicationStateEnum::CREATED->value)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    /**
      * @return CommunicationSaleInfo[]
      * @throws \DateMalformedStringException
      */

--- a/src/Repository/SysConfigRepository.php
+++ b/src/Repository/SysConfigRepository.php
@@ -5,6 +5,9 @@ namespace App\Repository;
 use App\Entity\SysConfig;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
 
 /**
  * @extends ServiceEntityRepository<SysConfig>
@@ -16,9 +19,36 @@ use Doctrine\Persistence\ManagerRegistry;
  */
 class SysConfigRepository extends ServiceEntityRepository
 {
-    public function __construct(ManagerRegistry $registry)
-    {
+    private const CACHE_TAG = 'sys_config';
+
+    public function __construct(
+        ManagerRegistry $registry,
+        #[Autowire(service: 'cache.sys_config')]
+        private readonly TagAwareCacheInterface $cache,
+    ) {
         parent::__construct($registry, SysConfig::class);
     }
 
+    /**
+     * Devuelve el propertyValue de una configuración, usando caché.
+     * Para lecturas de escritura (update de la entidad), usar findOneBy() directamente.
+     */
+    public function findCachedValue(string $propertyName, bool $mustBeActive = false): ?string
+    {
+        $key = 'sc_' . ($mustBeActive ? 'a_' : '') . md5($propertyName);
+
+        return $this->cache->get($key, function (ItemInterface $item) use ($propertyName, $mustBeActive) {
+            $item->tag([self::CACHE_TAG]);
+            $criteria = ['propertyName' => $propertyName];
+            if ($mustBeActive) {
+                $criteria['isActive'] = true;
+            }
+            return $this->findOneBy($criteria)?->getPropertyValue();
+        });
+    }
+
+    public function invalidateCache(): void
+    {
+        $this->cache->invalidateTags([self::CACHE_TAG]);
+    }
 }

--- a/src/Repository/SysConfigRepository.php
+++ b/src/Repository/SysConfigRepository.php
@@ -26,7 +26,7 @@ class SysConfigRepository extends ServiceEntityRepository
         ManagerRegistry $registry,
         #[Autowire(service: 'cache.sys_config')]
         private readonly TagAwareCacheInterface $cache,
-        #[Autowire('%env(default::SYS_CONFIG_ENCRYPTION_KEY)%')]
+        #[Autowire('%env(string:default::SYS_CONFIG_ENCRYPTION_KEY)%')]
         private readonly string $encryptionKey = '',
     ) {
         parent::__construct($registry, SysConfig::class);

--- a/src/Repository/SysConfigRepository.php
+++ b/src/Repository/SysConfigRepository.php
@@ -3,6 +3,7 @@
 namespace App\Repository;
 
 use App\Entity\SysConfig;
+use App\Service\SysConfigCipher;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -25,12 +26,15 @@ class SysConfigRepository extends ServiceEntityRepository
         ManagerRegistry $registry,
         #[Autowire(service: 'cache.sys_config')]
         private readonly TagAwareCacheInterface $cache,
+        #[Autowire('%env(default::SYS_CONFIG_ENCRYPTION_KEY)%')]
+        private readonly string $encryptionKey = '',
     ) {
         parent::__construct($registry, SysConfig::class);
     }
 
     /**
      * Devuelve el propertyValue de una configuración, usando caché.
+     * Si el valor está cifrado, lo descifra antes de devolver (y cachea el valor descifrado).
      * Para lecturas de escritura (update de la entidad), usar findOneBy() directamente.
      */
     public function findCachedValue(string $propertyName, bool $mustBeActive = false): ?string
@@ -43,7 +47,15 @@ class SysConfigRepository extends ServiceEntityRepository
             if ($mustBeActive) {
                 $criteria['isActive'] = true;
             }
-            return $this->findOneBy($criteria)?->getPropertyValue();
+            $config = $this->findOneBy($criteria);
+            if ($config === null) {
+                return null;
+            }
+            $value = $config->getPropertyValue();
+            if ($config->isEncrypted() && $value !== null && $this->encryptionKey !== '') {
+                $value = SysConfigCipher::decrypt($value, $this->encryptionKey);
+            }
+            return $value;
         });
     }
 

--- a/src/Security/DashboardUserChecker.php
+++ b/src/Security/DashboardUserChecker.php
@@ -6,6 +6,7 @@ use App\Entity\User;
 use Symfony\Component\Security\Core\Exception\AccountExpiredException;
 use Symfony\Component\Security\Core\Exception\CustomUserMessageAccountStatusException;
 use Symfony\Component\Security\Core\Exception\DisabledException;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
@@ -24,7 +25,7 @@ class DashboardUserChecker implements UserCheckerInterface
         }
     }
 
-    public function checkPostAuth(UserInterface $user): void
+    public function checkPostAuth(UserInterface $user, ?TokenInterface $token = null): void
     {
         if (!$user instanceof User) {
             return;

--- a/src/Service/BalanceService.php
+++ b/src/Service/BalanceService.php
@@ -78,14 +78,10 @@ class BalanceService extends CommonService
             $criticalBalance = $account->getCriticalBalance() ?? $account->getClient()?->getCriticalBalance();
             $minBalance = $account->getMinBalance() ?? $account->getClient()?->getMinBalance();
             if (is_null($criticalBalance)) {
-                $criticalBalance = (float)$this->sysConfigRepo->findOneBy([
-                    'propertyName' => 'client.critical.balance.operation',
-                ])?->getPropertyValue();
+                $criticalBalance = (float)$this->sysConfigRepo->findCachedValue('client.critical.balance.operation');
             }
             if (is_null($minBalance)) {
-                $minBalance = (float)$this->sysConfigRepo->findOneBy([
-                    'propertyName' => 'client.min.balance.operation',
-                ])?->getPropertyValue();
+                $minBalance = (float)$this->sysConfigRepo->findCachedValue('client.min.balance.operation');
             }
             /** @var \App\Repository\EmailNotificationRepository $emailNotifRepo */
             $emailNotifRepo = $this->em->getRepository(EmailNotification::class);

--- a/src/Service/CommunicationInfoService.php
+++ b/src/Service/CommunicationInfoService.php
@@ -32,6 +32,7 @@ class CommunicationInfoService extends CommonService
         SysConfigRepository $sysConfigRepo,
         SerializerInterface $serializer,
         private readonly EtecsaGatewayClient $etecsaClient,
+        private readonly HistoricalSaleService $historicalSaleService,
     ) {
         parent::__construct(
             $em,
@@ -87,6 +88,19 @@ class CommunicationInfoService extends CommonService
 
         $env = $tenant->getEnvironment();
 
-        return $this->etecsaClient->getStatus($env, $operationSale->getTransactionId());
+        $result = $this->etecsaClient->getStatus($env, $operationSale->getTransactionId());
+
+        $state = $operationSale->getState();
+        if ($state !== null) {
+            $infoArray = json_decode($this->serializer->serialize($result, 'json'), true) ?? [];
+            $this->historicalSaleService->createHistoricalCommunication(
+                $operationSale->getId(),
+                $state,
+                $infoArray
+            );
+            $this->em->flush();
+        }
+
+        return $result;
     }
 }

--- a/src/Service/CommunicationInfoService.php
+++ b/src/Service/CommunicationInfoService.php
@@ -3,13 +3,13 @@
 namespace App\Service;
 
 use ApiPlatform\Symfony\Security\Exception\AccessDeniedException;
-use App\DTO\Out\InfoResult;
 use App\DTO\RequestInfo;
 use App\Entity\CommunicationSalePackage;
 use App\Entity\CommunicationSaleRecharge;
 use App\Entity\User;
 use App\Repository\EnvironmentRepository;
 use App\Repository\SysConfigRepository;
+use App\Service\Etecsa\EtecsaGatewayClient;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityNotFoundException;
 use Psr\Log\LoggerInterface;
@@ -18,26 +18,9 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Serializer\SerializerInterface;
-use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
-use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
-use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
-use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class CommunicationInfoService extends CommonService
 {
-    /**
-     * @param \Doctrine\ORM\EntityManagerInterface $em
-     * @param \Symfony\Bundle\SecurityBundle\Security $security
-     * @param \Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface $parameters
-     * @param \Symfony\Component\Mailer\MailerInterface $mailer
-     * @param \Psr\Log\LoggerInterface $logger
-     * @param \Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface $passwordHasher
-     * @param \App\Repository\EnvironmentRepository $environmentRepository
-     * @param \App\Repository\SysConfigRepository $sysConfigRepo
-     * @param \Symfony\Component\Serializer\SerializerInterface $serializer
-     * @param \Symfony\Contracts\HttpClient\HttpClientInterface $httpClient
-     */
     public function __construct(
         EntityManagerInterface $em,
         Security $security,
@@ -48,7 +31,7 @@ class CommunicationInfoService extends CommonService
         EnvironmentRepository $environmentRepository,
         SysConfigRepository $sysConfigRepo,
         SerializerInterface $serializer,
-        private readonly HttpClientInterface $httpClient,
+        private readonly EtecsaGatewayClient $etecsaClient,
     ) {
         parent::__construct(
             $em,
@@ -63,14 +46,6 @@ class CommunicationInfoService extends CommonService
         );
     }
 
-    /**
-     * @param \App\DTO\RequestInfo $requestInfo
-     * @return mixed|object|string|void
-     * @throws \Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface
-     * @throws \Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface
-     * @throws \Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface
-     * @throws \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface
-     */
     public function querySale(RequestInfo $requestInfo)
     {
         $user = $this->security->getUser();
@@ -94,6 +69,8 @@ class CommunicationInfoService extends CommonService
                 'clientTransactionId' => $requestInfo->getClientTxId(),
             ];
         }
+
+        // Guardia: no consultar a la gateway si la venta no fue enviada previamente
         $operationSale = $this->em->getRepository($class)->findOneBy($params);
         $date = new \DateTimeImmutable('now');
         if (is_null($operationSale)) {
@@ -107,37 +84,9 @@ class CommunicationInfoService extends CommonService
         if (is_null($tenant)) {
             return;
         }
-        $url = $tenant->getEnvironment()?->getBasePath().'/information/status';
 
-        $body = [
-            'environment' => $tenant->getEnvironment()?->getType(),
-            'transactionId' => $operationSale->getTransactionId(),
-        ];
+        $env = $tenant->getEnvironment();
 
-        try {
-            $queryResponse = $this->httpClient->request(
-                'POST',
-                $url,
-                [
-                    'headers' => [
-                        'Content-Type' => 'application/json',
-                        'Accept' => 'application/json',
-                    ],
-                    'body' => $this->serializer->serialize($body, 'json'),
-                ]
-            );
-
-            $serviceResult = $queryResponse->getContent();
-
-            return $this->serializer->deserialize(
-                $serviceResult,
-                InfoResult::class,
-                'json',
-            );
-        } catch (ClientExceptionInterface| TransportExceptionInterface | RedirectionExceptionInterface | ServerExceptionInterface $e) {
-            throw $e;
-        } catch (\Exception $ex) {
-            throw $ex;
-        }
+        return $this->etecsaClient->getStatus($env, $operationSale->getTransactionId());
     }
 }

--- a/src/Service/CommunicationSaleService.php
+++ b/src/Service/CommunicationSaleService.php
@@ -987,7 +987,7 @@ class CommunicationSaleService extends CommonService
         } catch (\Exception $e) {
             $message = $e->getMessage();
             $this->logger->error($message);
-            if ($e instanceof ClientException && $e->getCode() === 404 && $isProcess) {
+            if ($e instanceof ClientException && $e->getCode() === 404) {
                 $currentStatus = $sale->getTransactionStatus();
                 $retryCount = (int) ($currentStatus['retryCount'] ?? 0);
 

--- a/src/Service/CommunicationSaleService.php
+++ b/src/Service/CommunicationSaleService.php
@@ -897,7 +897,10 @@ class CommunicationSaleService extends CommonService
             if ($fullResponse !== null) {
                 $fullResponseObj = isset($fullResponse->SaleRecharge) ? (object) $fullResponse->SaleRecharge : null;
                 if ($fullResponseObj !== null) {
-                    $isTrue = $statusResponse === "COMPLETED" && $fullResponseObj->RechargeStateCode === "OK";
+                    $rechargeStateCode = ($fullResponseObj->RechargeStateCode ?? '');
+                    $rechargeState     = ($fullResponseObj->RechargeState ?? '');
+                    $isTrue = $statusResponse === "COMPLETED"
+                        && ($rechargeStateCode === "OK" || $rechargeState === "Realizada");
                 }
             }
             $sale->setTransactionStatus($response);

--- a/src/Service/CommunicationSaleService.php
+++ b/src/Service/CommunicationSaleService.php
@@ -34,11 +34,11 @@ use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Serializer\SerializerInterface;
+use App\Service\Etecsa\EtecsaGatewayClient;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class CommunicationSaleService extends CommonService
 {
@@ -103,7 +103,6 @@ class CommunicationSaleService extends CommonService
      * @param \App\Repository\EnvironmentRepository $environmentRepository
      * @param \App\Repository\SysConfigRepository $sysConfigRepo
      * @param \Symfony\Component\Serializer\SerializerInterface $serializer
-     * @param \Symfony\Contracts\HttpClient\HttpClientInterface $httpClient
      * @param \App\Service\ConfigureSequenceService $configureSequence
      * @param \Symfony\Component\Messenger\MessageBusInterface $messageBus
      * @param \App\Service\HistoricalSaleService $historicalSaleService
@@ -119,7 +118,7 @@ class CommunicationSaleService extends CommonService
         EnvironmentRepository $environmentRepository,
         SysConfigRepository $sysConfigRepo,
         SerializerInterface $serializer,
-        private readonly HttpClientInterface $httpClient,
+        private readonly EtecsaGatewayClient $etecsaClient,
         private readonly ConfigureSequenceService $configureSequence,
         private readonly MessageBusInterface $messageBus,
         private readonly HistoricalSaleService $historicalSaleService,
@@ -469,18 +468,13 @@ class CommunicationSaleService extends CommonService
                     'environment' => $environment->getType(),
                 ];
 
-                $rechargeResponse = $this->httpClient->request(
-                    'POST',
-                    $urlRecharge,
-                    [
-                        'headers' => [
-                            'Content-Type' => 'application/json',
-                            'Accept' => 'application/json',
-                        ],
-                        'body' => $this->serializer->serialize($body, 'json', []),
-                    ]
+                $rechargeInfo = $this->etecsaClient->recharge(
+                    $environment,
+                    $phoneNumber,
+                    (int) $productCode,
+                    (float) $destination->amount,
+                    $saleRecharge->getTransactionId(),
                 );
-                $rechargeInfo = $rechargeResponse->toArray();
                 $saleRecharge->setTransactionStatus($rechargeInfo);
                 $saleRecharge->setStateProcess(CommunicationStateEnum::PENDING->value);
                 $rechargeResult = (object)((object)$rechargeInfo)->result;
@@ -754,19 +748,12 @@ class CommunicationSaleService extends CommonService
                 'environment' => $user->getEnvironment()?->getType(),
             ];
 
-            $saleResponse = $this->httpClient->request(
-                'POST',
-                $urlSale,
-                [
-                    'headers' => [
-                        'Content-Type' => 'application/json',
-                        'Accept' => 'application/json',
-                    ],
-                    'body' => $this->serializer->serialize($body, 'json', []),
-                ]
+            $saleInfo = $this->etecsaClient->sellPackage(
+                $user->getEnvironment(),
+                $transactionId,
+                $body['packageInfo'],
+                $body['client'],
             );
-
-            $saleInfo = $saleResponse->toArray();
             $saleResult = (object)((object)$saleInfo)->result;
             $code = null;
             if (property_exists($saleResult, 'code')) {
@@ -897,21 +884,11 @@ class CommunicationSaleService extends CommonService
             'transactionId' => $sale->getTransactionId(),
         ];
 
-        $rechargeResponse = null;
         try {
-            $rechargeResponse = $this->httpClient->request(
-                'POST',
-                $url,
-                [
-                    'headers' => [
-                        'Content-Type' => 'application/json',
-                        'Accept' => 'application/json',
-                    ],
-                    'body' => $this->serializer->serialize($body, 'json'),
-                ]
+            $response = $this->etecsaClient->getSaleInfo(
+                $tenant->getEnvironment(),
+                $sale->getTransactionId(),
             );
-
-            $response = $rechargeResponse->toArray();
             $responseInfo = (object)$response;
             $statusResponse = strtoupper($responseInfo->status);
             $result = isset($responseInfo->result) ? (object)$responseInfo->result : null;
@@ -1005,9 +982,8 @@ class CommunicationSaleService extends CommonService
             }
             $this->em->flush();
         } catch (\Exception $e) {
-            $infoResponse = $rechargeResponse !== null ? json_decode($rechargeResponse->getContent(false), true) : [];
             $message = $e->getMessage();
-            $this->logger->error($rechargeResponse !== null ? $rechargeResponse->getContent(false) : $message, is_array($infoResponse) ? $infoResponse : []);
+            $this->logger->error($message);
             if ($e instanceof ClientException && $e->getCode() === 404 && $isProcess) {
                 // TO-DO: Recheck info to process
                 // $this->tryAgainWithTransaction($saleId);

--- a/src/Service/CommunicationSaleService.php
+++ b/src/Service/CommunicationSaleService.php
@@ -987,7 +987,7 @@ class CommunicationSaleService extends CommonService
         } catch (\Exception $e) {
             $message = $e->getMessage();
             $this->logger->error($message);
-            if ($e instanceof ClientException && $e->getCode() === 404) {
+            if ($e->getCode() === 404) {
                 $currentStatus = $sale->getTransactionStatus();
                 $retryCount = (int) ($currentStatus['retryCount'] ?? 0);
 

--- a/src/Service/CommunicationSaleService.php
+++ b/src/Service/CommunicationSaleService.php
@@ -992,12 +992,22 @@ class CommunicationSaleService extends CommonService
                 $retryCount = (int) ($currentStatus['retryCount'] ?? 0);
 
                 if ($sale instanceof CommunicationSaleRecharge && $retryCount < 3) {
-                    $currentStatus['retryCount'] = $retryCount + 1;
-                    $sale->setTransactionStatus($currentStatus);
-                    $sale->setStateProcess(CommunicationStateEnum::CREATED->value);
-                    $this->em->flush();
-                    $this->messageBus->dispatch(new SaleRechargeMessage($sale->getId()));
-                    $this->logger->info("Sale {$saleId}: not found in ApiComm, resending (attempt {$currentStatus['retryCount']})");
+                    $now = new \DateTimeImmutable();
+                    $lastRetryAt = isset($currentStatus['lastRetryAt'])
+                        ? new \DateTimeImmutable($currentStatus['lastRetryAt'])
+                        : null;
+                    $referenceTime = $lastRetryAt ?? $sale->getCreatedAt();
+                    $secondsElapsed = $now->getTimestamp() - $referenceTime->getTimestamp();
+
+                    if ($secondsElapsed >= 4 * 3600) {
+                        $currentStatus['retryCount'] = $retryCount + 1;
+                        $currentStatus['lastRetryAt'] = $now->format(\DateTimeInterface::ATOM);
+                        $sale->setTransactionStatus($currentStatus);
+                        $sale->setStateProcess(CommunicationStateEnum::CREATED->value);
+                        $this->em->flush();
+                        $this->messageBus->dispatch(new SaleRechargeMessage($sale->getId()));
+                        $this->logger->info("Sale {$saleId}: not found in ApiComm, resending (attempt {$currentStatus['retryCount']})");
+                    }
                 } else {
                     $sale->setStateProcess(CommunicationStateEnum::FAILED->value);
                     $this->em->flush();

--- a/src/Service/CommunicationSaleService.php
+++ b/src/Service/CommunicationSaleService.php
@@ -341,13 +341,13 @@ class CommunicationSaleService extends CommonService
     public function tryAgainWithTransaction(int $saleId): void
     {
         $recharge = $this->em->getRepository(CommunicationSaleRecharge::class)->find($saleId);
-        $recharge?->setState(CommunicationStateEnum::PENDING);
+        if ($recharge === null) {
+            return;
+        }
+        $recharge->setState(CommunicationStateEnum::PENDING);
+        $recharge->setStateProcess(CommunicationStateEnum::CREATED->value);
         $this->em->flush();
-        $this->messageBus->dispatch(
-            new SaleRechargeMessage(
-                $saleId
-            )
-        );
+        $this->messageBus->dispatch(new SaleRechargeMessage($saleId));
     }
 
     /**
@@ -988,10 +988,20 @@ class CommunicationSaleService extends CommonService
             $message = $e->getMessage();
             $this->logger->error($message);
             if ($e instanceof ClientException && $e->getCode() === 404 && $isProcess) {
-                // TO-DO: Recheck info to process
-                // $this->tryAgainWithTransaction($saleId);
-                $sale->setStateProcess(CommunicationStateEnum::FAILED->value);
-                $this->em->flush();
+                $currentStatus = $sale->getTransactionStatus();
+                $retryCount = (int) ($currentStatus['retryCount'] ?? 0);
+
+                if ($sale instanceof CommunicationSaleRecharge && $retryCount < 3) {
+                    $currentStatus['retryCount'] = $retryCount + 1;
+                    $sale->setTransactionStatus($currentStatus);
+                    $sale->setStateProcess(CommunicationStateEnum::CREATED->value);
+                    $this->em->flush();
+                    $this->messageBus->dispatch(new SaleRechargeMessage($sale->getId()));
+                    $this->logger->info("Sale {$saleId}: not found in ApiComm, resending (attempt {$currentStatus['retryCount']})");
+                } else {
+                    $sale->setStateProcess(CommunicationStateEnum::FAILED->value);
+                    $this->em->flush();
+                }
             } elseif ($e->getCode() === 400) {
                 $comInfo = [
                     'status' => [

--- a/src/Service/CommunicationSaleService.php
+++ b/src/Service/CommunicationSaleService.php
@@ -137,6 +137,13 @@ class CommunicationSaleService extends CommonService
         );
     }
 
+    private const DISPATCH_ENABLED_KEY = 'communications.dispatch.enabled';
+
+    private function isDispatchEnabled(): bool
+    {
+        return $this->sysConfigRepo->findCachedValue(self::DISPATCH_ENABLED_KEY) !== '0';
+    }
+
     /**
      * Activa un lote de ventas RESERVED cuya promoción ya comenzó.
      * Persiste todos los cambios antes de despachar mensajes para evitar race conditions.
@@ -174,8 +181,12 @@ class CommunicationSaleService extends CommonService
 
         $this->em->flush();
 
-        foreach ($toDispatch as $sale) {
-            $this->messageBus->dispatch(new SaleRechargeMessage($sale->getId()));
+        if ($this->isDispatchEnabled()) {
+            foreach ($toDispatch as $sale) {
+                $this->messageBus->dispatch(new SaleRechargeMessage($sale->getId()));
+            }
+        } else {
+            $this->logger->info('Communications dispatch disabled: ' . count($toDispatch) . ' activated sale(s) queued in DB, pending dispatch.');
         }
 
         return $activated;
@@ -308,11 +319,11 @@ class CommunicationSaleService extends CommonService
             $this->em->persist($comHistoric);
             $this->em->flush();
 
-            $this->messageBus->dispatch(
-                new SaleRechargeMessage(
-                    $recharge->getId()
-                )
-            );
+            if ($this->isDispatchEnabled()) {
+                $this->messageBus->dispatch(new SaleRechargeMessage($recharge->getId()));
+            } else {
+                $this->logger->info("Communications dispatch disabled: recharge {$recharge->getId()} saved, pending dispatch.");
+            }
         } catch (\Exception $ex) {
             if (str_contains($ex->getMessage(), "unique_identification_client")) {
                 throw new MyCurrentException(
@@ -670,8 +681,12 @@ class CommunicationSaleService extends CommonService
             $this->em->persist($comHistoric);
             $this->em->flush();
 
-            $this->messageBus->dispatch(new SalePackageMessage($sale->getId()));
-        }  catch (\Exception $ex) {
+            if ($this->isDispatchEnabled()) {
+                $this->messageBus->dispatch(new SalePackageMessage($sale->getId()));
+            } else {
+                $this->logger->info("Communications dispatch disabled: sale package {$sale->getId()} saved, pending dispatch.");
+            }
+        } catch (\Exception $ex) {
             if (str_contains($ex->getMessage(), "unique_identification_client")) {
                 throw new MyCurrentException(
                     "102",

--- a/src/Service/CommunicationsDispatchService.php
+++ b/src/Service/CommunicationsDispatchService.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\CommunicationSaleInfo;
+use App\Entity\CommunicationSalePackage;
+use App\Entity\CommunicationSaleRecharge;
+use App\Entity\SysConfig;
+use App\Exception\MyCurrentException;
+use App\Message\DispatchPendingEmailMessage;
+use App\Message\SalePackageMessage;
+use App\Message\SaleRechargeMessage;
+use App\Repository\CommunicationSaleInfoRepository;
+use App\Repository\SysConfigRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+class CommunicationsDispatchService
+{
+    public const CONFIG_KEY = 'communications.dispatch.enabled';
+
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly SysConfigRepository $sysConfigRepo,
+        private readonly MessageBusInterface $messageBus,
+    ) {}
+
+    public function invalidateCache(): void
+    {
+        $this->sysConfigRepo->invalidateCache();
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->sysConfigRepo->findCachedValue(self::CONFIG_KEY) !== '0';
+    }
+
+    public function setEnabled(bool $enabled): void
+    {
+        $config = $this->sysConfigRepo->findOneBy(['propertyName' => self::CONFIG_KEY]);
+        if ($config === null) {
+            $config = (new SysConfig())->setPropertyName(self::CONFIG_KEY);
+            $this->em->persist($config);
+        }
+        $config->setPropertyValue($enabled ? '1' : '0');
+        $this->em->flush();
+        $this->sysConfigRepo->invalidateCache();
+    }
+
+    public function countPendingUndispatched(): int
+    {
+        /** @var CommunicationSaleInfoRepository $repo */
+        $repo = $this->em->getRepository(CommunicationSaleInfo::class);
+        return $repo->countPendingUndispatched();
+    }
+
+    /**
+     * Encola en RabbitMQ todas las ventas que quedaron sin despachar y envía un email de resumen.
+     * Lanza MyCurrentException si el dispatch está deshabilitado.
+     *
+     * @return array{recharges: int, packages: int, total: int}
+     * @throws MyCurrentException
+     */
+    public function dispatchPending(?string $triggeredBy = null): array
+    {
+        if (!$this->isEnabled()) {
+            throw new MyCurrentException(
+                'DISPATCH_DISABLED',
+                'El dispatch de comunicaciones está deshabilitado. Habilítalo antes de lanzar los mensajes pendientes.',
+                Response::HTTP_CONFLICT
+            );
+        }
+
+        /** @var CommunicationSaleInfoRepository $repo */
+        $repo = $this->em->getRepository(CommunicationSaleInfo::class);
+        $sales = $repo->findPendingUndispatched();
+
+        $recharges      = 0;
+        $packages       = 0;
+        $transactionIds = [];
+
+        foreach ($sales as $sale) {
+            if ($sale instanceof CommunicationSaleRecharge) {
+                $this->messageBus->dispatch(new SaleRechargeMessage($sale->getId()));
+                $recharges++;
+            } elseif ($sale instanceof CommunicationSalePackage) {
+                $this->messageBus->dispatch(new SalePackageMessage($sale->getId()));
+                $packages++;
+            }
+            if ($sale->getTransactionId() !== null) {
+                $transactionIds[] = $sale->getTransactionId();
+            }
+        }
+
+        $total = $recharges + $packages;
+
+        if ($total > 0) {
+            $this->messageBus->dispatch(new DispatchPendingEmailMessage(
+                recharges:      $recharges,
+                packages:       $packages,
+                total:          $total,
+                dispatchedAt:   (new \DateTimeImmutable('now'))->format(\DateTimeInterface::ATOM),
+                triggeredBy:    $triggeredBy,
+                transactionIds: $transactionIds,
+            ));
+        }
+
+        return ['recharges' => $recharges, 'packages' => $packages, 'total' => $total];
+    }
+}

--- a/src/Service/Etecsa/EtecsaCatalogSyncService.php
+++ b/src/Service/Etecsa/EtecsaCatalogSyncService.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace App\Service\Etecsa;
+
+use App\Entity\CommunicationNationality;
+use App\Entity\CommunicationOffice;
+use App\Entity\CommunicationProduct;
+use App\Entity\CommunicationProvinces;
+use App\Entity\Environment;
+use App\Repository\EnvironmentRepository;
+use App\Repository\SysConfigRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+use App\Service\CommonService;
+
+class EtecsaCatalogSyncService extends CommonService
+{
+    public function __construct(
+        EntityManagerInterface $em,
+        Security $security,
+        ParameterBagInterface $parameters,
+        MailerInterface $mailer,
+        LoggerInterface $logger,
+        UserPasswordHasherInterface $passwordHasher,
+        EnvironmentRepository $environmentRepository,
+        SysConfigRepository $sysConfigRepo,
+        SerializerInterface $serializer,
+        private readonly EtecsaGatewayClient $client,
+    ) {
+        parent::__construct($em, $security, $parameters, $mailer, $logger, $passwordHasher, $environmentRepository, $sysConfigRepo, $serializer);
+    }
+
+    /**
+     * Sincroniza el catálogo de nacionalidades usando upsert por (environment, comId).
+     * No elimina registros — solo inserta y actualiza.
+     */
+    public function syncNationalities(Environment $env): SyncResult
+    {
+        $items = $this->client->listNationalities($env);
+        $created = $updated = $skipped = 0;
+        $repo = $this->em->getRepository(CommunicationNationality::class);
+
+        foreach ($items as $raw) {
+            $item = (object) $raw;
+
+            if (!isset($item->Id)) {
+                ++$skipped;
+                continue;
+            }
+
+            $entity = $repo->findOneBy(['environment' => $env, 'comId' => (int) $item->Id]);
+
+            if ($entity === null) {
+                $entity = new CommunicationNationality();
+                $entity->setEnvironment($env);
+                $entity->setComId((int) $item->Id);
+                $this->em->persist($entity);
+                ++$created;
+            } else {
+                ++$updated;
+            }
+
+            $entity->setName((string) ($item->Name ?? ''));
+            $entity->setCodeAlpha3((string) ($item->Abbreviation ?? ''));
+        }
+
+        $this->em->flush();
+
+        return new SyncResult($created, $updated, $skipped);
+    }
+
+    /**
+     * Sincroniza provincias y sus oficinas comerciales usando upsert por (environment, comId).
+     * Las oficinas se sincronizan por provincia; no se eliminan registros existentes.
+     */
+    public function syncProvinces(Environment $env): SyncResult
+    {
+        $items = $this->client->listProvinces($env);
+        $created = $updated = $skipped = 0;
+        $repo = $this->em->getRepository(CommunicationProvinces::class);
+
+        foreach ($items as $raw) {
+            $item = (object) $raw;
+
+            if (!isset($item->Id)) {
+                ++$skipped;
+                continue;
+            }
+
+            $entity = $repo->findOneBy(['environment' => $env, 'comId' => (int) $item->Id]);
+
+            if ($entity === null) {
+                $entity = new CommunicationProvinces();
+                $entity->setEnvironment($env);
+                $entity->setComId((int) $item->Id);
+                $this->em->persist($entity);
+                ++$created;
+            } else {
+                ++$updated;
+            }
+
+            $entity->setName((string) ($item->Name ?? ''));
+        }
+
+        $this->em->flush();
+
+        return new SyncResult($created, $updated, $skipped);
+    }
+
+    /**
+     * Sincroniza oficinas comerciales para todas las provincias del entorno.
+     * Upsert por (environment, comId string). Requiere que las provincias ya estén sincronizadas.
+     */
+    public function syncOffices(Environment $env): SyncResult
+    {
+        $provinces = $this->em->getRepository(CommunicationProvinces::class)->findBy(['environment' => $env]);
+        $created = $updated = $skipped = 0;
+        $officeRepo = $this->em->getRepository(CommunicationOffice::class);
+
+        foreach ($provinces as $province) {
+            $items = $this->client->listCommercialOffices($env, $province->getComId());
+
+            foreach ($items as $raw) {
+                $item = (object) $raw;
+
+                if (!isset($item->Id)) {
+                    ++$skipped;
+                    continue;
+                }
+
+                $comId = (string) $item->Id;
+                $entity = $officeRepo->findOneBy(['environment' => $env, 'comId' => $comId]);
+
+                if ($entity === null) {
+                    $entity = new CommunicationOffice();
+                    $entity->setEnvironment($env);
+                    $entity->setComId($comId);
+                    $entity->setProvince($province);
+                    $this->em->persist($entity);
+                    ++$created;
+                } else {
+                    ++$updated;
+                }
+
+                $entity->setName((string) ($item->Name ?? ''));
+                $entity->setIsActive(true);
+                $entity->setIsAirport((bool) ($item->IsAirport ?? false));
+            }
+        }
+
+        $this->em->flush();
+
+        return new SyncResult($created, $updated, $skipped);
+    }
+
+    /**
+     * Sincroniza el catálogo de productos (paquetes ETECSA) usando upsert por (environment, packageId).
+     * Solo inserta/actualiza productos activos y vigentes; no elimina los ya expirados de la BD.
+     */
+    public function syncProducts(Environment $env): SyncResult
+    {
+        $items = $this->client->listPackages($env);
+        $created = $updated = $skipped = 0;
+        $repo = $this->em->getRepository(CommunicationProduct::class);
+        $now = new \DateTimeImmutable();
+
+        foreach ($items as $raw) {
+            $item = (object) $raw;
+
+            if (!isset($item->Id)) {
+                ++$skipped;
+                continue;
+            }
+
+            $entity = $repo->findOneBy(['environment' => $env, 'packageId' => (int) $item->Id]);
+
+            if ($entity === null) {
+                $entity = new CommunicationProduct();
+                $entity->setEnvironment($env);
+                $entity->setPackageId((int) $item->Id);
+                $this->em->persist($entity);
+                ++$created;
+            } else {
+                ++$updated;
+            }
+
+            $entity->setPackageType((string) ($item->PackageType ?? ''));
+            $entity->setProductType((string) ($item->PackageType ?? ''));
+            $entity->setPrice((float) ($item->Price ?? 0.0));
+            $entity->setEnabled((bool) ($item->Enabled ?? false));
+            $entity->setDescription((string) ($item->Description ?? ''));
+
+            if (!empty($item->InitialDate)) {
+                $entity->setInitialDate(new \DateTimeImmutable($item->InitialDate));
+            }
+
+            $endDate = !empty($item->FinalDate) ? new \DateTimeImmutable($item->FinalDate) : null;
+            $entity->setEndDateAt($endDate);
+        }
+
+        $this->em->flush();
+
+        return new SyncResult($created, $updated, $skipped);
+    }
+}

--- a/src/Service/Etecsa/EtecsaGatewayClient.php
+++ b/src/Service/Etecsa/EtecsaGatewayClient.php
@@ -38,6 +38,7 @@ class EtecsaGatewayClient extends CommonService
         private readonly HttpClientInterface $httpClient,
         #[Autowire('@monolog.logger.etecsa')] private readonly LoggerInterface $etecsaLogger,
         #[Autowire('%env(API_COMMUNICATIONS_KEY)%')] private readonly string $apiKey,
+        #[Autowire('%env(APP_TEST_PHONE)%')] private readonly string $testPhone,
     ) {
         parent::__construct($em, $security, $parameters, $mailer, $logger, $passwordHasher, $environmentRepository, $sysConfigRepo, $serializer);
     }
@@ -52,6 +53,10 @@ class EtecsaGatewayClient extends CommonService
         float $productPrice,
         string $transactionId,
     ): array {
+        if ($env->getType() === 'TEST' && str_ends_with($phoneNumber, '60')) {
+            $phoneNumber = $this->testPhone;
+        }
+
         $body = [
             'phoneNumber' => $phoneNumber,
             'productCode' => $productCode,

--- a/src/Service/Etecsa/EtecsaGatewayClient.php
+++ b/src/Service/Etecsa/EtecsaGatewayClient.php
@@ -37,7 +37,6 @@ class EtecsaGatewayClient extends CommonService
         SerializerInterface $serializer,
         private readonly HttpClientInterface $httpClient,
         #[Autowire('@monolog.logger.etecsa')] private readonly LoggerInterface $etecsaLogger,
-        #[Autowire('%env(API_COMMUNICATIONS_KEY)%')] private readonly string $apiKey,
         #[Autowire('%env(APP_TEST_PHONE)%')] private readonly string $testPhone,
     ) {
         parent::__construct($em, $security, $parameters, $mailer, $logger, $passwordHasher, $environmentRepository, $sysConfigRepo, $serializer);
@@ -189,13 +188,18 @@ class EtecsaGatewayClient extends CommonService
         $url = $env->getBasePath() . $path;
         $start = microtime(true);
 
+        $apiKey = $this->sysConfigRepo->findCachedValue('api.' . strtolower($env->getType()) . '.communications.key');
+        $headers = [
+            'Content-Type' => 'application/json',
+            'Accept'       => 'application/json',
+        ];
+        if ($apiKey !== null && $apiKey !== '') {
+            $headers['X-Api-Key'] = $apiKey;
+        }
+
         try {
             $response = $this->httpClient->request('POST', $url, [
-                'headers' => [
-                    'Content-Type'  => 'application/json',
-                    'Accept'        => 'application/json',
-                    'X-Api-Key'     => $this->apiKey,
-                ],
+                'headers' => $headers,
                 'body' => $this->serializer->serialize($body, 'json'),
             ]);
 

--- a/src/Service/Etecsa/EtecsaGatewayClient.php
+++ b/src/Service/Etecsa/EtecsaGatewayClient.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace App\Service\Etecsa;
+
+use App\DTO\Etecsa\EtecsaBalanceDto;
+use App\DTO\Out\InfoResult;
+use App\Entity\Environment;
+use App\Exception\MyCurrentException;
+use App\Repository\EnvironmentRepository;
+use App\Repository\SysConfigRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use App\Service\CommonService;
+
+class EtecsaGatewayClient extends CommonService
+{
+    public function __construct(
+        EntityManagerInterface $em,
+        Security $security,
+        ParameterBagInterface $parameters,
+        MailerInterface $mailer,
+        LoggerInterface $logger,
+        UserPasswordHasherInterface $passwordHasher,
+        EnvironmentRepository $environmentRepository,
+        SysConfigRepository $sysConfigRepo,
+        SerializerInterface $serializer,
+        private readonly HttpClientInterface $httpClient,
+        #[Autowire('@monolog.logger.etecsa')] private readonly LoggerInterface $etecsaLogger,
+        #[Autowire('%env(API_COMMUNICATIONS_KEY)%')] private readonly string $apiKey,
+    ) {
+        parent::__construct($em, $security, $parameters, $mailer, $logger, $passwordHasher, $environmentRepository, $sysConfigRepo, $serializer);
+    }
+
+    /**
+     * POST /sale/recharge — iniciar recarga de saldo.
+     */
+    public function recharge(
+        Environment $env,
+        string $phoneNumber,
+        int $productCode,
+        float $productPrice,
+        string $transactionId,
+    ): array {
+        $body = [
+            'phoneNumber' => $phoneNumber,
+            'productCode' => $productCode,
+            'productPrice' => round($productPrice, 2),
+            'transactionId' => $transactionId,
+            'environment' => $env->getType(),
+        ];
+
+        return $this->post($env, '/sale/recharge', $body);
+    }
+
+    /**
+     * POST /sale/package — venta de paquete turístico.
+     *
+     * @param array{id: int, packageType: string} $packageInfo
+     * @param array{id: string, name: string, identificationType: int, arrivalDate: string|null, isAirport: bool, commercialOfficeId: string, provinceId: int, nationality: int} $client
+     */
+    public function sellPackage(
+        Environment $env,
+        string $transactionId,
+        array $packageInfo,
+        array $client,
+        ?string $phoneNumber = null,
+    ): array {
+        $body = [
+            'packageInfo' => $packageInfo,
+            'client' => $client,
+            'transactionId' => $transactionId,
+            'environment' => $env->getType(),
+        ];
+
+        if ($phoneNumber !== null) {
+            $body['phoneNumber'] = $phoneNumber;
+        }
+
+        return $this->post($env, '/sale/package', $body);
+    }
+
+    /**
+     * POST /sale/sale-info — consultar información de venta por transactionId.
+     * Llamar solo si existe registro local previo de la venta.
+     */
+    public function getSaleInfo(Environment $env, string $transactionId): array
+    {
+        $body = [
+            'environment' => $env->getType(),
+            'transactionId' => $transactionId,
+        ];
+
+        return $this->post($env, '/sale/sale-info', $body);
+    }
+
+    /**
+     * POST /information/status — estado detallado de una venta.
+     * Llamar solo si existe registro local previo de la venta.
+     */
+    public function getStatus(Environment $env, string $transactionId): InfoResult
+    {
+        $body = [
+            'environment' => $env->getType(),
+            'transactionId' => $transactionId,
+        ];
+
+        $raw = $this->rawPost($env, '/information/status', $body);
+
+        return $this->serializer->deserialize($raw, InfoResult::class, 'json');
+    }
+
+    /**
+     * POST /information/packages — catálogo de paquetes disponibles.
+     */
+    public function listPackages(Environment $env): array
+    {
+        return $this->post($env, '/information/packages', ['environment' => $env->getType()]);
+    }
+
+    /**
+     * POST /information/balance — saldo disponible en CUP y USD.
+     */
+    public function getBalance(Environment $env): EtecsaBalanceDto
+    {
+        $data = $this->post($env, '/information/balance', ['environment' => $env->getType()]);
+
+        return new EtecsaBalanceDto(
+            cupAmount: (float) ($data['CupBalance'] ?? $data['cupBalance'] ?? $data['cup'] ?? 0.0),
+            usdAmount: (float) ($data['UsdBalance'] ?? $data['usdBalance'] ?? $data['usd'] ?? 0.0),
+            fetchedAt: new \DateTimeImmutable(),
+        );
+    }
+
+    /**
+     * POST /information/nationalities — catálogo de nacionalidades.
+     */
+    public function listNationalities(Environment $env): array
+    {
+        return $this->post($env, '/information/nationalities', ['environment' => $env->getType()]);
+    }
+
+    /**
+     * POST /information/provinces — catálogo de provincias.
+     */
+    public function listProvinces(Environment $env): array
+    {
+        return $this->post($env, '/information/provinces', ['environment' => $env->getType()]);
+    }
+
+    /**
+     * POST /information/commercialOffices — oficinas comerciales de una provincia.
+     */
+    public function listCommercialOffices(Environment $env, ?int $provinceId = null): array
+    {
+        $body = ['environment' => $env->getType()];
+
+        if ($provinceId !== null) {
+            $body['provinceId'] = $provinceId;
+        }
+
+        return $this->post($env, '/information/commercialOffices', $body);
+    }
+
+    // -------------------------------------------------------------------------
+
+    private function post(Environment $env, string $path, array $body): array
+    {
+        return (array) json_decode($this->rawPost($env, $path, $body), true);
+    }
+
+    private function rawPost(Environment $env, string $path, array $body): string
+    {
+        $url = $env->getBasePath() . $path;
+        $start = microtime(true);
+
+        try {
+            $response = $this->httpClient->request('POST', $url, [
+                'headers' => [
+                    'Content-Type'  => 'application/json',
+                    'Accept'        => 'application/json',
+                    'X-Api-Key'     => $this->apiKey,
+                ],
+                'body' => $this->serializer->serialize($body, 'json'),
+            ]);
+
+            $content = $response->getContent();
+
+            $this->etecsaLogger->info('ETECSA gateway call', [
+                'path' => $path,
+                'env' => $env->getType(),
+                'ms' => round((microtime(true) - $start) * 1000),
+                'status' => $response->getStatusCode(),
+            ]);
+
+            return $content;
+        } catch (ClientExceptionInterface $e) {
+            $this->etecsaLogger->error('ETECSA client error', ['path' => $path, 'error' => $e->getMessage()]);
+            throw new MyCurrentException('ETECSA_CLIENT_ERROR', $e->getMessage(), $e->getCode() ?: 400);
+        } catch (ServerExceptionInterface $e) {
+            $this->etecsaLogger->error('ETECSA server error', ['path' => $path, 'error' => $e->getMessage()]);
+            throw new MyCurrentException('ETECSA_SERVER_ERROR', $e->getMessage(), 502);
+        } catch (TransportExceptionInterface | RedirectionExceptionInterface $e) {
+            $this->etecsaLogger->error('ETECSA transport error', ['path' => $path, 'error' => $e->getMessage()]);
+            throw new MyCurrentException('ETECSA_GATEWAY_TIMEOUT', $e->getMessage(), 503);
+        }
+    }
+}

--- a/src/Service/Etecsa/SyncResult.php
+++ b/src/Service/Etecsa/SyncResult.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Service\Etecsa;
+
+final class SyncResult
+{
+    public function __construct(
+        public readonly int $created = 0,
+        public readonly int $updated = 0,
+        public readonly int $skipped = 0,
+    ) {
+    }
+
+    public function add(SyncResult $other): self
+    {
+        return new self(
+            $this->created + $other->created,
+            $this->updated + $other->updated,
+            $this->skipped + $other->skipped,
+        );
+    }
+
+    public function __toString(): string
+    {
+        return "created={$this->created}, updated={$this->updated}, skipped={$this->skipped}";
+    }
+}

--- a/src/Service/SysConfigAdminService.php
+++ b/src/Service/SysConfigAdminService.php
@@ -17,7 +17,7 @@ class SysConfigAdminService
     public function __construct(
         private readonly EntityManagerInterface $em,
         private readonly SysConfigRepository $sysConfigRepo,
-        #[Autowire('%env(default::SYS_CONFIG_ENCRYPTION_KEY)%')]
+        #[Autowire('%env(string:default::SYS_CONFIG_ENCRYPTION_KEY)%')]
         private readonly string $encryptionKey = '',
     ) {}
 

--- a/src/Service/SysConfigAdminService.php
+++ b/src/Service/SysConfigAdminService.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Service;
+
+use App\DTO\CreateSysConfigDto;
+use App\DTO\UpdateSysConfigDto;
+use App\Entity\SysConfig;
+use App\Exception\MyCurrentException;
+use App\Repository\SysConfigRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+class SysConfigAdminService
+{
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly SysConfigRepository $sysConfigRepo,
+    ) {}
+
+    public function create(CreateSysConfigDto $dto): SysConfig
+    {
+        $existing = $this->sysConfigRepo->findOneBy(['propertyName' => $dto->getPropertyName()]);
+        if ($existing !== null) {
+            throw new MyCurrentException(
+                'SYS_CONFIG_DUPLICATE',
+                "Ya existe una variable con el nombre '{$dto->getPropertyName()}'.",
+                Response::HTTP_CONFLICT
+            );
+        }
+
+        $config = new SysConfig();
+        $config->setPropertyName($dto->getPropertyName());
+        $config->setPropertyValue($dto->getPropertyValue());
+        $config->setIsActive($dto->getIsActive() ?? true);
+        $config->setClients($dto->getClients());
+
+        $this->em->persist($config);
+        $this->em->flush();
+        $this->sysConfigRepo->invalidateCache();
+
+        return $config;
+    }
+
+    public function update(SysConfig $config, UpdateSysConfigDto $dto): SysConfig
+    {
+        if ($dto->getPropertyName() !== null && $dto->getPropertyName() !== $config->getPropertyName()) {
+            $existing = $this->sysConfigRepo->findOneBy(['propertyName' => $dto->getPropertyName()]);
+            if ($existing !== null) {
+                throw new MyCurrentException(
+                    'SYS_CONFIG_DUPLICATE',
+                    "Ya existe una variable con el nombre '{$dto->getPropertyName()}'.",
+                    Response::HTTP_CONFLICT
+                );
+            }
+            $config->setPropertyName($dto->getPropertyName());
+        }
+
+        if ($dto->getPropertyValue() !== null) {
+            $config->setPropertyValue($dto->getPropertyValue());
+        }
+
+        if ($dto->getIsActive() !== null) {
+            $config->setIsActive($dto->getIsActive());
+        }
+
+        if ($dto->getClients() !== null) {
+            $config->setClients($dto->getClients());
+        }
+
+        $this->em->flush();
+        $this->sysConfigRepo->invalidateCache();
+
+        return $config;
+    }
+
+    public function toggle(SysConfig $config): SysConfig
+    {
+        $config->setIsActive(!$config->isActive());
+        $this->em->flush();
+        $this->sysConfigRepo->invalidateCache();
+
+        return $config;
+    }
+
+    public function delete(SysConfig $config): void
+    {
+        $config->setRemovedAt(new \DateTimeImmutable('now'));
+        $this->em->flush();
+        $this->sysConfigRepo->invalidateCache();
+    }
+}

--- a/src/Service/SysConfigAdminService.php
+++ b/src/Service/SysConfigAdminService.php
@@ -7,7 +7,9 @@ use App\DTO\UpdateSysConfigDto;
 use App\Entity\SysConfig;
 use App\Exception\MyCurrentException;
 use App\Repository\SysConfigRepository;
+use App\Service\SysConfigCipher;
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\Response;
 
 class SysConfigAdminService
@@ -15,6 +17,8 @@ class SysConfigAdminService
     public function __construct(
         private readonly EntityManagerInterface $em,
         private readonly SysConfigRepository $sysConfigRepo,
+        #[Autowire('%env(default::SYS_CONFIG_ENCRYPTION_KEY)%')]
+        private readonly string $encryptionKey = '',
     ) {}
 
     public function create(CreateSysConfigDto $dto): SysConfig
@@ -28,9 +32,17 @@ class SysConfigAdminService
             );
         }
 
+        $isEncrypted = $dto->getIsEncrypted() ?? false;
+        $value = $dto->getPropertyValue();
+        if ($isEncrypted) {
+            $this->assertEncryptionKeyAvailable();
+            $value = SysConfigCipher::encrypt($value, $this->encryptionKey);
+        }
+
         $config = new SysConfig();
         $config->setPropertyName($dto->getPropertyName());
-        $config->setPropertyValue($dto->getPropertyValue());
+        $config->setPropertyValue($value);
+        $config->setIsEncrypted($isEncrypted);
         $config->setIsActive($dto->getIsActive() ?? true);
         $config->setClients($dto->getClients());
 
@@ -55,8 +67,29 @@ class SysConfigAdminService
             $config->setPropertyName($dto->getPropertyName());
         }
 
+        $currentIsEncrypted = $config->isEncrypted();
+        $newIsEncrypted = $dto->getIsEncrypted() ?? $currentIsEncrypted;
+
         if ($dto->getPropertyValue() !== null) {
-            $config->setPropertyValue($dto->getPropertyValue());
+            $value = $dto->getPropertyValue();
+            if ($newIsEncrypted) {
+                $this->assertEncryptionKeyAvailable();
+                $value = SysConfigCipher::encrypt($value, $this->encryptionKey);
+            }
+            $config->setPropertyValue($value);
+        } elseif ($newIsEncrypted !== $currentIsEncrypted) {
+            // Cambio de modo sin nuevo valor: re-cifrar o descifrar el valor existente
+            $stored = $config->getPropertyValue() ?? '';
+            $this->assertEncryptionKeyAvailable();
+            if ($newIsEncrypted) {
+                $config->setPropertyValue(SysConfigCipher::encrypt($stored, $this->encryptionKey));
+            } else {
+                $config->setPropertyValue(SysConfigCipher::decrypt($stored, $this->encryptionKey));
+            }
+        }
+
+        if ($dto->getIsEncrypted() !== null) {
+            $config->setIsEncrypted($newIsEncrypted);
         }
 
         if ($dto->getIsActive() !== null) {
@@ -87,5 +120,16 @@ class SysConfigAdminService
         $config->setRemovedAt(new \DateTimeImmutable('now'));
         $this->em->flush();
         $this->sysConfigRepo->invalidateCache();
+    }
+
+    private function assertEncryptionKeyAvailable(): void
+    {
+        if ($this->encryptionKey === '') {
+            throw new MyCurrentException(
+                'SYS_CONFIG_ENCRYPTION_KEY_MISSING',
+                'La variable de entorno SYS_CONFIG_ENCRYPTION_KEY no está configurada.',
+                Response::HTTP_INTERNAL_SERVER_ERROR
+            );
+        }
     }
 }

--- a/src/Service/SysConfigCipher.php
+++ b/src/Service/SysConfigCipher.php
@@ -6,6 +6,9 @@ final class SysConfigCipher
 {
     public static function encrypt(string $plaintext, string $hexKey): string
     {
+        if (strlen($hexKey) !== 64 || !ctype_xdigit($hexKey)) {
+            throw new \RuntimeException('SYS_CONFIG_ENCRYPTION_KEY debe ser exactamente 64 caracteres hexadecimales (openssl rand -hex 32)');
+        }
         $key = sodium_hex2bin($hexKey);
         $nonce = random_bytes(SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
         $ciphertext = sodium_crypto_secretbox($plaintext, $nonce, $key);
@@ -14,6 +17,9 @@ final class SysConfigCipher
 
     public static function decrypt(string $encoded, string $hexKey): string
     {
+        if (strlen($hexKey) !== 64 || !ctype_xdigit($hexKey)) {
+            throw new \RuntimeException('SYS_CONFIG_ENCRYPTION_KEY debe ser exactamente 64 caracteres hexadecimales (openssl rand -hex 32)');
+        }
         $key = sodium_hex2bin($hexKey);
         $decoded = base64_decode($encoded, true);
         if ($decoded === false || strlen($decoded) <= SODIUM_CRYPTO_SECRETBOX_NONCEBYTES) {

--- a/src/Service/SysConfigCipher.php
+++ b/src/Service/SysConfigCipher.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Service;
+
+final class SysConfigCipher
+{
+    public static function encrypt(string $plaintext, string $hexKey): string
+    {
+        $key = sodium_hex2bin($hexKey);
+        $nonce = random_bytes(SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
+        $ciphertext = sodium_crypto_secretbox($plaintext, $nonce, $key);
+        return base64_encode($nonce . $ciphertext);
+    }
+
+    public static function decrypt(string $encoded, string $hexKey): string
+    {
+        $key = sodium_hex2bin($hexKey);
+        $decoded = base64_decode($encoded, true);
+        if ($decoded === false || strlen($decoded) <= SODIUM_CRYPTO_SECRETBOX_NONCEBYTES) {
+            throw new \RuntimeException('SysConfig: datos cifrados inválidos');
+        }
+        $nonce = substr($decoded, 0, SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
+        $ciphertext = substr($decoded, SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
+        $plaintext = sodium_crypto_secretbox_open($ciphertext, $nonce, $key);
+        if ($plaintext === false) {
+            throw new \RuntimeException('SysConfig: falló el descifrado — clave incorrecta o dato corrompido');
+        }
+        return $plaintext;
+    }
+}

--- a/src/Service/TakeProductService.php
+++ b/src/Service/TakeProductService.php
@@ -3,15 +3,13 @@
 namespace App\Service;
 
 use App\Entity\Account;
-use App\Entity\CommunicationNationality;
-use App\Entity\CommunicationOffice;
 use App\Entity\CommunicationPackage;
 use App\Entity\CommunicationPriceTable;
 use App\Entity\CommunicationProduct;
-use App\Entity\CommunicationProvinces;
 use App\Exception\MyCurrentException;
 use App\Repository\EnvironmentRepository;
 use App\Repository\SysConfigRepository;
+use App\Service\Etecsa\EtecsaCatalogSyncService;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -19,41 +17,32 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Serializer\SerializerInterface;
-use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
-use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
-use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
-use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
-use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
 
+/**
+ * @deprecated Usar EtecsaCatalogSyncService directamente.
+ * Los métodos takeProduct() y takeOtherData() delegan en EtecsaCatalogSyncService.
+ * Este servicio se mantiene para compatibilidad con app:takeOther:command y app:takeProduct.
+ */
 class TakeProductService extends CommonService
 {
     public function __construct(
-        EntityManagerInterface               $em,
-        Security                             $security,
-        ParameterBagInterface                $parameters,
-        MailerInterface                      $mailer,
-        LoggerInterface                      $logger,
-        UserPasswordHasherInterface          $passwordHasher,
-        EnvironmentRepository                $environmentRepository,
-        SysConfigRepository                  $sysConfigRepo,
-        SerializerInterface                  $serializer,
-        private readonly HttpClientInterface $httpClient
-    )
-    {
+        EntityManagerInterface $em,
+        Security $security,
+        ParameterBagInterface $parameters,
+        MailerInterface $mailer,
+        LoggerInterface $logger,
+        UserPasswordHasherInterface $passwordHasher,
+        EnvironmentRepository $environmentRepository,
+        SysConfigRepository $sysConfigRepo,
+        SerializerInterface $serializer,
+        private readonly EtecsaCatalogSyncService $catalogSyncService,
+    ) {
         parent::__construct($em, $security, $parameters, $mailer, $logger, $passwordHasher, $environmentRepository, $sysConfigRepo, $serializer);
     }
 
 
     /**
-     * @param string $env
-     * @return array
-     * @throws \Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface
-     * @throws \Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface
-     * @throws \Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface
-     * @throws \Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface
-     * @throws \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface
-     * @throws \Exception
+     * @deprecated Usar EtecsaCatalogSyncService::syncProducts()
      */
     public function takeProduct(string $env): array
     {
@@ -61,83 +50,25 @@ class TakeProductService extends CommonService
             $environments = $this->environmentRepository->findBy([
                 'scope' => 'ET',
                 'isActive' => true,
-                'type' => $env
+                'type' => $env,
             ]);
 
             $items = 0;
-
-            foreach ($environments as $key => $item) {
-                $response = $this->httpClient->request(
-                    'POST',
-                    $item->getBasePath() . '/information/packages',
-                    [
-                        'headers' => [
-                            'Content-Type' => 'application/json',
-                            'Accept' => 'application/json',
-                        ],
-                        'body' => $this->serializer->serialize([
-                            'environment' => $item->getType(),
-                        ], 'json', []),
-                    ]
-                );
-
-                $products = (object)$response->toArray();
-                $currentDate = new \DateTimeImmutable();
-                $existingProducts = $this->em->getRepository(CommunicationProduct::class)->findBy([
-                    'environment' => $item,
-                ]);
-                $existingByPackageId = [];
-                foreach ($existingProducts as $ep) {
-                    $existingByPackageId[$ep->getPackageId()] = true;
-                }
-                foreach ($products as $productItem) {
-                    $currentProduct = (object)$productItem;
-                    $endDate = !is_null($currentProduct->FinalDate) ? new \DateTimeImmutable($currentProduct->FinalDate) : null;
-                    if ((is_null($endDate) || $currentDate <= $endDate) && $currentProduct->Enabled && !isset($existingByPackageId[$currentProduct->Id])) {
-                        $product = new CommunicationProduct();
-                        $product->setPackageType($currentProduct->PackageType);
-                        $product->setEnvironment($item);
-                        $product->setPackageId($currentProduct->Id);
-                        $product->setDescription($currentProduct->Description);
-                        $product->setEnabled($currentProduct->Enabled);
-                        if (!is_null($currentProduct->InitialDate)) {
-                            $product->setInitialDate(new \DateTimeImmutable($currentProduct->InitialDate));
-                        }
-                        if (!is_null($endDate)) {
-                            $product->setEndDateAt($endDate);
-                        }
-                        $product->setPrice($currentProduct->Price);
-                        $product->setProductType($currentProduct->PackageType);
-                        $this->em->persist($product);
-                        ++$items;
-                    }
-                }
+            foreach ($environments as $item) {
+                $result = $this->catalogSyncService->syncProducts($item);
+                $items += $result->created;
             }
 
-            if ($items > 0) {
-                $this->em->flush();
-            }
-
-            return [
-                'items' => $items,
-                'isProcessed' => true
-            ];
+            return ['items' => $items, 'isProcessed' => true];
         } catch (\Exception $exception) {
             $this->logger->error($exception->getMessage());
-            if ($exception->getCode()) {
-                $codeExc = (string)$exception->getCode();
-            } else
-                $codeExc = 'Unknown error';
+            $codeExc = $exception->getCode() ? (string) $exception->getCode() : 'Unknown error';
             throw new MyCurrentException($codeExc, $exception->getMessage());
         }
     }
 
     /**
-     * @throws TransportExceptionInterface
-     * @throws ServerExceptionInterface
-     * @throws RedirectionExceptionInterface
-     * @throws DecodingExceptionInterface
-     * @throws ClientExceptionInterface
+     * @deprecated Usar EtecsaCatalogSyncService::syncNationalities() / syncProvinces() / syncOffices()
      */
     public function takeOtherData(): void
     {
@@ -146,107 +77,11 @@ class TakeProductService extends CommonService
             'isActive' => true,
         ]);
 
-        foreach ($environments as $key => $item) {
-            $nationalitiesResponse = $this->httpClient->request(
-                'POST',
-                $item->getBasePath() . '/information/nationalities',
-                [
-                    'headers' => [
-                        'Content-Type' => 'application/json',
-                        'Accept' => 'application/json',
-                    ],
-                    'body' => $this->serializer->serialize([
-                        'environment' => $item->getType(),
-                    ], 'json', []),
-                ]
-            );
-
-            $nationalitiesET = $nationalitiesResponse->toArray();
-            if (count($nationalitiesET) > 0) {
-                $info = $this->em->getRepository(CommunicationNationality::class)->deleteAll($item);
-            }
-            foreach ($nationalitiesET as $nationalityItemET) {
-                $ntItem = (object)$nationalityItemET;
-
-                $nationality = new CommunicationNationality();
-                $nationality->setEnvironment($item);
-                $nationality->setComId($ntItem->Id);
-                $nationality->setName($ntItem->Name);
-                $nationality->setCodeAlpha3($ntItem->Abbreviation);
-
-                $this->em->persist($nationality);
-            }
-
-            $provincesResponse = $this->httpClient->request(
-                'POST',
-                $item->getBasePath() . '/information/provinces',
-                [
-                    'headers' => [
-                        'Content-Type' => 'application/json',
-                        'Accept' => 'application/json',
-                    ],
-                    'body' => $this->serializer->serialize([
-                        'environment' => $item->getType(),
-                    ], 'json', []),
-                ]
-            );
-
-            $provincesET = $provincesResponse->toArray();
-            foreach ($provincesET as $provinceItemET) {
-                $prvItem = (object)$provinceItemET;
-                if (property_exists($prvItem, 'Id') && !is_null($prvItem->Id)) {
-
-                    $commercialOfficesResponse = $this->httpClient->request(
-                        'POST',
-                        $item->getBasePath() . '/information/commercialOffices',
-                        [
-                            'headers' => [
-                                'Content-Type' => 'application/json',
-                                'Accept' => 'application/json',
-                            ],
-                            'body' => $this->serializer->serialize([
-                                'environment' => $item->getType(),
-                                'provinceId' => $prvItem->Id,
-                            ], 'json', []),
-                        ]
-                    );
-
-                    $provincesComm = $this->em->getRepository(CommunicationProvinces::class)->findOneBy([
-                        'environment' => $item,
-                        'comId' => $prvItem->Id,
-                    ]);
-
-                    $commercialOfficesET = $commercialOfficesResponse->toArray();
-                    if (!is_null($provincesComm) && count($commercialOfficesET) > 0) {
-                        $this->em->getRepository(CommunicationOffice::class)->deleteAll($item, $provincesComm->getId());
-                        $this->em->remove($provincesComm);
-                    }
-                    $province = new CommunicationProvinces();
-                    $province->setName($prvItem->Name);
-                    $province->setComId($prvItem->Id);
-                    $province->setEnvironment($item);
-
-                    $this->em->persist($province);
-                    foreach ($commercialOfficesET as $commercialOfficeItemET) {
-                        $coItem = (object)$commercialOfficeItemET;
-
-                        if (property_exists($coItem, 'Id') && !is_null($coItem->Id)) {
-                            $comOffice = new CommunicationOffice();
-                            $comOffice->setComId($coItem->Id);
-                            $comOffice->setName($coItem->Name);
-                            $comOffice->setEnvironment($item);
-                            $comOffice->setProvince($province);
-                            $comOffice->setIsActive(true);
-                            $comOffice->setIsAirport(false);
-
-                            $this->em->persist($comOffice);
-                        }
-                    }
-                }
-            }
+        foreach ($environments as $item) {
+            $this->catalogSyncService->syncNationalities($item);
+            $this->catalogSyncService->syncProvinces($item);
+            $this->catalogSyncService->syncOffices($item);
         }
-
-        $this->em->flush();
     }
 
     /**

--- a/src/Service/TransferCalculatorService.php
+++ b/src/Service/TransferCalculatorService.php
@@ -92,9 +92,9 @@ class TransferCalculatorService extends CommonService
                                 'fromCurrency' => $data->getSendCurrency(),
                                 'toCurrency' => $data->getSendCurrency(),
                                 'sendAmount' => $data->getSendAmount(),
-                                'tenantProcessorId' => (int)$this->sysConfigRepo->findOneBy([
-                                    'propertyName' => 'rebuspay.tenant.account.' . strtolower($user->getEnvironmentName()) . '.value',
-                                ])?->getPropertyValue(),
+                                'tenantProcessorId' => (int)$this->sysConfigRepo->findCachedValue(
+                                    'rebuspay.tenant.account.' . strtolower($user->getEnvironmentName()) . '.value'
+                                ),
                             ], 'json', []
                         ),
                     ]

--- a/src/Service/TwoFactorService.php
+++ b/src/Service/TwoFactorService.php
@@ -226,7 +226,7 @@ class TwoFactorService
 
     private function readValue(string $key, ?string $default): ?string
     {
-        return $this->sysConfigRepo->findOneBy(['propertyName' => $key])?->getPropertyValue() ?? $default;
+        return $this->sysConfigRepo->findCachedValue($key) ?? $default;
     }
 
     private function writeValue(string $key, string $value): void
@@ -238,6 +238,7 @@ class TwoFactorService
         }
         $config->setPropertyValue($value);
         $this->em->flush();
+        $this->sysConfigRepo->invalidateCache();
     }
 
     private function buildIssuer(User $user): string

--- a/src/State/CalculatorProcessor.php
+++ b/src/State/CalculatorProcessor.php
@@ -88,9 +88,9 @@ class CalculatorProcessor implements ProcessorInterface
                                     'fromCurrency' => $data->getSendCurrency(),
                                     'toCurrency' => $data->getSendCurrency(),
                                     'sendAmount' => $data->getSendAmount(),
-                                    'tenantProcessorId' => (int)$this->configRepository->findOneBy([
-                                        'propertyName' => 'rebuspay.tenant.account.'.strtolower($user->getEnvironmentName()).'.value'
-                                ])?->getPropertyValue()
+                                    'tenantProcessorId' => (int)$this->configRepository->findCachedValue(
+                                        'rebuspay.tenant.account.' . strtolower($user->getEnvironmentName()) . '.value'
+                                    )
                                 ], 'json', []
                             ),
                         ]

--- a/src/State/CreateSaleInfoProcessor.php
+++ b/src/State/CreateSaleInfoProcessor.php
@@ -15,6 +15,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
 use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
@@ -27,6 +28,7 @@ class CreateSaleInfoProcessor implements ProcessorInterface
         private readonly CommunicationSaleService $saleService,
         private readonly EntityManagerInterface $em,
         private readonly Security $security,
+        #[Autowire('limiter.api_recharge')]
         private readonly RateLimiterFactory $apiRechargeLimiter,
     ) {
     }

--- a/src/State/CreateSaleInfoProcessor.php
+++ b/src/State/CreateSaleInfoProcessor.php
@@ -28,7 +28,7 @@ class CreateSaleInfoProcessor implements ProcessorInterface
         private readonly CommunicationSaleService $saleService,
         private readonly EntityManagerInterface $em,
         private readonly Security $security,
-        #[Autowire('limiter.api_recharge')]
+        #[Autowire(service: 'limiter.api_recharge')]
         private readonly RateLimiterFactory $apiRechargeLimiter,
     ) {
     }

--- a/src/State/CreateTransactionProcessor.php
+++ b/src/State/CreateTransactionProcessor.php
@@ -56,7 +56,7 @@ class CreateTransactionProcessor implements ProcessorInterface
         private readonly SenderRepository $senderRepository,
         private readonly BalanceOperationRepository $balanceRepository,
         private readonly TransferCalculatorService $transferCalculatorService,
-        #[Autowire('limiter.api_transfer')]
+        #[Autowire(service: 'limiter.api_transfer')]
         private readonly RateLimiterFactory $apiTransferLimiter,
     ) {
         $encoders = [new XmlEncoder(), new JsonEncoder()];

--- a/src/State/CreateTransactionProcessor.php
+++ b/src/State/CreateTransactionProcessor.php
@@ -126,12 +126,10 @@ class CreateTransactionProcessor implements ProcessorInterface
                             'reason' => $data->getReasonNote(),
                             'senderId' => $sender->getRebusSenderId(),
                             'beneficiaryId' => $beneficiary->getRebusId(),
-                            'tenantProcessorId' => (int)$this->configRepository->findOneBy([
-                                'propertyName' => 'rebuspay.tenant.account.'.strtolower(
-                                        $user->getEnvironmentName()
-                                    ).'.value',
-                                'isActive' => true,
-                            ])?->getPropertyValue(),
+                            'tenantProcessorId' => (int)$this->configRepository->findCachedValue(
+                                'rebuspay.tenant.account.' . strtolower($user->getEnvironmentName()) . '.value',
+                                mustBeActive: true,
+                            ),
                         ], 'json', []
                     );
                     $response = $this->httpClient->request(

--- a/src/State/CreateTransactionProcessor.php
+++ b/src/State/CreateTransactionProcessor.php
@@ -24,6 +24,7 @@ use Doctrine\ORM\NonUniqueResultException;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\Exception\BadRequestException;
 use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Encoder\XmlEncoder;
@@ -55,6 +56,7 @@ class CreateTransactionProcessor implements ProcessorInterface
         private readonly SenderRepository $senderRepository,
         private readonly BalanceOperationRepository $balanceRepository,
         private readonly TransferCalculatorService $transferCalculatorService,
+        #[Autowire('limiter.api_transfer')]
         private readonly RateLimiterFactory $apiTransferLimiter,
     ) {
         $encoders = [new XmlEncoder(), new JsonEncoder()];

--- a/templates/emails/communications/dispatch-pending.html.twig
+++ b/templates/emails/communications/dispatch-pending.html.twig
@@ -1,0 +1,173 @@
+{% extends 'emails/_base.html.twig' %}
+
+{% block title %}Despacho de mensajes pendientes — Comremit{% endblock %}
+
+{% block preheader %}&#9989; {{ total }} mensaje(s) encolado(s) al API de comunicaciones el {{ dispatchedAt|date('d/m/Y H:i') }}{% endblock %}
+
+{% block brand_header %}
+<span style="font-size:20px;font-weight:bold;color:#ffffff;font-family:Arial,Helvetica,sans-serif;letter-spacing:0.5px;">
+    Comremit
+</span>
+{% endblock %}
+
+{% block banner %}
+<tr>
+    <td align="center" style="background-color:#16a34a;padding:28px 40px 24px 40px;">
+        <p style="margin:0 0 6px 0;font-size:24px;font-weight:bold;color:#ffffff;
+                  font-family:Arial,Helvetica,sans-serif;line-height:1.2;">
+            Despacho de mensajes completado
+        </p>
+        <p style="margin:0;font-size:14px;color:rgba(255,255,255,0.85);font-family:Arial,Helvetica,sans-serif;">
+            &#9989;&nbsp; {{ total }} mensaje(s) encolado(s) al API de comunicaciones
+        </p>
+    </td>
+</tr>
+{% endblock %}
+
+{% block content %}
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+
+    <tr>
+        <td style="font-size:14px;color:#1a1a1a;line-height:24px;padding-bottom:24px;font-family:Arial,Helvetica,sans-serif;">
+            Se han encolado correctamente los mensajes pendientes de envío al API de comunicaciones.
+            A continuación se muestra el resumen de la operación.
+        </td>
+    </tr>
+
+    <!-- SUMMARY CARD -->
+    <tr>
+        <td style="padding-bottom:28px;">
+            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0"
+                   style="border:1px solid #e0e0e0;border-collapse:collapse;border-radius:4px;">
+
+                <tr style="background-color:#f9fafb;">
+                    <td colspan="2" style="padding:12px 18px;font-size:11px;font-weight:bold;color:#666666;
+                                           text-transform:uppercase;letter-spacing:0.5px;
+                                           border-bottom:1px solid #e0e0e0;
+                                           font-family:Arial,Helvetica,sans-serif;">
+                        Resumen del despacho
+                    </td>
+                </tr>
+
+                <tr>
+                    <td style="padding:12px 18px;font-size:13px;color:#555555;width:50%;
+                                border-bottom:1px solid #e0e0e0;font-family:Arial,Helvetica,sans-serif;">
+                        Recargas encoladas
+                    </td>
+                    <td style="padding:12px 18px;font-size:14px;font-weight:bold;color:#1a1a1a;
+                                border-bottom:1px solid #e0e0e0;font-family:Arial,Helvetica,sans-serif;">
+                        {{ recharges }}
+                    </td>
+                </tr>
+
+                <tr style="background-color:#f9fafb;">
+                    <td style="padding:12px 18px;font-size:13px;color:#555555;
+                                border-bottom:1px solid #e0e0e0;font-family:Arial,Helvetica,sans-serif;">
+                        Ventas de paquete encoladas
+                    </td>
+                    <td style="padding:12px 18px;font-size:14px;font-weight:bold;color:#1a1a1a;
+                                border-bottom:1px solid #e0e0e0;font-family:Arial,Helvetica,sans-serif;">
+                        {{ packages }}
+                    </td>
+                </tr>
+
+                <tr>
+                    <td style="padding:14px 18px;font-size:13px;font-weight:bold;color:#16a34a;
+                                border-bottom:1px solid #e0e0e0;font-family:Arial,Helvetica,sans-serif;">
+                        Total encolado
+                    </td>
+                    <td style="padding:14px 18px;font-size:18px;font-weight:bold;color:#16a34a;
+                                border-bottom:1px solid #e0e0e0;font-family:Arial,Helvetica,sans-serif;">
+                        {{ total }}
+                    </td>
+                </tr>
+
+                <tr style="background-color:#f9fafb;">
+                    <td style="padding:12px 18px;font-size:13px;color:#555555;
+                                border-bottom:1px solid #e0e0e0;font-family:Arial,Helvetica,sans-serif;">
+                        Fecha y hora
+                    </td>
+                    <td style="padding:12px 18px;font-size:13px;color:#1a1a1a;
+                                border-bottom:1px solid #e0e0e0;font-family:Arial,Helvetica,sans-serif;">
+                        {{ dispatchedAt|date('d/m/Y H:i:s') }} (UTC)
+                    </td>
+                </tr>
+
+                <tr>
+                    <td style="padding:12px 18px;font-size:13px;color:#555555;
+                                font-family:Arial,Helvetica,sans-serif;">
+                        Accionado por
+                    </td>
+                    <td style="padding:12px 18px;font-size:13px;color:#1a1a1a;
+                                font-family:Arial,Helvetica,sans-serif;">
+                        {{ triggeredBy }}
+                    </td>
+                </tr>
+
+            </table>
+        </td>
+    </tr>
+
+    {% if transactionIds is not empty %}
+    <!-- TRANSACTION IDS -->
+    <tr>
+        <td style="padding-bottom:6px;font-size:12px;font-weight:bold;color:#666666;
+                    text-transform:uppercase;letter-spacing:0.5px;font-family:Arial,Helvetica,sans-serif;">
+            Transacciones encoladas ({{ transactionIds|length }})
+        </td>
+    </tr>
+    <tr>
+        <td style="padding-bottom:28px;">
+            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0"
+                   style="border:1px solid #e0e0e0;border-collapse:collapse;border-radius:4px;">
+                {% for txId in transactionIds %}
+                <tr style="{{ loop.index is odd ? 'background-color:#f9fafb;' : '' }}">
+                    <td style="padding:8px 18px;font-size:12px;color:#444444;
+                                font-family:monospace,Arial,sans-serif;
+                                {{ not loop.last ? 'border-bottom:1px solid #f0f0f0;' : '' }}">
+                        {{ txId }}
+                    </td>
+                </tr>
+                {% endfor %}
+            </table>
+        </td>
+    </tr>
+    {% endif %}
+
+    <tr>
+        <td style="padding-bottom:20px;">
+            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                <tr><td style="border-top:1px solid #e0e0e0;font-size:1px;line-height:1px;">&nbsp;</td></tr>
+            </table>
+        </td>
+    </tr>
+
+    <tr>
+        <td align="center" style="font-size:12px;color:#888888;font-family:Arial,Helvetica,sans-serif;">
+            Este es un mensaje autom&aacute;tico del sistema &mdash; no requiere acci&oacute;n.
+        </td>
+    </tr>
+
+</table>
+{% endblock %}
+
+{% block footer %}
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+    <tr>
+        <td align="center" style="color:#ffffff;font-size:13px;font-weight:bold;padding-bottom:4px;font-family:Arial,Helvetica,sans-serif;">
+            Comremit Solutions SL
+        </td>
+    </tr>
+    <tr>
+        <td align="center" style="color:rgba(255,255,255,0.6);font-size:11px;line-height:18px;padding-bottom:10px;font-family:Arial,Helvetica,sans-serif;">
+            Pasaje del Carme, 24 &mdash; Sant Cugat del Vall&eacute;s, 08173 &mdash; Barcelona, Espa&ntilde;a &mdash; CIF: B10583565
+        </td>
+    </tr>
+    <tr>
+        <td align="center" style="border-top:1px solid rgba(255,255,255,0.12);padding-top:12px;
+                                   font-size:11px;color:rgba(255,255,255,0.45);font-family:Arial,Helvetica,sans-serif;">
+            Este es un mensaje autom&aacute;tico &mdash; por favor no respondas a este correo.
+        </td>
+    </tr>
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
  - `default::FOO` retorna `null` cuando la variable está indefinida; con `string` no nullable produce TypeError en construcción, rompiendo todos los endpoints que dependan de `SysConfigRepository` o `SysConfigAdminService`.
  - Reemplazado por `string:default::FOO` en ambos servicios para coaccionar null → ''.
  - Las guardas existentes (`!== ''` y `assertEncryptionKeyAvailable()`) siguen funcionando.
  
  ## Archivos modificados
  - `src/Repository/SysConfigRepository.php:29`
  - `src/Service/SysConfigAdminService.php:20`
  
  ## Test plan
  - [ ] Deploy a staging y verificar que `GET /api/communication/packages` responde 200
  - [ ] Endpoints con SysConfig no cifrado funcionan sin la env var
  - [ ] Creación con `isEncrypted=true` sin env var retorna `SYS_CONFIG_ENCRYPTION_KEY_MISSING`
  - [ ] 257 tests unitarios pasan ✅
