### PR TITLE
fix(check-status): re-apply transactionStatus after em->refresh on CO…

### DIFF
--- a/src/Service/CommunicationSaleService.php
+++ b/src/Service/CommunicationSaleService.php
@@ -930,6 +930,7 @@ class CommunicationSaleService extends CommonService
                 if ($sale->getState() === CommunicationStateEnum::COMPLETED) {
                     return;
                 }
+                $sale->setTransactionStatus($response);
                 if (isset($responseInfo->orderId)) {
                     $sale->setTransactionOrder($responseInfo->orderId);
                 }


### PR DESCRIPTION
…MPLETED

em->refresh() discards all in-memory changes, including the setTransactionStatus($response) set before the COMPLETED branch. Re-apply it after the refresh and the concurrency early-return so the flush persists the latest ETECSA payload alongside state/stateProcess.