### PR TITLE
fix(prices): exponer y permitir editar la tarifa usada; completar ser…

### DIFF
--- a/src/Controller/DashboardClientPackagesController.php
+++ b/src/Controller/DashboardClientPackagesController.php
@@ -37,6 +37,7 @@ class DashboardClientPackagesController extends AbstractController
         'amount' => 'pp.amount',
         'name' => 'pp.name',
         'isActive' => 'pp.isActive',
+        'createdAt' => 'pp.createdAt',
     ];
 
     private const PACKAGE_SORTABLE = [
@@ -45,6 +46,7 @@ class DashboardClientPackagesController extends AbstractController
         'amount' => 'cp.amount',
         'activeStartAt' => 'cp.activeStartAt',
         'activeEndAt' => 'cp.activeEndAt',
+        'createdAt' => 'cp.createdAt',
     ];
 
     public function __construct(
@@ -370,6 +372,13 @@ class DashboardClientPackagesController extends AbstractController
                 'id' => $pp->getProduct()->getId(),
                 'description' => $pp->getProduct()->getDescription(),
             ] : null,
+            'priceUsed' => $pp->getPriceUsed() ? [
+                'id' => $pp->getPriceUsed()->getId(),
+                'startPrice' => $pp->getPriceUsed()->getStartPrice(),
+                'currencyPrice' => $pp->getPriceUsed()->getCurrencyPrice(),
+                'amount' => $pp->getPriceUsed()->getAmount(),
+                'currency' => $pp->getPriceUsed()->getCurrency(),
+            ] : null,
         ];
     }
 
@@ -383,6 +392,8 @@ class DashboardClientPackagesController extends AbstractController
             'currency' => $cp->getCurrency(),
             'activeStartAt' => $cp->getActiveStartAt()?->format('c'),
             'activeEndAt' => $cp->getActiveEndAt()?->format('c'),
+            'destination' => $cp->getDestination(),
+            'validity' => $cp->getValidity(),
             'tenant' => [
                 'id' => $cp->getTenant()?->getId(),
                 'clientName' => $cp->getTenant()?->getClient()?->getCompanyName(),

--- a/src/DTO/UpdatePricePackageDto.php
+++ b/src/DTO/UpdatePricePackageDto.php
@@ -30,6 +30,9 @@ class UpdatePricePackageDto implements IInput
 
     protected ?string $activeEndAt;
 
+    #[Assert\Positive]
+    protected ?int $priceUsedId;
+
     public function __construct(
         ?float $price = null,
         ?string $priceCurrency = null,
@@ -40,6 +43,7 @@ class UpdatePricePackageDto implements IInput
         ?bool $isActive = null,
         ?string $activeStartAt = null,
         ?string $activeEndAt = null,
+        ?int $priceUsedId = null,
     ) {
         $this->price         = $price;
         $this->priceCurrency = $priceCurrency;
@@ -50,6 +54,7 @@ class UpdatePricePackageDto implements IInput
         $this->isActive      = $isActive;
         $this->activeStartAt = $activeStartAt;
         $this->activeEndAt   = $activeEndAt;
+        $this->priceUsedId   = $priceUsedId;
     }
 
     public function getPrice(): ?float { return $this->price; }
@@ -78,4 +83,7 @@ class UpdatePricePackageDto implements IInput
 
     public function getActiveEndAt(): ?string { return $this->activeEndAt; }
     public function setActiveEndAt(?string $v): void { $this->activeEndAt = $v; }
+
+    public function getPriceUsedId(): ?int { return $this->priceUsedId; }
+    public function setPriceUsedId(?int $v): void { $this->priceUsedId = $v; }
 }

--- a/src/Service/CommunicationPackageService.php
+++ b/src/Service/CommunicationPackageService.php
@@ -180,6 +180,13 @@ class CommunicationPackageService extends CommonService
         if ($dto->getActiveEndAt() !== null) {
             $pp->setActiveEndAt(new \DateTimeImmutable($dto->getActiveEndAt()));
         }
+        if ($dto->getPriceUsedId() !== null) {
+            $priceUsed = $this->em->getRepository(CommunicationPrice::class)->find($dto->getPriceUsedId());
+            if ($priceUsed === null) {
+                throw new MyCurrentException('PRICE_NOT_FOUND', 'Communication price not found', 404);
+            }
+            $pp->setPriceUsed($priceUsed);
+        }
 
         $this->em->flush();
 


### PR DESCRIPTION
…ialize de paquetes

Precios (CommunicationPricePackage):
- serializePricePackage ahora devuelve `priceUsed` {id, startPrice, currencyPrice, amount, currency}. Antes se persistía la tarifa (CommunicationPrice) al crear pero nunca se serializaba, así que en edición era imposible saber/mostrar qué tarifa se usó.
- UpdatePricePackageDto acepta `priceUsedId` y CommunicationPackageService ::updatePrice lo aplica → ahora la tarifa es editable (antes ni existía la propiedad en el DTO de update).
- PRICE_SORTABLE gana `createdAt` (el listado ordena por ese campo).

Paquetes (CommunicationClientPackage):
- serializeClientPackage (listado) ahora incluye `destination` y `validity`; la lista los renderizaba pero el serialize no los enviaba, dejando esas columnas siempre en '—'.
- PACKAGE_SORTABLE gana `createdAt`.

Verificado contra la API/BD y con e2e (revertir priceUsed hace fallar el test de edición de precios).