### PR TITLE
fix(2fa): permitir configurar el 2FA cuando la política ya lo exige

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -26,6 +26,13 @@ framework:
             policy: 'sliding_window'
             limit: 20
             interval: '5 minutes'
+        # Intentos de código 2FA (verificación, enrolamiento y confirmación desde el perfil).
+        # El intervalo va alineado con la vida del pendingToken: sin esto, un código de 6
+        # dígitos es forzable por fuerza bruta durante los 10 minutos que dura el token.
+        two_factor_code:
+            policy: 'sliding_window'
+            limit: 10
+            interval: '10 minutes'
         forgot_password:
             policy: 'fixed_window'
             limit: 3

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -57,6 +57,12 @@ security:
         - { path: '^/dashboard/api/activate', roles: PUBLIC_ACCESS }
         - { path: '^/dashboard/api/refresh', roles: PUBLIC_ACCESS }
         - { path: '^/dashboard/api/2fa/verify', roles: PUBLIC_ACCESS }
+        # Enrolamiento durante el login: el usuario aún no tiene JWT (no lo tendrá hasta
+        # activar el 2FA). Se autentica con el pendingToken, validado en el servicio.
+        - { path: '^/dashboard/api/2fa/enroll', roles: PUBLIC_ACCESS }
+        # Recuperación (código de respaldo o reinicio por correo): mismo caso, el usuario
+        # está a medias del login y solo dispone del pendingToken.
+        - { path: '^/dashboard/api/2fa/recover', roles: PUBLIC_ACCESS }
         - { path: '^/api', roles: ROLE_API_USER }
         - { path: '^/dashboard/api', roles: ROLE_SYSTEM_USER }
         # - { path: ^/profile, roles: ROLE_USER }

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -48,6 +48,13 @@ services:
         arguments:
             $appEnv: '%kernel.environment%'
 
+    # La clave de cifrado del secreto TOTP se deriva del secreto de la aplicación.
+    # Cambiar APP_SECRET invalida los secretos ya cifrados: los usuarios afectados
+    # tendrían que volver a enrolar su 2FA.
+    App\Security\SecretCipher:
+        arguments:
+            $appSecret: '%env(APP_SECRET)%'
+
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones
 

--- a/migrations/Version20260720000000.php
+++ b/migrations/Version20260720000000.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Endurecimiento del 2FA y siembra de su configuración global.
+ */
+final class Version20260720000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Añade two_factor_last_time_step (anti-replay TOTP) y siembra las claves 2fa.* en sys_config';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // Último time step TOTP consumido: impide reutilizar un código dentro de su
+        // ventana de validez. Nullable porque los usuarios ya enrolados aún no tienen uno.
+        $this->addSql('ALTER TABLE "user" ADD COLUMN IF NOT EXISTS two_factor_last_time_step BIGINT DEFAULT NULL');
+
+        // Hasta ahora estas claves solo nacían al guardar desde el panel de administración:
+        // en un entorno nuevo la política caía a los defaults del código sin dejar rastro
+        // en la base de datos. Se siembran explícitamente con los valores por defecto.
+        // El id no tiene DEFAULT (Doctrine usa estrategia SEQUENCE), así que se toma
+        // explícitamente de la secuencia.
+        $this->addSql(<<<'SQL'
+            INSERT INTO sys_config (id, property_name, property_value, created_at, updated_at, is_active, is_encrypted)
+            SELECT nextval('sys_config_id_seq'), v.name, v.value, NOW(), NOW(), TRUE, FALSE
+            FROM (VALUES
+                ('2fa.mode',   'optional'),
+                ('2fa.method', 'totp')
+            ) AS v(name, value)
+            WHERE NOT EXISTS (
+                SELECT 1 FROM sys_config sc WHERE sc.property_name = v.name
+            )
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE "user" DROP COLUMN IF EXISTS two_factor_last_time_step');
+        // 2fa.deadline no se siembra, así que no se elimina: podría existir por
+        // configuración real del administrador.
+        $this->addSql("DELETE FROM sys_config WHERE property_name IN ('2fa.mode', '2fa.method')");
+    }
+}

--- a/migrations/Version20260720120000.php
+++ b/migrations/Version20260720120000.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Códigos de respaldo del 2FA, para que un usuario que pierde el dispositivo pueda
+ * recuperar el acceso por sí mismo.
+ */
+final class Version20260720120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Añade user.two_factor_backup_codes (hashes de los códigos de respaldo sin usar)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE "user" ADD COLUMN IF NOT EXISTS two_factor_backup_codes JSON DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE "user" DROP COLUMN IF EXISTS two_factor_backup_codes');
+    }
+}

--- a/scripts/2fa-totp.php
+++ b/scripts/2fa-totp.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Genera el código TOTP actual para un secreto Base32, usando el mismo helper que la
+ * aplicación. Herramienta de pruebas manuales del flujo 2FA.
+ *
+ * Uso: php scripts/2fa-totp.php <SECRETO_BASE32>
+ */
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use App\Security\TwoFactorHelper;
+
+$secret = $argv[1] ?? null;
+
+if ($secret === null) {
+    fwrite(STDERR, "Uso: php scripts/2fa-totp.php <SECRETO_BASE32>\n");
+    exit(1);
+}
+
+$ref = new ReflectionClass(TwoFactorHelper::class);
+
+$decode = $ref->getMethod('base32Decode');
+$decode->setAccessible(true);
+
+$hotp = $ref->getMethod('hotp');
+$hotp->setAccessible(true);
+
+$key       = $decode->invoke(null, $secret);
+$timestep  = (int) floor(time() / 30);
+
+echo $hotp->invoke(null, $key, $timestep) . "\n";

--- a/src/Command/EncryptTwoFactorSecretsCommand.php
+++ b/src/Command/EncryptTwoFactorSecretsCommand.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\User;
+use App\Security\SecretCipher;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:2fa:encrypt-secrets',
+    description: 'Cifra en reposo los secretos TOTP que todavía están guardados en claro.',
+)]
+class EncryptTwoFactorSecretsCommand extends Command
+{
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly SecretCipher           $cipher,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption('dry-run', null, InputOption::VALUE_NONE, 'Muestra qué se cifraría sin escribir nada.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io     = new SymfonyStyle($input, $output);
+        $dryRun = (bool) $input->getOption('dry-run');
+
+        /** @var User[] $users */
+        $users = $this->em->getRepository(User::class)
+            ->createQueryBuilder('u')
+            ->where('u.twoFactorSecret IS NOT NULL')
+            ->getQuery()
+            ->getResult();
+
+        $pendientes = 0;
+
+        foreach ($users as $user) {
+            $stored = $user->getTwoFactorSecret();
+
+            if ($stored === null || $this->cipher->isEncrypted($stored)) {
+                continue;
+            }
+
+            $pendientes++;
+
+            if (!$dryRun) {
+                $user->setTwoFactorSecret($this->cipher->encrypt($stored));
+            }
+        }
+
+        if ($pendientes === 0) {
+            $io->success('No hay secretos en claro: todos están ya cifrados.');
+
+            return Command::SUCCESS;
+        }
+
+        if ($dryRun) {
+            $io->note(sprintf('%d secreto(s) se cifrarían. Vuelve a ejecutar sin --dry-run.', $pendientes));
+
+            return Command::SUCCESS;
+        }
+
+        $this->em->flush();
+        $io->success(sprintf('%d secreto(s) cifrados.', $pendientes));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Controller/AdminTwoFactorConfigController.php
+++ b/src/Controller/AdminTwoFactorConfigController.php
@@ -4,9 +4,11 @@ namespace App\Controller;
 
 use App\DTO\TwoFactorConfigDto;
 use App\DTO\Out\TwoFactorConfigOutDto;
+use App\Entity\User;
 use App\Exception\MyCurrentException;
 use App\OpenApi\Attribute\DashboardEndpoint;
 use App\Service\TwoFactorService;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
@@ -16,7 +18,8 @@ use Symfony\Component\Routing\Attribute\Route;
 class AdminTwoFactorConfigController extends AbstractController
 {
     public function __construct(
-        private readonly TwoFactorService $twoFactorService,
+        private readonly TwoFactorService       $twoFactorService,
+        private readonly EntityManagerInterface $em,
     ) {}
 
     #[Route('/config', name: 'admin_2fa_config_get', methods: ['GET'])]
@@ -52,9 +55,35 @@ class AdminTwoFactorConfigController extends AbstractController
         try {
             $config = $this->twoFactorService->updateConfig($dto);
         } catch (MyCurrentException $e) {
-            return $this->json(['error' => ['message' => $e->getMessage()]], $e->getCode());
+            return $this->json(['error' => ['message' => $e->getMessage(), 'code' => $e->getCodeWork()]], $e->getCode());
         }
 
         return $this->json($config);
+    }
+
+    #[Route('/reset/{userId}', name: 'admin_2fa_reset_user', methods: ['POST'], requirements: ['userId' => '\d+'])]
+    #[DashboardEndpoint(
+        summary: 'Reiniciar el 2FA de un usuario',
+        description: 'Último recurso cuando un usuario ha perdido el dispositivo y sus códigos de respaldo: desactiva su 2FA y elimina secreto y códigos. Si la política global lo exige, se le pedirá configurarlo de nuevo en su próximo inicio de sesión, de modo que la cuenta no queda desprotegida. Solo accesible para `ROLE_SUPER_ADMIN`.',
+        tag: '2FA Admin',
+    )]
+    public function resetUser(int $userId): JsonResponse
+    {
+        if (!$this->isGranted('ROLE_SUPER_ADMIN')) {
+            return $this->json(['error' => ['message' => 'Access denied']], Response::HTTP_FORBIDDEN);
+        }
+
+        $user = $this->em->getRepository(User::class)->find($userId);
+
+        if ($user === null) {
+            return $this->json(
+                ['error' => ['message' => 'User not found', 'code' => 'USER_NOT_FOUND']],
+                Response::HTTP_NOT_FOUND
+            );
+        }
+
+        $this->twoFactorService->resetForUser($user);
+
+        return $this->json(['twoFactorEnabled' => false, 'userId' => $userId]);
     }
 }

--- a/src/Controller/ApiLoginController.php
+++ b/src/Controller/ApiLoginController.php
@@ -72,13 +72,16 @@ class ApiLoginController extends AbstractController
             ], Response::HTTP_TOO_MANY_REQUESTS);
         }
 
-        // Si el usuario requiere 2FA, devolver pending token en lugar del JWT
+        // Si el usuario requiere 2FA, devolver pending token en lugar del JWT.
+        // `requiresEnrollment` indica que aún no lo ha configurado: el cliente debe
+        // llevarlo a /2fa/enroll/* en vez de pedirle un código que no puede generar.
         if ($this->twoFactorService->requiresTwoFactor($user)) {
             $verification = $this->twoFactorService->startLoginVerification($user);
             return $this->json([
-                'requires2fa'  => true,
-                'pendingToken' => $verification['pendingToken'],
-                'method'       => $verification['method'],
+                'requires2fa'        => true,
+                'requiresEnrollment' => $this->twoFactorService->requiresEnrollment($user),
+                'pendingToken'       => $verification['pendingToken'],
+                'method'             => $verification['method'],
             ]);
         }
 

--- a/src/Controller/TwoFactorController.php
+++ b/src/Controller/TwoFactorController.php
@@ -2,7 +2,10 @@
 
 namespace App\Controller;
 
+use App\DTO\TwoFactorBackupCodeDto;
 use App\DTO\TwoFactorCodeDto;
+use App\DTO\TwoFactorDisableDto;
+use App\DTO\TwoFactorEnrollSetupDto;
 use App\DTO\TwoFactorVerifyDto;
 use App\DTO\Out\TwoFactorSetupOutDto;
 use App\Entity\User;
@@ -12,9 +15,11 @@ use App\Service\RefreshTokenService;
 use App\Service\TwoFactorService;
 use App\Service\UserService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\CurrentUser;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -27,7 +32,67 @@ class TwoFactorController extends AbstractController
         private readonly UserService         $userService,
         private readonly RefreshTokenService $refreshTokenService,
         private readonly NormalizerInterface $serializer,
+        #[Autowire(service: 'limiter.two_factor_code')]
+        private readonly RateLimiterFactory  $twoFactorCodeLimiter,
     ) {}
+
+    /**
+     * Emite la sesión completa (JWT + cookie de refresh). Compartido por la verificación
+     * y por la confirmación del enrolamiento: en ambos casos el usuario acaba de superar
+     * el segundo factor, así que el resultado debe ser idéntico al de un login normal.
+     */
+    private function issueSession(User $user, string $clientIp, ?array $backupCodes = null): JsonResponse
+    {
+        $user->setCurrentIp($clientIp);
+        $currentUser  = $this->userService->createPayloadUser($user);
+        $accessToken  = $this->userService->createTokenFromPayload($user, $currentUser);
+        $refreshToken = $this->refreshTokenService->createForUser($user, $clientIp);
+
+        $payload = [
+            'token'     => $accessToken,
+            'expiresIn' => (int) $this->getParameter('app.jwt.expired') * 60,
+            'user'      => $this->serializer->normalize($currentUser, 'json', ['groups' => ['profile']]),
+        ];
+
+        // Los códigos de respaldo solo viajan al activarse el 2FA: es la única vez que
+        // existen en claro y el cliente debe mostrarlos para que el usuario los guarde.
+        if ($backupCodes !== null) {
+            $payload['backupCodes'] = $backupCodes;
+        }
+
+        $response = $this->json($payload);
+
+        $response->headers->setCookie($this->refreshTokenService->createCookie($refreshToken));
+
+        return $response;
+    }
+
+    /**
+     * Respuesta de error del módulo 2FA. Incluye el código simbólico (`INVALID_2FA_CODE`,
+     * `PENDING_TOKEN_EXPIRED`…) además del mensaje: el cliente necesita distinguir los
+     * casos para decidir si limpia el código o vuelve al paso de credenciales.
+     */
+    private function errorResponse(MyCurrentException $e): JsonResponse
+    {
+        return $this->json(
+            ['error' => ['message' => $e->getMessage(), 'code' => $e->getCodeWork()]],
+            $e->getCode()
+        );
+    }
+
+    /** Limita los intentos de código por pendingToken o por usuario. */
+    private function tooManyAttempts(string $key): bool
+    {
+        return !$this->twoFactorCodeLimiter->create($key)->consume()->isAccepted();
+    }
+
+    private function rateLimitResponse(): JsonResponse
+    {
+        return $this->json(
+            ['error' => ['message' => 'Too many attempts. Please try again later.', 'code' => 'TOO_MANY_ATTEMPTS']],
+            Response::HTTP_TOO_MANY_REQUESTS
+        );
+    }
 
     #[Route('/setup', name: 'dashboard_2fa_setup', methods: ['POST'])]
     #[DashboardEndpoint(
@@ -49,7 +114,7 @@ class TwoFactorController extends AbstractController
         try {
             $result = $this->twoFactorService->startSetup($user);
         } catch (MyCurrentException $e) {
-            return $this->json(['error' => ['message' => $e->getMessage()]], $e->getCode());
+            return $this->errorResponse($e);
         }
 
         return $this->json($result);
@@ -58,7 +123,7 @@ class TwoFactorController extends AbstractController
     #[Route('/confirm', name: 'dashboard_2fa_confirm', methods: ['POST'])]
     #[DashboardEndpoint(
         summary: 'Confirmar y activar el 2FA',
-        description: 'Verifica el código obtenido tras llamar a `/2fa/setup` y activa el 2FA en la cuenta. Una vez activado, todos los siguientes inicios de sesión requerirán verificación 2FA. Errores posibles: `2FA_SETUP_NOT_STARTED` (llamar antes a `/2fa/setup`), `INVALID_2FA_CODE` (código incorrecto), `2FA_CODE_EXPIRED` (solo `method=email`; reiniciar el proceso).',
+        description: 'Verifica el código obtenido tras llamar a `/2fa/setup` y activa el 2FA en la cuenta. Una vez activado, todos los siguientes inicios de sesión requerirán verificación 2FA. Devuelve además `backupCodes`: un juego de códigos de un solo uso que solo se muestran aquí y que permiten entrar si el usuario pierde el dispositivo. Errores posibles: `2FA_SETUP_NOT_STARTED` (llamar antes a `/2fa/setup`), `INVALID_2FA_CODE` (código incorrecto), `2FA_CODE_EXPIRED` (solo `method=email`; reiniciar el proceso).',
         tag: '2FA',
         requestDto: TwoFactorCodeDto::class,
     )]
@@ -68,28 +133,44 @@ class TwoFactorController extends AbstractController
             return $this->json(['error' => ['message' => 'Unauthorized']], Response::HTTP_UNAUTHORIZED);
         }
 
+        if ($this->tooManyAttempts('2fa_user_' . $user->getId())) {
+            return $this->rateLimitResponse();
+        }
+
         try {
             $this->twoFactorService->confirmSetup($user, $dto->getCode());
         } catch (MyCurrentException $e) {
-            return $this->json(['error' => ['message' => $e->getMessage()]], $e->getCode());
+            return $this->errorResponse($e);
         }
 
-        return $this->json(['twoFactorEnabled' => true]);
+        return $this->json([
+            'twoFactorEnabled' => true,
+            'backupCodes'      => $this->twoFactorService->regenerateBackupCodes($user),
+        ]);
     }
 
     #[Route('', name: 'dashboard_2fa_disable', methods: ['DELETE'])]
     #[DashboardEndpoint(
         summary: 'Desactivar el 2FA',
-        description: 'Desactiva el 2FA del usuario autenticado y elimina el secreto almacenado. Si la política global es `mandatory` y el deadline ya ha pasado, el próximo login volverá a requerir 2FA igualmente (se generará un código nuevo). Devuelve `{ "twoFactorEnabled": false }`.',
+        description: 'Desactiva el 2FA del usuario autenticado y elimina el secreto almacenado. Exige la contraseña actual en el cuerpo de la petición: sin ella, un token de sesión robado bastaría para apagar el segundo factor. Si la política global es `mandatory` y el deadline ya ha pasado, el próximo login pedirá configurarlo de nuevo. Devuelve `{ "twoFactorEnabled": false }`. Error posible: `INVALID_CURRENT_PASSWORD`.',
         tag: '2FA',
+        requestDto: TwoFactorDisableDto::class,
     )]
-    public function disable(#[CurrentUser] ?User $user): JsonResponse
+    public function disable(#[CurrentUser] ?User $user, TwoFactorDisableDto $dto): JsonResponse
     {
         if ($user === null) {
             return $this->json(['error' => ['message' => 'Unauthorized']], Response::HTTP_UNAUTHORIZED);
         }
 
-        $this->twoFactorService->disable($user);
+        if ($this->tooManyAttempts('2fa_user_' . $user->getId())) {
+            return $this->rateLimitResponse();
+        }
+
+        try {
+            $this->twoFactorService->disableWithPassword($user, $dto->getPassword());
+        } catch (MyCurrentException $e) {
+            return $this->errorResponse($e);
+        }
 
         return $this->json(['twoFactorEnabled' => false]);
     }
@@ -105,28 +186,167 @@ class TwoFactorController extends AbstractController
     {
         $clientIp = $request->getClientIp() ?? 'unknown';
 
+        if ($this->tooManyAttempts('2fa_' . $dto->getPendingToken())) {
+            return $this->rateLimitResponse();
+        }
+
         try {
             $user = $this->twoFactorService->verifyLoginCode(
                 $dto->getPendingToken(),
                 $dto->getCode()
             );
         } catch (MyCurrentException $e) {
-            return $this->json(['error' => ['message' => $e->getMessage()]], $e->getCode());
+            return $this->errorResponse($e);
         }
 
-        $user->setCurrentIp($clientIp);
-        $currentUser  = $this->userService->createPayloadUser($user);
-        $accessToken  = $this->userService->createTokenFromPayload($user, $currentUser);
-        $refreshToken = $this->refreshTokenService->createForUser($user, $clientIp);
+        return $this->issueSession($user, $clientIp);
+    }
 
-        $response = $this->json([
-            'token'     => $accessToken,
-            'expiresIn' => (int) $this->getParameter('app.jwt.expired') * 60,
-            'user'      => $this->serializer->normalize($currentUser, 'json', ['groups' => ['profile']]),
-        ]);
+    #[Route('/enroll/setup', name: 'dashboard_2fa_enroll_setup', methods: ['POST'])]
+    #[DashboardEndpoint(
+        summary: 'Iniciar el enrolamiento del 2FA durante el login',
+        description: 'Primer paso cuando `/login` devuelve `requiresEnrollment=true`: el usuario debe configurar el 2FA porque la política global ya lo exige, pero todavía no lo tiene activo. Se autentica con el `pendingToken` emitido por `/login` (no hace falta JWT, que aún no existe). Si `method=totp` devuelve el secreto y la URI para el QR; si `method=email` envía un código al correo. Continuar con `/2fa/enroll/confirm`.',
+        tag: '2FA',
+        requestDto: TwoFactorEnrollSetupDto::class,
+        responseDto: TwoFactorSetupOutDto::class,
+    )]
+    public function enrollSetup(TwoFactorEnrollSetupDto $dto): JsonResponse
+    {
+        if ($this->tooManyAttempts('2fa_' . $dto->getPendingToken())) {
+            return $this->rateLimitResponse();
+        }
 
-        $response->headers->setCookie($this->refreshTokenService->createCookie($refreshToken));
+        try {
+            $result = $this->twoFactorService->startEnrollment($dto->getPendingToken());
+        } catch (MyCurrentException $e) {
+            return $this->errorResponse($e);
+        }
+
+        return $this->json($result);
+    }
+
+    #[Route('/enroll/confirm', name: 'dashboard_2fa_enroll_confirm', methods: ['POST'])]
+    #[DashboardEndpoint(
+        summary: 'Confirmar el enrolamiento y completar el login',
+        description: 'Segundo paso del enrolamiento durante el login. Verifica el primer código, activa el 2FA y devuelve el JWT y el refresh token: enrolarse e iniciar sesión son una sola operación, de modo que nunca se emite una sesión sin segundo factor. Errores posibles: `INVALID_PENDING_TOKEN`, `PENDING_TOKEN_EXPIRED`, `INVALID_2FA_CODE`, `2FA_CODE_EXPIRED`, `2FA_ALREADY_ENABLED`.',
+        tag: '2FA',
+        requestDto: TwoFactorVerifyDto::class,
+    )]
+    public function enrollConfirm(TwoFactorVerifyDto $dto, Request $request): JsonResponse
+    {
+        $clientIp = $request->getClientIp() ?? 'unknown';
+
+        if ($this->tooManyAttempts('2fa_' . $dto->getPendingToken())) {
+            return $this->rateLimitResponse();
+        }
+
+        try {
+            $resultado = $this->twoFactorService->confirmEnrollment(
+                $dto->getPendingToken(),
+                $dto->getCode()
+            );
+        } catch (MyCurrentException $e) {
+            return $this->errorResponse($e);
+        }
+
+        return $this->issueSession($resultado['user'], $clientIp, $resultado['backupCodes']);
+    }
+
+    #[Route('/recover/backup-code', name: 'dashboard_2fa_recover_backup', methods: ['POST'])]
+    #[DashboardEndpoint(
+        summary: 'Entrar con un código de respaldo',
+        description: 'Permite completar el login usando uno de los códigos de respaldo entregados al activar el 2FA, para cuando el usuario ha perdido el dispositivo. El código es de un solo uso y se invalida al consumirse. Devuelve el JWT igual que `/2fa/verify`, junto con `backupCodesRemaining` para avisar al usuario de cuántos le quedan. Error posible: `INVALID_BACKUP_CODE`.',
+        tag: '2FA',
+        requestDto: TwoFactorBackupCodeDto::class,
+    )]
+    public function recoverWithBackupCode(TwoFactorBackupCodeDto $dto, Request $request): JsonResponse
+    {
+        $clientIp = $request->getClientIp() ?? 'unknown';
+
+        if ($this->tooManyAttempts('2fa_' . $dto->getPendingToken())) {
+            return $this->rateLimitResponse();
+        }
+
+        try {
+            $user = $this->twoFactorService->verifyBackupCode(
+                $dto->getPendingToken(),
+                $dto->getCode()
+            );
+        } catch (MyCurrentException $e) {
+            return $this->errorResponse($e);
+        }
+
+        $response = $this->issueSession($user, $clientIp);
+        $payload  = json_decode($response->getContent(), true);
+        $payload['backupCodesRemaining'] = $this->twoFactorService->countBackupCodes($user);
+        $response->setData($payload);
 
         return $response;
+    }
+
+    #[Route('/recover/email/request', name: 'dashboard_2fa_recover_email_request', methods: ['POST'])]
+    #[DashboardEndpoint(
+        summary: 'Pedir un código por correo para reiniciar el 2FA',
+        description: 'Vía de último recurso para quien ha perdido el dispositivo y los códigos de respaldo. Requiere el `pendingToken`, es decir, haber superado ya usuario y contraseña: comprometer solo el correo no permite saltarse el segundo factor. Envía un código de 6 dígitos válido 10 minutos. Continuar con `/2fa/recover/email/confirm`.',
+        tag: '2FA',
+        requestDto: TwoFactorEnrollSetupDto::class,
+    )]
+    public function requestEmailReset(TwoFactorEnrollSetupDto $dto): JsonResponse
+    {
+        if ($this->tooManyAttempts('2fa_' . $dto->getPendingToken())) {
+            return $this->rateLimitResponse();
+        }
+
+        try {
+            $this->twoFactorService->requestEmailReset($dto->getPendingToken());
+        } catch (MyCurrentException $e) {
+            return $this->errorResponse($e);
+        }
+
+        return $this->json(['message' => 'Verification code sent to your email.']);
+    }
+
+    #[Route('/recover/email/confirm', name: 'dashboard_2fa_recover_email_confirm', methods: ['POST'])]
+    #[DashboardEndpoint(
+        summary: 'Confirmar el reinicio del 2FA por correo',
+        description: 'Valida el código enviado al correo y desactiva el 2FA del usuario, dejando vivo el `pendingToken` para que continúe con `/2fa/enroll/setup` y vincule su dispositivo nuevo. No emite sesión: el acceso se obtiene al terminar el enrolamiento, nunca antes. Devuelve `{ "requiresEnrollment": true }`.',
+        tag: '2FA',
+        requestDto: TwoFactorVerifyDto::class,
+    )]
+    public function confirmEmailReset(TwoFactorVerifyDto $dto): JsonResponse
+    {
+        if ($this->tooManyAttempts('2fa_' . $dto->getPendingToken())) {
+            return $this->rateLimitResponse();
+        }
+
+        try {
+            $this->twoFactorService->confirmEmailReset($dto->getPendingToken(), $dto->getCode());
+        } catch (MyCurrentException $e) {
+            return $this->errorResponse($e);
+        }
+
+        return $this->json(['requiresEnrollment' => true]);
+    }
+
+    #[Route('/backup-codes', name: 'dashboard_2fa_regenerate_backup_codes', methods: ['POST'])]
+    #[DashboardEndpoint(
+        summary: 'Regenerar los códigos de respaldo',
+        description: 'Genera un juego nuevo de códigos de respaldo e invalida los anteriores. Se devuelven en claro una única vez: si el usuario los pierde, tendrá que volver a generarlos. Requiere tener el 2FA activo.',
+        tag: '2FA',
+    )]
+    public function regenerateBackupCodes(#[CurrentUser] ?User $user): JsonResponse
+    {
+        if ($user === null) {
+            return $this->json(['error' => ['message' => 'Unauthorized']], Response::HTTP_UNAUTHORIZED);
+        }
+
+        if (!$user->isTwoFactorEnabled()) {
+            return $this->json(
+                ['error' => ['message' => '2FA is not enabled.', 'code' => '2FA_NOT_ENABLED']],
+                Response::HTTP_CONFLICT
+            );
+        }
+
+        return $this->json(['backupCodes' => $this->twoFactorService->regenerateBackupCodes($user)]);
     }
 }

--- a/src/DTO/TwoFactorBackupCodeDto.php
+++ b/src/DTO/TwoFactorBackupCodeDto.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\DTO;
+
+use App\OpenApi\Attribute\OAProperty;
+use Symfony\Component\Validator\Constraints as Assert;
+
+class TwoFactorBackupCodeDto implements IInput
+{
+    #[OAProperty(description: 'Token temporal devuelto por `/login` en el campo `pendingToken`. Expira en 10 minutos.')]
+    #[Assert\NotBlank]
+    protected ?string $pendingToken = null;
+
+    #[OAProperty(description: 'Código de respaldo con formato `XXXX-XXXX`, de los entregados al activar el 2FA. Se acepta con o sin guion y sin distinguir mayúsculas. Es de un solo uso.')]
+    #[Assert\NotBlank]
+    #[Assert\Length(min: 8, max: 9)]
+    protected ?string $code = null;
+
+    public function __construct(
+        ?string $pendingToken = null,
+        ?string $code = null,
+    ) {
+        $this->pendingToken = $pendingToken;
+        $this->code         = $code;
+    }
+
+    public function getPendingToken(): ?string { return $this->pendingToken; }
+    public function setPendingToken(?string $v): void { $this->pendingToken = $v; }
+
+    public function getCode(): ?string { return $this->code; }
+    public function setCode(?string $v): void { $this->code = $v; }
+}

--- a/src/DTO/TwoFactorDisableDto.php
+++ b/src/DTO/TwoFactorDisableDto.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\DTO;
+
+use App\OpenApi\Attribute\OAProperty;
+use Symfony\Component\Validator\Constraints as Assert;
+
+class TwoFactorDisableDto implements IInput
+{
+    #[OAProperty(description: 'Contraseña actual del usuario. Se exige para desactivar el 2FA de modo que un token de sesión robado no baste para apagar el segundo factor.')]
+    #[Assert\NotBlank]
+    protected ?string $password = null;
+
+    public function __construct(
+        ?string $password = null,
+    ) {
+        $this->password = $password;
+    }
+
+    public function getPassword(): ?string { return $this->password; }
+    public function setPassword(?string $v): void { $this->password = $v; }
+}

--- a/src/DTO/TwoFactorEnrollSetupDto.php
+++ b/src/DTO/TwoFactorEnrollSetupDto.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\DTO;
+
+use App\OpenApi\Attribute\OAProperty;
+use Symfony\Component\Validator\Constraints as Assert;
+
+class TwoFactorEnrollSetupDto implements IInput
+{
+    #[OAProperty(description: 'Token temporal devuelto por `/login` en el campo `pendingToken` cuando `requiresEnrollment=true`. Expira en 10 minutos.')]
+    #[Assert\NotBlank]
+    protected ?string $pendingToken = null;
+
+    public function __construct(
+        ?string $pendingToken = null,
+    ) {
+        $this->pendingToken = $pendingToken;
+    }
+
+    public function getPendingToken(): ?string { return $this->pendingToken; }
+    public function setPendingToken(?string $v): void { $this->pendingToken = $v; }
+}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -123,6 +123,23 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, IInput
     #[ORM\Column(nullable: true)]
     private ?DateTimeImmutable $twoFactorEmailCodeExpiresAt = null;
 
+    /**
+     * Último time step TOTP consumido. Impide reutilizar un código dentro de su ventana
+     * de validez (±30 s): solo se acepta un time step estrictamente mayor a este.
+     */
+    #[ORM\Column(type: 'bigint', nullable: true)]
+    private ?string $twoFactorLastTimeStep = null;
+
+    /**
+     * Hashes SHA-256 de los códigos de respaldo aún sin usar. Se guardan hasheados porque
+     * son credenciales de acceso completo; en claro solo existen en el momento de
+     * generarlos, cuando se muestran al usuario una única vez.
+     *
+     * @var string[]|null
+     */
+    #[ORM\Column(type: 'json', nullable: true)]
+    private ?array $twoFactorBackupCodes = null;
+
     public function __construct()
     {
         $this->historicPasswords = new ArrayCollection();
@@ -495,4 +512,12 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, IInput
 
     public function getTwoFactorEmailCodeExpiresAt(): ?DateTimeImmutable { return $this->twoFactorEmailCodeExpiresAt; }
     public function setTwoFactorEmailCodeExpiresAt(?DateTimeImmutable $v): void { $this->twoFactorEmailCodeExpiresAt = $v; }
+
+    public function getTwoFactorLastTimeStep(): ?int { return $this->twoFactorLastTimeStep === null ? null : (int) $this->twoFactorLastTimeStep; }
+    public function setTwoFactorLastTimeStep(?int $v): void { $this->twoFactorLastTimeStep = $v === null ? null : (string) $v; }
+
+    /** @return string[]|null */
+    public function getTwoFactorBackupCodes(): ?array { return $this->twoFactorBackupCodes; }
+    /** @param string[]|null $v */
+    public function setTwoFactorBackupCodes(?array $v): void { $this->twoFactorBackupCodes = $v; }
 }

--- a/src/Security/DashboardAccessToken.php
+++ b/src/Security/DashboardAccessToken.php
@@ -38,7 +38,15 @@ class DashboardAccessToken extends AbstractAuthenticator
             throw new CustomUserMessageAuthenticationException('Empty authorization token.');
         }
 
-        $user = $this->userService->parser($token);
+        // Un token inválido, caducado o malformado es un fallo de autenticación, no un
+        // error del servidor: sin este catch la excepción del parser escapaba del
+        // firewall y cualquier Bearer basura respondía 500 en lugar de 401. El mensaje se
+        // mantiene genérico a propósito, para no filtrar por qué falló la validación.
+        try {
+            $user = $this->userService->parser($token);
+        } catch (\Throwable) {
+            throw new CustomUserMessageAuthenticationException('Invalid or expired token.');
+        }
 
         return new SelfValidatingPassport(new UserBadge($user->getUserIdentifier()));
     }

--- a/src/Security/SecretCipher.php
+++ b/src/Security/SecretCipher.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Security;
+
+/**
+ * Cifrado simétrico autenticado (AES-256-GCM) para secretos que deben poder recuperarse
+ * en claro, como el secreto TOTP: no sirve un hash porque hay que regenerar códigos con él.
+ *
+ * El formato almacenado es `v1:base64(nonce || tag || ciphertext)`. El prefijo de versión
+ * permite migrar de algoritmo más adelante, y distinguir un valor cifrado de uno heredado
+ * en claro sin necesidad de una columna extra.
+ *
+ * La clave se deriva por HKDF a partir de un secreto de aplicación, de modo que esta
+ * función nunca usa el secreto crudo y un cambio de propósito no reutiliza material de
+ * clave. Ojo: si ese secreto cambia, los valores existentes dejan de poder descifrarse y
+ * los usuarios afectados tendrán que volver a enrolar su 2FA.
+ */
+class SecretCipher
+{
+    private const CIPHER  = 'aes-256-gcm';
+    private const PREFIX  = 'v1:';
+    private const INFO    = '2fa-secret-encryption';
+    private const TAG_LEN = 16;
+
+    private readonly string $key;
+
+    public function __construct(string $appSecret)
+    {
+        $this->key = hash_hkdf('sha256', $appSecret, 32, self::INFO);
+    }
+
+    public function encrypt(string $plaintext): string
+    {
+        $nonce = random_bytes(openssl_cipher_iv_length(self::CIPHER));
+        $tag   = '';
+
+        $ciphertext = openssl_encrypt(
+            $plaintext,
+            self::CIPHER,
+            $this->key,
+            OPENSSL_RAW_DATA,
+            $nonce,
+            $tag,
+            '',
+            self::TAG_LEN
+        );
+
+        if ($ciphertext === false) {
+            throw new \RuntimeException('Unable to encrypt secret.');
+        }
+
+        return self::PREFIX . base64_encode($nonce . $tag . $ciphertext);
+    }
+
+    /**
+     * Descifra un valor. Los valores sin el prefijo de versión se devuelven tal cual: son
+     * secretos anteriores al cifrado y deben seguir funcionando hasta que se migren.
+     */
+    public function decrypt(string $stored): string
+    {
+        if (!str_starts_with($stored, self::PREFIX)) {
+            return $stored;
+        }
+
+        $raw = base64_decode(substr($stored, strlen(self::PREFIX)), true);
+        if ($raw === false) {
+            throw new \RuntimeException('Unable to decode encrypted secret.');
+        }
+
+        $nonceLen = openssl_cipher_iv_length(self::CIPHER);
+        $nonce    = substr($raw, 0, $nonceLen);
+        $tag      = substr($raw, $nonceLen, self::TAG_LEN);
+        $cipher   = substr($raw, $nonceLen + self::TAG_LEN);
+
+        $plaintext = openssl_decrypt($cipher, self::CIPHER, $this->key, OPENSSL_RAW_DATA, $nonce, $tag);
+
+        if ($plaintext === false) {
+            throw new \RuntimeException('Unable to decrypt secret.');
+        }
+
+        return $plaintext;
+    }
+
+    public function isEncrypted(string $stored): bool
+    {
+        return str_starts_with($stored, self::PREFIX);
+    }
+}

--- a/src/Security/TwoFactorHelper.php
+++ b/src/Security/TwoFactorHelper.php
@@ -10,6 +10,10 @@ final class TwoFactorHelper
     private const BASE32_CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
     private const TOTP_WINDOW  = 1; // accept ±1 time step (±30 s)
 
+    /** Sin 0/O ni 1/I/L: el usuario transcribe estos códigos a mano. */
+    private const BACKUP_CHARS       = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789';
+    private const BACKUP_CODE_COUNT  = 10;
+
     // ── TOTP ────────────────────────────────────────────────────────────────
 
     public static function generateSecret(): string
@@ -31,16 +35,28 @@ final class TwoFactorHelper
 
     public static function verifyTotp(string $secret, string $code): bool
     {
+        return self::matchTotpTimeStep($secret, $code) !== null;
+    }
+
+    /**
+     * Devuelve el time step con el que casa el código, o null si no casa con ninguno de
+     * la ventana aceptada. Quien lo llame debe persistir el valor devuelto y rechazar
+     * cualquier time step que no sea estrictamente mayor al último usado: sin eso, un
+     * código interceptado puede reutilizarse durante toda su ventana de validez.
+     */
+    public static function matchTotpTimeStep(string $secret, string $code): ?int
+    {
         $secretBytes = self::base32Decode($secret);
         $timeStep    = (int) floor(time() / 30);
 
         for ($i = -self::TOTP_WINDOW; $i <= self::TOTP_WINDOW; $i++) {
-            if (hash_equals(self::hotp($secretBytes, $timeStep + $i), $code)) {
-                return true;
+            $candidate = $timeStep + $i;
+            if (hash_equals(self::hotp($secretBytes, $candidate), $code)) {
+                return $candidate;
             }
         }
 
-        return false;
+        return null;
     }
 
     // ── Email OTP ───────────────────────────────────────────────────────────
@@ -48,6 +64,45 @@ final class TwoFactorHelper
     public static function generateEmailCode(): string
     {
         return str_pad((string) random_int(0, 999999), 6, '0', STR_PAD_LEFT);
+    }
+
+    // ── Códigos de respaldo ─────────────────────────────────────────────────
+
+    /**
+     * Genera códigos de un solo uso con formato `XXXX-XXXX`. Se excluyen los caracteres
+     * ambiguos (0/O, 1/I/L) porque el usuario los va a transcribir a mano desde papel.
+     *
+     * @return string[] códigos en claro; solo se muestran una vez
+     */
+    public static function generateBackupCodes(int $cantidad = self::BACKUP_CODE_COUNT): array
+    {
+        $codigos = [];
+
+        for ($i = 0; $i < $cantidad; $i++) {
+            $bruto = '';
+            for ($j = 0; $j < 8; $j++) {
+                $bruto .= self::BACKUP_CHARS[random_int(0, strlen(self::BACKUP_CHARS) - 1)];
+            }
+            $codigos[] = substr($bruto, 0, 4) . '-' . substr($bruto, 4);
+        }
+
+        return $codigos;
+    }
+
+    /**
+     * Hash de un código de respaldo. SHA-256 sin sal es suficiente aquí: a diferencia de
+     * una contraseña, el código lo genera el sistema con ~41 bits de entropía, así que no
+     * es susceptible de ataque por diccionario y no hace falta un hash lento.
+     */
+    public static function hashBackupCode(string $code): string
+    {
+        return hash('sha256', self::normalizeBackupCode($code));
+    }
+
+    /** Acepta el código con o sin guion, en mayúsculas o minúsculas. */
+    public static function normalizeBackupCode(string $code): string
+    {
+        return strtoupper(str_replace(['-', ' '], '', trim($code)));
     }
 
     // ── Internals ───────────────────────────────────────────────────────────

--- a/src/Service/TwoFactorService.php
+++ b/src/Service/TwoFactorService.php
@@ -9,10 +9,12 @@ use App\Exception\MyCurrentException;
 use App\Message\TwoFactorEmailCodeMessage;
 use App\Message\TwoFactorMandatoryNotificationMessage;
 use App\Repository\SysConfigRepository;
+use App\Security\SecretCipher;
 use App\Security\TwoFactorHelper;
 use DateTimeImmutable;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 class TwoFactorService
 {
@@ -21,11 +23,24 @@ class TwoFactorService
     private const KEY_DEADLINE = '2fa.deadline';
 
     public function __construct(
-        private readonly EntityManagerInterface $em,
-        private readonly SysConfigRepository    $sysConfigRepo,
-        private readonly MessageBusInterface    $bus,
-        private readonly string                 $appEnv,
+        private readonly EntityManagerInterface      $em,
+        private readonly SysConfigRepository         $sysConfigRepo,
+        private readonly MessageBusInterface         $bus,
+        private readonly UserPasswordHasherInterface $passwordHasher,
+        private readonly SecretCipher                $cipher,
+        private readonly string                      $appEnv,
     ) {}
+
+    /**
+     * Secreto TOTP en claro. Se guarda cifrado en base de datos, así que todo acceso al
+     * secreto debe pasar por aquí en lugar de leer la propiedad directamente.
+     */
+    private function plainSecret(User $user): ?string
+    {
+        $stored = $user->getTwoFactorSecret();
+
+        return $stored === null ? null : $this->cipher->decrypt($stored);
+    }
 
     public function getConfig(): array
     {
@@ -60,7 +75,9 @@ class TwoFactorService
 
         if ($method === 'totp') {
             $secret = TwoFactorHelper::generateSecret();
-            $user->setTwoFactorSecret($secret);
+            // En base de datos va cifrado; al cliente se le devuelve en claro una única
+            // vez, que es cuando lo necesita para vincular la app autenticadora.
+            $user->setTwoFactorSecret($this->cipher->encrypt($secret));
             $this->em->flush();
 
             return [
@@ -92,13 +109,11 @@ class TwoFactorService
         $method = $this->readValue(self::KEY_METHOD, 'totp');
 
         if ($method === 'totp') {
-            $secret = $user->getTwoFactorSecret();
+            $secret = $this->plainSecret($user);
             if ($secret === null) {
                 throw new MyCurrentException('2FA_SETUP_NOT_STARTED', '2FA setup not started.', 400);
             }
-            if (!TwoFactorHelper::verifyTotp($secret, $code)) {
-                throw new MyCurrentException('INVALID_2FA_CODE', 'Invalid verification code.', 422);
-            }
+            $this->consumeTotpCode($user, $secret, $code);
         } else {
             $storedCode = $user->getTwoFactorEmailCode();
             $expiresAt  = $user->getTwoFactorEmailCodeExpiresAt();
@@ -119,6 +134,149 @@ class TwoFactorService
         $this->em->flush();
     }
 
+    /**
+     * Genera un juego nuevo de códigos de respaldo y devuelve los códigos en claro. Se
+     * guardan hasheados, así que esta es la única ocasión en que pueden mostrarse: si el
+     * usuario los pierde, hay que regenerarlos.
+     *
+     * @return string[]
+     */
+    public function regenerateBackupCodes(User $user): array
+    {
+        $codigos = TwoFactorHelper::generateBackupCodes();
+
+        $user->setTwoFactorBackupCodes(
+            array_map(static fn (string $c): string => TwoFactorHelper::hashBackupCode($c), $codigos)
+        );
+        $this->em->flush();
+
+        return $codigos;
+    }
+
+    /**
+     * Consume un código de respaldo para completar el login cuando el usuario ha perdido
+     * el dispositivo. El código se elimina al usarse: es de un solo uso.
+     *
+     * @throws MyCurrentException
+     */
+    public function verifyBackupCode(string $pendingToken, string $code): User
+    {
+        $user = $this->resolvePendingToken($pendingToken);
+
+        $almacenados = $user->getTwoFactorBackupCodes() ?? [];
+        $hash        = TwoFactorHelper::hashBackupCode($code);
+
+        $restantes = array_values(array_filter(
+            $almacenados,
+            static fn (string $h): bool => !hash_equals($h, $hash)
+        ));
+
+        if (count($restantes) === count($almacenados)) {
+            throw new MyCurrentException('INVALID_BACKUP_CODE', 'Invalid or already used backup code.', 422);
+        }
+
+        $user->setTwoFactorBackupCodes($restantes);
+        $user->setTwoFactorPendingToken(null);
+        $user->setTwoFactorPendingTokenExpiresAt(null);
+        $this->em->flush();
+
+        return $user;
+    }
+
+    /**
+     * Último recurso de recuperación: envía un código al correo del usuario para poder
+     * reiniciar su 2FA. Arranca desde el pendingToken, es decir, solo después de haber
+     * validado usuario y contraseña — de modo que comprometer únicamente el correo no
+     * basta para saltarse el segundo factor.
+     *
+     * @throws MyCurrentException
+     */
+    public function requestEmailReset(string $pendingToken): void
+    {
+        $user = $this->resolvePendingToken($pendingToken);
+
+        $code = TwoFactorHelper::generateEmailCode();
+        $user->setTwoFactorEmailCode($code);
+        $user->setTwoFactorEmailCodeExpiresAt(new DateTimeImmutable('+10 minutes'));
+        $this->em->flush();
+
+        $brand = strtolower($user->getCompany()?->getContractWith() ?? 'comremit');
+        $this->bus->dispatch(new TwoFactorEmailCodeMessage(
+            $user->getEmail(),
+            $user->getFirstName(),
+            $code,
+            $brand
+        ));
+    }
+
+    /**
+     * Valida el código enviado por correo y deja al usuario sin 2FA, manteniendo vivo el
+     * pendingToken para que continúe directamente con el enrolamiento del dispositivo
+     * nuevo. No emite sesión: se entra al terminar de re-enrolar, nunca antes.
+     *
+     * @throws MyCurrentException
+     */
+    public function confirmEmailReset(string $pendingToken, string $code): void
+    {
+        $user = $this->resolvePendingToken($pendingToken);
+
+        $almacenado = $user->getTwoFactorEmailCode();
+        $expira     = $user->getTwoFactorEmailCodeExpiresAt();
+
+        if ($almacenado === null || $expira === null) {
+            throw new MyCurrentException('2FA_RESET_NOT_STARTED', 'Reset not started.', 400);
+        }
+        if (new DateTimeImmutable() > $expira) {
+            throw new MyCurrentException('2FA_CODE_EXPIRED', 'Verification code expired. Please start again.', 422);
+        }
+        if (!hash_equals($almacenado, $code)) {
+            throw new MyCurrentException('INVALID_2FA_CODE', 'Invalid verification code.', 422);
+        }
+
+        // Se conserva el pendingToken: es lo que autentica el enrolamiento posterior.
+        $token   = $user->getTwoFactorPendingToken();
+        $expiraT = $user->getTwoFactorPendingTokenExpiresAt();
+
+        $this->disable($user);
+
+        $user->setTwoFactorPendingToken($token);
+        $user->setTwoFactorPendingTokenExpiresAt($expiraT);
+        $this->em->flush();
+    }
+
+    /** Cuántos códigos de respaldo le quedan sin usar. */
+    public function countBackupCodes(User $user): int
+    {
+        return count($user->getTwoFactorBackupCodes() ?? []);
+    }
+
+    /**
+     * Reset administrativo: deja al usuario sin 2FA para que vuelva a enrolarse en su
+     * próximo login. Último recurso cuando ha perdido dispositivo y códigos de respaldo.
+     */
+    public function resetForUser(User $user): void
+    {
+        $this->disable($user);
+        $user->setTwoFactorBackupCodes(null);
+        $this->em->flush();
+    }
+
+    /**
+     * Desactiva el 2FA. Exige la contraseña actual: sin ella, un token de sesión robado
+     * bastaría para apagar el segundo factor, que es precisamente lo que debe proteger
+     * la cuenta cuando el token se ve comprometido.
+     *
+     * @throws MyCurrentException INVALID_CURRENT_PASSWORD
+     */
+    public function disableWithPassword(User $user, string $password): void
+    {
+        if (!$this->passwordHasher->isPasswordValid($user, $password)) {
+            throw new MyCurrentException('INVALID_CURRENT_PASSWORD', 'Current password is incorrect.', 422);
+        }
+
+        $this->disable($user);
+    }
+
     public function disable(User $user): void
     {
         $user->setTwoFactorEnabled(false);
@@ -127,6 +285,10 @@ class TwoFactorService
         $user->setTwoFactorPendingTokenExpiresAt(null);
         $user->setTwoFactorEmailCode(null);
         $user->setTwoFactorEmailCodeExpiresAt(null);
+        $user->setTwoFactorLastTimeStep(null);
+        // Sin segundo factor activo los códigos de respaldo no tienen sentido y no deben
+        // sobrevivir para un enrolamiento futuro.
+        $user->setTwoFactorBackupCodes(null);
         $this->em->flush();
     }
 
@@ -146,6 +308,16 @@ class TwoFactorService
         }
 
         return false;
+    }
+
+    /**
+     * El usuario debe pasar por el enrolamiento antes de poder verificar: la política
+     * global le exige 2FA pero todavía no lo ha activado. Solo tiene sentido consultarlo
+     * cuando `requiresTwoFactor()` ya ha devuelto true.
+     */
+    public function requiresEnrollment(User $user): bool
+    {
+        return !$user->isTwoFactorEnabled();
     }
 
     /** @throws MyCurrentException */
@@ -177,8 +349,14 @@ class TwoFactorService
         return ['pendingToken' => $token, 'method' => $method];
     }
 
-    /** @throws MyCurrentException */
-    public function verifyLoginCode(string $pendingToken, string $code): User
+    /**
+     * Resuelve el usuario dueño de un pendingToken vigente. El pendingToken es una
+     * credencial de un solo propósito emitida por `/login` tras validar las credenciales,
+     * y es lo que autentica tanto la verificación como el enrolamiento durante el login.
+     *
+     * @throws MyCurrentException INVALID_PENDING_TOKEN | PENDING_TOKEN_EXPIRED
+     */
+    private function resolvePendingToken(string $pendingToken): User
     {
         /** @var User|null $user */
         $user = $this->em->getRepository(User::class)->findOneBy([
@@ -194,13 +372,66 @@ class TwoFactorService
             throw new MyCurrentException('PENDING_TOKEN_EXPIRED', 'Login session expired. Please log in again.', 401);
         }
 
+        return $user;
+    }
+
+    /**
+     * Primer paso del enrolamiento durante el login: genera el secreto y la URI del QR
+     * para un usuario que aún no tiene 2FA pero al que la política ya se lo exige.
+     *
+     * @throws MyCurrentException
+     */
+    public function startEnrollment(string $pendingToken): array
+    {
+        $user = $this->resolvePendingToken($pendingToken);
+
+        if ($user->isTwoFactorEnabled()) {
+            throw new MyCurrentException('2FA_ALREADY_ENABLED', '2FA is already enabled.', 409);
+        }
+
+        return $this->startSetup($user);
+    }
+
+    /**
+     * Segundo paso del enrolamiento durante el login: confirma el primer código, activa el
+     * 2FA y consume el pendingToken. Devuelve el usuario para que el controlador emita la
+     * sesión, de modo que enrolarse y entrar sean una sola operación, junto con los códigos
+     * de respaldo recién generados (única ocasión en que pueden mostrarse en claro).
+     *
+     * @throws MyCurrentException
+     *
+     * @return array{user: User, backupCodes: string[]}
+     */
+    public function confirmEnrollment(string $pendingToken, string $code): array
+    {
+        $user = $this->resolvePendingToken($pendingToken);
+
+        if ($user->isTwoFactorEnabled()) {
+            throw new MyCurrentException('2FA_ALREADY_ENABLED', '2FA is already enabled.', 409);
+        }
+
+        $this->confirmSetup($user, $code);
+
+        $user->setTwoFactorPendingToken(null);
+        $user->setTwoFactorPendingTokenExpiresAt(null);
+        $this->em->flush();
+
+        return ['user' => $user, 'backupCodes' => $this->regenerateBackupCodes($user)];
+    }
+
+    /** @throws MyCurrentException */
+    public function verifyLoginCode(string $pendingToken, string $code): User
+    {
+        $user = $this->resolvePendingToken($pendingToken);
+
         $method = $this->readValue(self::KEY_METHOD, 'totp');
 
         if ($method === 'totp') {
-            $secret = $user->getTwoFactorSecret();
-            if ($secret === null || !TwoFactorHelper::verifyTotp($secret, $code)) {
+            $secret = $this->plainSecret($user);
+            if ($secret === null) {
                 throw new MyCurrentException('INVALID_2FA_CODE', 'Invalid verification code.', 422);
             }
+            $this->consumeTotpCode($user, $secret, $code);
         } else {
             $storedCode = $user->getTwoFactorEmailCode();
             $codeExpiry = $user->getTwoFactorEmailCodeExpiresAt();
@@ -222,6 +453,33 @@ class TwoFactorService
         $this->em->flush();
 
         return $user;
+    }
+
+    /**
+     * Valida un código TOTP y lo marca como consumido. Un código solo se acepta una vez:
+     * su time step debe ser estrictamente mayor al último usado, de modo que un código
+     * interceptado no pueda reutilizarse durante los 30-90 s que dura su ventana.
+     *
+     * @throws MyCurrentException INVALID_2FA_CODE | 2FA_CODE_ALREADY_USED
+     */
+    private function consumeTotpCode(User $user, string $secret, string $code): void
+    {
+        $timeStep = TwoFactorHelper::matchTotpTimeStep($secret, $code);
+
+        if ($timeStep === null) {
+            throw new MyCurrentException('INVALID_2FA_CODE', 'Invalid verification code.', 422);
+        }
+
+        $lastTimeStep = $user->getTwoFactorLastTimeStep();
+        if ($lastTimeStep !== null && $timeStep <= $lastTimeStep) {
+            throw new MyCurrentException(
+                '2FA_CODE_ALREADY_USED',
+                'This code has already been used. Please wait for the next one.',
+                422
+            );
+        }
+
+        $user->setTwoFactorLastTimeStep($timeStep);
     }
 
     private function readValue(string $key, ?string $default): ?string

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -386,13 +386,18 @@ class UserService extends CommonService
 
             return $this->createUserFromPayload($objectParser->data);
         } catch (\Exception $e) {
+            // Un token malformado (sin las tres partes del JWT) no tiene payload que
+            // inspeccionar: antes se accedía a $tokenSplit[1] a ciegas y cualquier cadena
+            // sin puntos hacía fallar este catch, convirtiendo un 401 en un 500.
             $tokenSplit = explode('.', $token);
-            $dataCode = base64_decode($tokenSplit[1]);
-            $objectDecode = json_decode($dataCode, true);
-            if (is_array($objectDecode) && array_key_exists('jti', $objectDecode) && is_numeric($objectDecode['jti'])) {
-                $session = $this->em->getRepository(UserSession::class)->find($objectDecode['jti']);
-                if (!is_null($session)) {
-                    $this->closeAllSessions([$session]);
+            if (isset($tokenSplit[1])) {
+                $dataCode = base64_decode($tokenSplit[1]);
+                $objectDecode = json_decode($dataCode, true);
+                if (is_array($objectDecode) && array_key_exists('jti', $objectDecode) && is_numeric($objectDecode['jti'])) {
+                    $session = $this->em->getRepository(UserSession::class)->find($objectDecode['jti']);
+                    if (!is_null($session)) {
+                        $this->closeAllSessions([$session]);
+                    }
                 }
             }
             throw $e;


### PR DESCRIPTION
Un usuario sin 2FA al que la política obligatoria ya alcanzaba quedaba bloqueado sin salida: el login le pedía un código que no podía generar (no tenía secreto), /2fa/verify devolvía 422 siempre y /2fa/setup exigía el JWT que nunca iba a obtener. Con 2fa.deadline=2026-08-31 y 3 usuarios activos sin enrolar, el bloqueo tenía fecha.

Ahora /login devuelve requiresEnrollment y se añaden dos endpoints públicos que se autentican con el pendingToken (emitido solo tras validar usuario y contraseña):

  POST /2fa/enroll/setup    -> secreto + otpUri para el QR
  POST /2fa/enroll/confirm  -> activa el 2FA y emite la sesión

No se emite JWT hasta que el segundo factor queda activo, así que la obligatoriedad sigue siendo una garantía de la API y no de la interfaz.

Recuperación para quien pierde el dispositivo:
- Códigos de respaldo: 10 por usuario, hasheados, de un solo uso, entregados en claro una única vez y regenerables.
- Reinicio por correo (/2fa/recover/email/*): parte del pendingToken, de modo que comprometer solo la cuenta de correo no basta. No da acceso: encadena con el re-enrolamiento.
- Reset administrativo (POST /admin/2fa/reset/{userId}, ROLE_SUPER_ADMIN).

Endurecimiento del módulo:
- Secreto TOTP cifrado en reposo (AES-256-GCM, clave derivada por HKDF). Comando app:2fa:encrypt-secrets migra los existentes. Rotar APP_SECRET invalida los secretos y obliga a re-enrolar.
- Anti-replay: se persiste el time step consumido, así un código no puede reutilizarse dentro de su ventana de validez.
- Desactivar el 2FA exige la contraseña actual: un token robado ya no basta para apagar el segundo factor.
- Rate limiter two_factor_code en verificación, enrolamiento y alta.
- Las respuestas de error del módulo incluyen el código simbólico además del mensaje; sin él el cliente no podía distinguir los casos.

Además, dos arreglos ajenos al 2FA que salieron por el camino:
- Un Bearer malformado devolvía 500 en vez de 401: parser() accedía a $tokenSplit[1] sin comprobar que existiera y relanzaba una excepción que el firewall no trataba como fallo de autenticación.
- Migración que siembra 2fa.mode y 2fa.method, que hasta ahora solo nacían al guardar desde el panel de administración.


Claude-Session: https://claude.ai/code/session_01NR3av7A4mJbWQWiQeEX32x

---

## Antes de desplegar

1. **Migraciones**: dos nuevas (`Version20260720000000`, `Version20260720120000`). Añaden columnas y siembran `2fa.mode`/`2fa.method` sin pisar los valores existentes.
2. **Cifrado de secretos, paso manual**: tras desplegar, ejecutar `php bin/console app:2fa:encrypt-secrets` (admite `--dry-run`). Los secretos en claro siguen funcionando mientras tanto, así que no rompe nada, pero no quedan cifrados hasta lanzarlo.
3. **No rotar `APP_SECRET`**: la clave de cifrado de los secretos TOTP se deriva de él; cambiarlo obligaría a todos los usuarios a re-enrolar su 2FA.

## Contexto de urgencia

En producción `2fa.deadline` está en **2026-08-31** y hay **3 usuarios activos sin 2FA configurado**. Sin este cambio, ese día quedan bloqueados sin ninguna vía de recuperación.

## Verificación

- Bug reproducido antes de tocar código y confirmado resuelto después.
- e2e nuevo con 7 casos (`e2e/2fa/enrollment.spec.ts` en dashboard-cm), con verificación cruzada contra base de datos. Probada su efectividad rompiendo el fix a propósito.
- PHPStan limpio, 257 tests PHPUnit OK, 97/97 unitarios de frontend y suite e2e completa en verde.

> [!WARNING]
> Este cambio toca el camino de login de **todos** los usuarios. Conviene validarlo en staging con un usuario real antes de mergear a master.
