### PR TITLE
feat(notifications): centro de notificaciones in-app con stream SSE

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -63,6 +63,11 @@ security:
         # Recuperación (código de respaldo o reinicio por correo): mismo caso, el usuario
         # está a medias del login y solo dispone del pendingToken.
         - { path: '^/dashboard/api/2fa/recover', roles: PUBLIC_ACCESS }
+        # EventSource no puede enviar el header Authorization: este stream se autentica
+        # con un ticket de un solo uso (POST /notifications/stream-ticket, sí autenticado)
+        # consumido dentro del propio controlador, no con el Bearer del resto del dashboard.
+        # Debe ir ANTES de la regla genérica de /dashboard/api (gana la primera que matchea).
+        - { path: '^/dashboard/api/notifications/stream$', roles: PUBLIC_ACCESS }
         - { path: '^/api', roles: ROLE_API_USER }
         - { path: '^/dashboard/api', roles: ROLE_SYSTEM_USER }
         # - { path: ^/profile, roles: ROLE_USER }

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -18,6 +18,17 @@ parameters:
     jwt_aud_default: 'https://dashboard.comremit.com'
     phrase_key: '%env(JWT_PHRASE_KEY)%'
 
+    # Centro de notificaciones in-app. Configurables por entorno para poder
+    # acortarlos en staging (ver e2e) sin tocar el valor de producción.
+    notifications_stream_ticket_ttl_default: 30
+    notifications_stream_ttl_default: 270
+    notifications_stream_interval_default: 5
+    notifications_max_streams_default: 20
+    app.notifications.stream_ticket_ttl: '%env(int:default:notifications_stream_ticket_ttl_default:NOTIFICATIONS_STREAM_TICKET_TTL)%'
+    app.notifications.stream_ttl: '%env(int:default:notifications_stream_ttl_default:NOTIFICATIONS_STREAM_TTL)%'
+    app.notifications.stream_interval: '%env(int:default:notifications_stream_interval_default:NOTIFICATIONS_STREAM_INTERVAL)%'
+    app.notifications.max_streams: '%env(int:default:notifications_max_streams_default:NOTIFICATIONS_MAX_STREAMS)%'
+
 
 services:
 #    App\State\CreateBeneficiaryCardProcessor:
@@ -54,6 +65,16 @@ services:
     App\Security\SecretCipher:
         arguments:
             $appSecret: '%env(APP_SECRET)%'
+
+    App\Service\NotificationCenterService:
+        arguments:
+            $streamTicketTtl: '%app.notifications.stream_ticket_ttl%'
+            $streamTtl: '%app.notifications.stream_ttl%'
+            $maxStreams: '%app.notifications.max_streams%'
+
+    App\Controller\DashboardNotificationsController:
+        arguments:
+            $streamInterval: '%app.notifications.stream_interval%'
 
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones

--- a/docker/nginx/conf.d/default.conf
+++ b/docker/nginx/conf.d/default.conf
@@ -9,6 +9,24 @@ server {
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 
+    # Stream SSE de notificaciones: pool PHP-FPM dedicado (ver
+    # docker/php-fpm/stream.conf) para que las conexiones largas (hasta
+    # streamTtl segundos) no agoten los workers del pool [www] que sirve el
+    # resto de la API. access_log off porque la query string lleva el ticket
+    # de un solo uso. fastcgi_buffering off + gzip off para que los eventos
+    # lleguen al cliente al vuelo, no cuando nginx llene su buffer.
+    location = /dashboard/api/notifications/stream {
+        access_log off;
+        fastcgi_pass php-fpm:9001;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $realpath_root/index.php;
+        fastcgi_param SCRIPT_NAME /index.php;
+        fastcgi_param DOCUMENT_ROOT $realpath_root;
+        fastcgi_buffering off;
+        fastcgi_read_timeout 300s;
+        gzip off;
+    }
+
     location / {
         try_files $uri /index.php$is_args$args;
     }

--- a/docker/php-fpm/Dockerfile
+++ b/docker/php-fpm/Dockerfile
@@ -26,10 +26,11 @@ RUN install-php-extensions \
 
 COPY docker/php-fpm/php.ini $PHP_INI_DIR/conf.d/app.ini
 COPY docker/php-fpm/www.conf /usr/local/etc/php-fpm.d/www.conf
+COPY docker/php-fpm/stream.conf /usr/local/etc/php-fpm.d/stream.conf
 
 WORKDIR /var/www
 
-EXPOSE 9000
+EXPOSE 9000 9001
 
 CMD ["php-fpm"]
 
@@ -67,6 +68,6 @@ RUN composer dump-autoload --optimize \
 
 USER www-data
 
-EXPOSE 9000
+EXPOSE 9000 9001
 
 CMD ["php-fpm"]

--- a/docker/php-fpm/stream.conf
+++ b/docker/php-fpm/stream.conf
@@ -1,0 +1,30 @@
+; Pool dedicado al stream SSE de notificaciones (GET /notifications/stream).
+;
+; Cada conexión abierta retiene un worker de PHP-FPM hasta streamTtl segundos
+; (por defecto 270s, ver app.notifications.stream_ttl). El pool [www] tiene
+; pm.max_children=50 para el tráfico normal de la API: sin un pool aparte,
+; unas pocas decenas de pestañas con el dashboard abierto agotarían todos
+; los workers y la API entera dejaría de responder. Este pool aísla ese
+; riesgo — el stream nunca puede robarle workers al resto de endpoints.
+[stream]
+user = www-data
+group = www-data
+
+listen = 0.0.0.0:9001
+
+; ondemand: arranca sin workers y los crea bajo demanda, hasta el límite.
+; Encaja con un endpoint de tráfico intermitente y conexiones largas, a
+; diferencia del pool [www] (dynamic, siempre con spare servers listos).
+pm = ondemand
+pm.max_children = 20
+pm.process_idle_timeout = 10s
+pm.max_requests = 200
+
+; Cinturón y tirantes: si el bucle del controlador no corta a tiempo (bug,
+; deadlock de red), PHP-FPM mata el worker a los 5 min. El controlador ya
+; corta a los streamTtl segundos (270s por defecto) desde dentro.
+request_terminate_timeout = 300
+
+clear_env = no
+catch_workers_output = yes
+decorate_workers_output = no

--- a/migrations/Version20260728120000.php
+++ b/migrations/Version20260728120000.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Centro de notificaciones in-app: bandeja con audiencia (usuario, rol,
+ * cliente o global), recibos de lectura por usuario, y tickets de un solo uso
+ * para autenticar el stream SSE sin abrir sesión PHP (ver
+ * DashboardNotificationsController::stream).
+ */
+final class Version20260728120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create notification, notification_receipt and notification_stream_ticket tables';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE IF NOT EXISTS notification (
+                id             SERIAL PRIMARY KEY,
+                type           VARCHAR(60)  NOT NULL,
+                level          VARCHAR(10)  NOT NULL DEFAULT 'INFO',
+                audience       VARCHAR(10)  NOT NULL,
+                target_user_id INT          DEFAULT NULL,
+                target_role    VARCHAR(50)  DEFAULT NULL,
+                client_id      INT          DEFAULT NULL,
+                environment_id INT          DEFAULT NULL,
+                title          VARCHAR(180) NOT NULL,
+                body           TEXT         DEFAULT NULL,
+                link           VARCHAR(255) DEFAULT NULL,
+                data           JSON         DEFAULT NULL,
+                group_key      VARCHAR(160) DEFAULT NULL,
+                group_count    INT          NOT NULL DEFAULT 1,
+                created_at     TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                updated_at     TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                expires_at     TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL,
+                CONSTRAINT chk_notification_audience
+                    CHECK (audience IN ('USER', 'ROLE', 'CLIENT', 'GLOBAL')),
+                CONSTRAINT chk_notification_target CHECK (
+                    (audience = 'USER'   AND target_user_id IS NOT NULL) OR
+                    (audience = 'ROLE'   AND target_role    IS NOT NULL) OR
+                    (audience = 'CLIENT' AND client_id      IS NOT NULL) OR
+                    (audience = 'GLOBAL')
+                ),
+                CONSTRAINT fk_notification_target_user FOREIGN KEY (target_user_id)
+                    REFERENCES "user" (id) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
+                CONSTRAINT fk_notification_client FOREIGN KEY (client_id)
+                    REFERENCES client (id) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
+                CONSTRAINT fk_notification_environment FOREIGN KEY (environment_id)
+                    REFERENCES environment (id) ON DELETE SET NULL DEFERRABLE INITIALLY DEFERRED
+            )
+        SQL);
+
+        // Índices parciales por audiencia: el conteo de no leídas solo necesita
+        // tocar el subconjunto de filas de la audiencia relevante, nunca la tabla entera.
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_notif_aud_user ON notification (target_user_id, created_at DESC) WHERE audience = \'USER\'');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_notif_aud_role ON notification (target_role, created_at DESC) WHERE audience = \'ROLE\'');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_notif_aud_client ON notification (client_id, created_at DESC) WHERE audience = \'CLIENT\'');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_notif_aud_global ON notification (created_at DESC) WHERE audience = \'GLOBAL\'');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_notif_expires ON notification (expires_at) WHERE expires_at IS NOT NULL');
+        $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS uq_notif_group_key ON notification (group_key) WHERE group_key IS NOT NULL');
+
+        $this->addSql(<<<'SQL'
+            CREATE TABLE IF NOT EXISTS notification_receipt (
+                id              SERIAL PRIMARY KEY,
+                notification_id INT NOT NULL,
+                user_id         INT NOT NULL,
+                read_at         TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL,
+                dismissed_at    TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL,
+                CONSTRAINT uq_notification_receipt UNIQUE (notification_id, user_id),
+                CONSTRAINT fk_receipt_notification FOREIGN KEY (notification_id)
+                    REFERENCES notification (id) ON DELETE CASCADE,
+                CONSTRAINT fk_receipt_user FOREIGN KEY (user_id)
+                    REFERENCES "user" (id) ON DELETE CASCADE
+            )
+        SQL);
+
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_receipt_user_notification ON notification_receipt (user_id, notification_id)');
+
+        $this->addSql(<<<'SQL'
+            CREATE TABLE IF NOT EXISTS notification_stream_ticket (
+                id             SERIAL PRIMARY KEY,
+                token_hash     VARCHAR(128) NOT NULL,
+                user_id        INT NOT NULL,
+                environment_id INT DEFAULT NULL,
+                created_at     TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                expires_at     TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                used_at        TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL,
+                CONSTRAINT uq_stream_ticket_token_hash UNIQUE (token_hash),
+                CONSTRAINT fk_stream_ticket_user FOREIGN KEY (user_id)
+                    REFERENCES "user" (id) ON DELETE CASCADE,
+                CONSTRAINT fk_stream_ticket_environment FOREIGN KEY (environment_id)
+                    REFERENCES environment (id) ON DELETE SET NULL
+            )
+        SQL);
+
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_stream_ticket_expires ON notification_stream_ticket (expires_at)');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_stream_ticket_used_at ON notification_stream_ticket (used_at)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE IF EXISTS notification_stream_ticket');
+        $this->addSql('DROP TABLE IF EXISTS notification_receipt');
+        $this->addSql('DROP TABLE IF EXISTS notification');
+    }
+}

--- a/src/Command/PurgeNotificationsCommand.php
+++ b/src/Command/PurgeNotificationsCommand.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Command;
+
+use App\Service\NotificationCenterService;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:notifications-purge',
+    description: 'Purga notificaciones caducadas/fuera de retención y tickets de stream vencidos',
+)]
+class PurgeNotificationsCommand extends Command
+{
+    public function __construct(
+        private readonly NotificationCenterService $notificationCenter,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('retention-days', null, InputOption::VALUE_REQUIRED, 'Días de retención de notificaciones', 90)
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Solo contar, sin borrar');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $retentionDays = (int) $input->getOption('retention-days');
+        $dryRun = (bool) $input->getOption('dry-run');
+
+        $result = $this->notificationCenter->purge($retentionDays, $dryRun);
+
+        if ($dryRun) {
+            $io->note(sprintf(
+                'Se purgarían %d notificación(es) y %d ticket(s) de stream (retención: %d días).',
+                $result['notifications'],
+                $result['tickets'],
+                $retentionDays,
+            ));
+
+            return Command::SUCCESS;
+        }
+
+        $io->success(sprintf(
+            'Purgadas %d notificación(es) y %d ticket(s) de stream (retención: %d días).',
+            $result['notifications'],
+            $result['tickets'],
+            $retentionDays,
+        ));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Command/TestNotificationCommand.php
+++ b/src/Command/TestNotificationCommand.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\DTO\NotificationDraft;
+use App\Entity\User;
+use App\Enums\NotificationLevelEnum;
+use App\Enums\NotificationTypeEnum;
+use App\Service\NotificationCenterService;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'app:test-notification',
+    description: 'Emite una notificación in-app de prueba a un usuario, por email',
+)]
+class TestNotificationCommand extends Command
+{
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly NotificationCenterService $notificationCenter,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('email', InputArgument::REQUIRED, 'Email del usuario destinatario');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $email = (string) $input->getArgument('email');
+        $user = $this->em->getRepository(User::class)->findOneBy(['email' => $email]);
+
+        if ($user === null) {
+            $output->writeln(sprintf('<error>No existe ningún usuario con el email %s</error>', $email));
+
+            return Command::FAILURE;
+        }
+
+        $notification = $this->notificationCenter->notifyUser($user, new NotificationDraft(
+            type: NotificationTypeEnum::CUSTOM,
+            title: 'Notificación de prueba',
+            level: NotificationLevelEnum::INFO,
+            body: 'Esta es una notificación de prueba emitida por app:test-notification.',
+            link: '/dashboards/finance',
+        ));
+
+        if ($notification === null) {
+            $output->writeln('<error>No se pudo emitir la notificación (revisa los logs).</error>');
+
+            return Command::FAILURE;
+        }
+
+        $output->writeln(sprintf('<info>Notificación #%d emitida a %s</info>', $notification->getId(), $email));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Command/TrySaleAgainCommand.php
+++ b/src/Command/TrySaleAgainCommand.php
@@ -4,7 +4,14 @@ declare(strict_types=1);
 
 namespace App\Command;
 
+use App\DTO\NotificationDraft;
+use App\Entity\CommunicationSaleRecharge;
+use App\Enums\NotificationAudienceEnum;
+use App\Enums\NotificationLevelEnum;
+use App\Enums\NotificationTypeEnum;
 use App\Service\CommunicationSaleService;
+use App\Service\NotificationCenterService;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -15,8 +22,11 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 #[AsCommand(name: 'app:try_sale_again', description: 'Hello PhpStorm')]
 class TrySaleAgainCommand extends Command
 {
-    public function __construct(protected readonly CommunicationSaleService $service)
-    {
+    public function __construct(
+        protected readonly CommunicationSaleService $service,
+        private readonly EntityManagerInterface $em,
+        private readonly NotificationCenterService $notificationCenter,
+    ) {
         parent::__construct();
     }
 
@@ -33,6 +43,26 @@ class TrySaleAgainCommand extends Command
         try {
             $saleId = (int) $input->getArgument('saleId');
             $this->service->tryAgainWithTransaction($saleId);
+
+            // Que un operador/cron tenga que forzar un reintento manual ya es
+            // una señal para ROLE_ADMIN, agrupada por hora para no inundar la
+            // bandeja con un reintento por sale.
+            $recharge = $this->em->getRepository(CommunicationSaleRecharge::class)->find($saleId);
+            if ($recharge !== null) {
+                $this->notificationCenter->bumpGroup(
+                    'sale_retry:' . (new \DateTimeImmutable())->format('Y-m-d-H'),
+                    NotificationAudienceEnum::ROLE,
+                    new NotificationDraft(
+                        type: NotificationTypeEnum::SALE_RETRY_EXHAUSTED,
+                        title: 'Reintentos de venta forzados manualmente',
+                        level: NotificationLevelEnum::WARNING,
+                        link: '/apps/sales/' . $saleId,
+                        data: ['lastSaleId' => $saleId],
+                        environmentId: $recharge->getTenant()?->getEnvironment()?->getId(),
+                    ),
+                    targetRole: 'ROLE_ADMIN',
+                );
+            }
 
             $io->success('Completed try again sale');
 

--- a/src/Controller/DashboardCommunicationsDispatchController.php
+++ b/src/Controller/DashboardCommunicationsDispatchController.php
@@ -64,6 +64,15 @@ class DashboardCommunicationsDispatchController extends AbstractController
     #[Route('/communications/dispatch-config/pending-stream', name: 'dashboard_communications_dispatch_pending_stream', methods: ['GET'])]
     public function pendingStream(): StreamedResponse
     {
+        // Este endpoint mantiene la sesión del usuario abierta (autenticación
+        // por firewall con estado) durante todo el stream: sin cerrarla, el
+        // resto de peticiones del mismo usuario quedan bloqueadas detrás del
+        // lock de sesión de PHP hasta que el stream corte (hasta 270s). Cerrarla
+        // aquí no afecta a la autenticación ya resuelta para esta petición.
+        if (session_status() === \PHP_SESSION_ACTIVE) {
+            session_write_close();
+        }
+
         $response = new StreamedResponse(function () {
             set_time_limit(0);
 

--- a/src/Controller/DashboardNotificationsController.php
+++ b/src/Controller/DashboardNotificationsController.php
@@ -1,0 +1,308 @@
+<?php
+
+namespace App\Controller;
+
+use App\DTO\CreateNotificationDto;
+use App\DTO\Out\NotificationOutDto;
+use App\DTO\Out\NotificationStreamTicketOutDto;
+use App\DTO\Out\PaginatedListOutDto;
+use App\Entity\User;
+use App\Exception\MyCurrentException;
+use App\OpenApi\Attribute\DashboardEndpoint;
+use App\Service\NotificationCenterService;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[Route('/notifications')]
+class DashboardNotificationsController extends AbstractController
+{
+    public function __construct(
+        private readonly NotificationCenterService $service,
+        private readonly EntityManagerInterface $em,
+        private readonly int $streamInterval = 5,
+    ) {
+    }
+
+    #[Route('', name: 'dashboard_notifications_list', methods: ['GET'])]
+    #[DashboardEndpoint(summary: 'Listar notificaciones del usuario', tag: 'Notifications', responseDto: PaginatedListOutDto::class, itemDto: NotificationOutDto::class)]
+    public function list(Request $request): JsonResponse
+    {
+        $user = $this->getAuthUser();
+        if ($user === null) {
+            return $this->unauthorized();
+        }
+
+        $page = max(0, (int) $request->query->get('page', 0));
+        $limit = min(100, max(1, (int) $request->query->get('limit', 20)));
+        $orderBy = (string) $request->query->get('orderBy', 'createdAt DESC');
+        $onlyUnread = $request->query->get('status') === 'unread';
+        $type = $request->query->get('type');
+        $level = $request->query->get('level');
+        $environmentId = $this->resolveEnvironmentId($request);
+
+        $result = $this->service->list($user, $environmentId, $page, $limit, $onlyUnread, $type, $level, $orderBy);
+
+        return $this->json([
+            'limit' => $limit,
+            'currentPage' => $page,
+            'hasNext' => $result['hasNext'],
+            'hasPrevious' => $page > 0,
+            'unreadCount' => $this->service->unreadCount($user, $environmentId),
+            'results' => $result['items'],
+        ]);
+    }
+
+    #[Route('/unread-count', name: 'dashboard_notifications_unread_count', methods: ['GET'])]
+    #[DashboardEndpoint(summary: 'Contador de notificaciones no leídas', tag: 'Notifications')]
+    public function unreadCount(Request $request): JsonResponse
+    {
+        $user = $this->getAuthUser();
+        if ($user === null) {
+            return $this->unauthorized();
+        }
+
+        return $this->json(['unreadCount' => $this->service->unreadCount($user, $this->resolveEnvironmentId($request))]);
+    }
+
+    #[Route('/{id}/read', name: 'dashboard_notifications_read', methods: ['PATCH'], requirements: ['id' => '\d+'])]
+    #[DashboardEndpoint(summary: 'Marcar una notificación como leída', tag: 'Notifications')]
+    public function markRead(int $id): JsonResponse
+    {
+        $user = $this->getAuthUser();
+        if ($user === null) {
+            return $this->unauthorized();
+        }
+
+        try {
+            return $this->json($this->service->markRead($user, $id));
+        } catch (MyCurrentException $e) {
+            return $this->json(['error' => ['message' => $e->getMessage()]], $e->getCode());
+        }
+    }
+
+    #[Route('/{id}/unread', name: 'dashboard_notifications_unread', methods: ['PATCH'], requirements: ['id' => '\d+'])]
+    #[DashboardEndpoint(summary: 'Marcar una notificación como no leída', tag: 'Notifications')]
+    public function markUnread(int $id): JsonResponse
+    {
+        $user = $this->getAuthUser();
+        if ($user === null) {
+            return $this->unauthorized();
+        }
+
+        try {
+            return $this->json($this->service->markUnread($user, $id));
+        } catch (MyCurrentException $e) {
+            return $this->json(['error' => ['message' => $e->getMessage()]], $e->getCode());
+        }
+    }
+
+    #[Route('/read-all', name: 'dashboard_notifications_mark_all', methods: ['POST'])]
+    #[DashboardEndpoint(summary: 'Marcar todas las notificaciones como leídas', tag: 'Notifications')]
+    public function markAllRead(Request $request): JsonResponse
+    {
+        $user = $this->getAuthUser();
+        if ($user === null) {
+            return $this->unauthorized();
+        }
+
+        return $this->json($this->service->markAllRead($user, $this->resolveEnvironmentId($request)));
+    }
+
+    #[Route('/{id}', name: 'dashboard_notifications_dismiss', methods: ['DELETE'], requirements: ['id' => '\d+'])]
+    #[DashboardEndpoint(summary: 'Descartar una notificación', tag: 'Notifications')]
+    public function dismiss(int $id): JsonResponse
+    {
+        $user = $this->getAuthUser();
+        if ($user === null) {
+            return $this->unauthorized();
+        }
+
+        try {
+            return $this->json($this->service->dismiss($user, $id));
+        } catch (MyCurrentException $e) {
+            return $this->json(['error' => ['message' => $e->getMessage()]], $e->getCode());
+        }
+    }
+
+    #[Route('/stream-ticket', name: 'dashboard_notifications_stream_ticket', methods: ['POST'])]
+    #[DashboardEndpoint(summary: 'Emitir un ticket de un solo uso para abrir el stream SSE', tag: 'Notifications', responseDto: NotificationStreamTicketOutDto::class, responseStatusCode: 201)]
+    public function streamTicket(Request $request): JsonResponse
+    {
+        $user = $this->getAuthUser();
+        if ($user === null) {
+            return $this->unauthorized();
+        }
+
+        $ticket = $this->service->issueStreamTicket($user, $this->resolveEnvironmentId($request));
+
+        return $this->json($ticket, Response::HTTP_CREATED);
+    }
+
+    /**
+     * Ruta PUBLIC_ACCESS (config/packages/security.yaml): EventSource no
+     * puede enviar el header Authorization, así que este endpoint se
+     * autentica con un ticket de un solo uso, no con el Bearer del resto del
+     * dashboard. Al no procesar Authorization no se restaura sesión desde la
+     * cookie (DashboardAccessToken::supports() es false) — no hay lock de
+     * sesión PHP de por medio. El session_write_close() es cinturón y
+     * tirantes por si el firewall llegara a abrir una de todos modos.
+     */
+    #[Route('/stream', name: 'dashboard_notifications_stream', methods: ['GET'])]
+    public function streamEvents(Request $request): Response
+    {
+        if (session_status() === \PHP_SESSION_ACTIVE) {
+            session_write_close();
+        }
+
+        $rawTicket = (string) $request->query->get('ticket', '');
+        if ($rawTicket === '') {
+            return $this->json(['error' => ['message' => 'Missing stream ticket']], Response::HTTP_UNAUTHORIZED);
+        }
+
+        try {
+            $ticket = $this->service->consumeStreamTicket($rawTicket);
+        } catch (MyCurrentException $e) {
+            return $this->json(['error' => ['message' => $e->getMessage()]], $e->getCode());
+        }
+
+        if (!$this->service->hasCapacityForNewStream()) {
+            $response = $this->json(['error' => ['message' => 'Too many concurrent streams, retry later']], Response::HTTP_SERVICE_UNAVAILABLE);
+            $response->headers->set('Retry-After', '60');
+
+            return $response;
+        }
+
+        $user = $ticket->getUser();
+        if ($user === null) {
+            return $this->json(['error' => ['message' => 'Invalid stream ticket']], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $userId = $user->getId();
+        $clientId = $user->getCompany()?->getId();
+        $reachableRoles = $this->service->resolveReachableRoles($user);
+        $isAdmin = \in_array('ROLE_ADMIN', $reachableRoles, true);
+        $environmentId = $ticket->getEnvironment()?->getId();
+
+        $lastEventId = (int) ($request->headers->get('Last-Event-ID') ?? $request->query->get('lastId', 0));
+        $streamTtl = $this->service->getStreamTtl();
+        $streamInterval = max(1, $this->streamInterval);
+        $service = $this->service;
+        $em = $this->em;
+
+        $response = new StreamedResponse(function () use (
+            $service,
+            $em,
+            $userId,
+            $clientId,
+            $reachableRoles,
+            $environmentId,
+            $isAdmin,
+            $lastEventId,
+            $streamTtl,
+            $streamInterval,
+        ) {
+            set_time_limit(0);
+
+            $lastId = $lastEventId;
+            $lastUnread = -1;
+            $streamStart = new \DateTimeImmutable();
+            $deadline = time() + $streamTtl;
+
+            while (time() < $deadline && !connection_aborted()) {
+                // Limpia la identity map para forzar lectura fresca de BD, igual
+                // que DashboardCommunicationsDispatchController::pendingStream().
+                // Por eso todo lo que sigue trabaja con IDs primitivos, nunca
+                // con la entidad User capturada antes del bucle.
+                $em->clear();
+
+                $result = $service->pollForRaw($userId, $clientId, $reachableRoles, $environmentId, $lastId);
+                $lastId = $result['lastId'];
+
+                foreach ($result['items'] as $item) {
+                    echo 'id: ' . $item['id'] . "\n";
+                    echo "event: notification\n";
+                    echo 'data: ' . json_encode($item) . "\n\n";
+                }
+
+                if ($result['unreadCount'] !== $lastUnread) {
+                    $lastUnread = $result['unreadCount'];
+                    echo "event: unread\n";
+                    echo 'data: ' . json_encode(['unreadCount' => $result['unreadCount']]) . "\n\n";
+                }
+
+                if ($isAdmin) {
+                    $live = $service->countRecentRecharges($environmentId, $streamStart);
+                    echo "event: live\n";
+                    echo 'data: ' . json_encode(['recharges' => $live]) . "\n\n";
+                }
+
+                echo ": ping\n\n";
+                if (ob_get_level() > 0) {
+                    ob_flush();
+                }
+                flush();
+
+                sleep($streamInterval);
+            }
+
+            echo "event: close\ndata: {}\n\n";
+            if (ob_get_level() > 0) {
+                ob_flush();
+            }
+            flush();
+        });
+
+        $response->headers->set('Content-Type', 'text/event-stream');
+        $response->headers->set('Cache-Control', 'no-cache');
+        $response->headers->set('X-Accel-Buffering', 'no');
+        $response->headers->set('Connection', 'keep-alive');
+
+        return $response;
+    }
+
+    #[Route('', name: 'dashboard_notifications_create', methods: ['POST'])]
+    #[IsGranted('ROLE_ADMIN')]
+    #[DashboardEndpoint(summary: 'Difundir una notificación manual a un usuario, rol o cliente', tag: 'Notifications', requestDto: CreateNotificationDto::class, responseDto: NotificationOutDto::class, responseStatusCode: 201)]
+    public function create(CreateNotificationDto $dto): JsonResponse
+    {
+        $actor = $this->getAuthUser();
+        if ($actor === null) {
+            return $this->unauthorized();
+        }
+
+        try {
+            $notification = $this->service->createManual($dto, $actor);
+        } catch (MyCurrentException $e) {
+            return $this->json(['error' => ['message' => $e->getMessage()]], $e->getCode());
+        }
+
+        return $this->json($this->service->serialize($notification, false), Response::HTTP_CREATED);
+    }
+
+    private function getAuthUser(): ?User
+    {
+        $user = $this->getUser();
+
+        return $user instanceof User ? $user : null;
+    }
+
+    private function unauthorized(): JsonResponse
+    {
+        return $this->json(['error' => ['message' => 'Unauthorized']], Response::HTTP_UNAUTHORIZED);
+    }
+
+    private function resolveEnvironmentId(Request $request): ?int
+    {
+        if ($request->headers->has('X-Environment-Id')) {
+            return (int) $request->headers->get('X-Environment-Id');
+        }
+
+        return null;
+    }
+}

--- a/src/DTO/CreateNotificationDto.php
+++ b/src/DTO/CreateNotificationDto.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace App\DTO;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Difusión manual de una notificación desde el dashboard (ROLE_ADMIN). Es
+ * también el único mecanismo para sembrar notificaciones deterministas desde
+ * los e2e, ya que las demás nacen de eventos de dominio que no se pueden
+ * disparar a voluntad.
+ */
+class CreateNotificationDto implements IInput
+{
+    #[Assert\NotBlank]
+    #[Assert\Choice(choices: ['USER', 'ROLE', 'CLIENT', 'GLOBAL'])]
+    protected ?string $audience;
+
+    #[Assert\Choice(choices: ['INFO', 'SUCCESS', 'WARNING', 'ERROR', 'CRITICAL'])]
+    protected ?string $level = 'INFO';
+
+    #[Assert\Positive]
+    protected ?int $targetUserId;
+
+    #[Assert\Length(max: 50)]
+    protected ?string $targetRole;
+
+    #[Assert\Positive]
+    protected ?int $clientId;
+
+    #[Assert\Positive]
+    protected ?int $environmentId;
+
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 180)]
+    protected ?string $title;
+
+    protected ?string $body;
+
+    #[Assert\Length(max: 255)]
+    protected ?string $link;
+
+    /** @var array<string, mixed>|null */
+    protected ?array $data;
+
+    public function __construct(
+        ?string $audience = null,
+        ?string $level = 'INFO',
+        ?int $targetUserId = null,
+        ?string $targetRole = null,
+        ?int $clientId = null,
+        ?int $environmentId = null,
+        ?string $title = null,
+        ?string $body = null,
+        ?string $link = null,
+        ?array $data = null,
+    ) {
+        $this->audience = $audience;
+        $this->level = $level;
+        $this->targetUserId = $targetUserId;
+        $this->targetRole = $targetRole;
+        $this->clientId = $clientId;
+        $this->environmentId = $environmentId;
+        $this->title = $title;
+        $this->body = $body;
+        $this->link = $link;
+        $this->data = $data;
+    }
+
+    public function getAudience(): ?string
+    {
+        return $this->audience;
+    }
+
+    public function setAudience(?string $audience): void
+    {
+        $this->audience = $audience;
+    }
+
+    public function getLevel(): ?string
+    {
+        return $this->level;
+    }
+
+    public function setLevel(?string $level): void
+    {
+        $this->level = $level;
+    }
+
+    public function getTargetUserId(): ?int
+    {
+        return $this->targetUserId;
+    }
+
+    public function setTargetUserId(?int $targetUserId): void
+    {
+        $this->targetUserId = $targetUserId;
+    }
+
+    public function getTargetRole(): ?string
+    {
+        return $this->targetRole;
+    }
+
+    public function setTargetRole(?string $targetRole): void
+    {
+        $this->targetRole = $targetRole;
+    }
+
+    public function getClientId(): ?int
+    {
+        return $this->clientId;
+    }
+
+    public function setClientId(?int $clientId): void
+    {
+        $this->clientId = $clientId;
+    }
+
+    public function getEnvironmentId(): ?int
+    {
+        return $this->environmentId;
+    }
+
+    public function setEnvironmentId(?int $environmentId): void
+    {
+        $this->environmentId = $environmentId;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(?string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getBody(): ?string
+    {
+        return $this->body;
+    }
+
+    public function setBody(?string $body): void
+    {
+        $this->body = $body;
+    }
+
+    public function getLink(): ?string
+    {
+        return $this->link;
+    }
+
+    public function setLink(?string $link): void
+    {
+        $this->link = $link;
+    }
+
+    public function getData(): ?array
+    {
+        return $this->data;
+    }
+
+    public function setData(?array $data): void
+    {
+        $this->data = $data;
+    }
+}

--- a/src/DTO/NotificationDraft.php
+++ b/src/DTO/NotificationDraft.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\DTO;
+
+use App\Enums\NotificationLevelEnum;
+use App\Enums\NotificationTypeEnum;
+
+/**
+ * Value object interno para construir una notificación antes de persistirla.
+ * No implementa IInput: nunca llega directamente de una petición HTTP, lo
+ * construyen los servicios/handlers que detectan un evento de dominio (o el
+ * controlador de difusión manual, a partir de un CreateNotificationDto ya
+ * validado).
+ */
+final class NotificationDraft
+{
+    public function __construct(
+        public readonly NotificationTypeEnum $type,
+        public readonly string $title,
+        public readonly NotificationLevelEnum $level = NotificationLevelEnum::INFO,
+        public readonly ?string $body = null,
+        public readonly ?string $link = null,
+        /** @var array<string, mixed>|null */
+        public readonly ?array $data = null,
+        public readonly ?int $environmentId = null,
+        public readonly ?\DateTimeImmutable $expiresAt = null,
+    ) {
+    }
+}

--- a/src/DTO/Out/NotificationDismissOutDto.php
+++ b/src/DTO/Out/NotificationDismissOutDto.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\DTO\Out;
+
+final class NotificationDismissOutDto
+{
+    public bool $deleted = true;
+    public int $unreadCount;
+}

--- a/src/DTO/Out/NotificationMarkAllOutDto.php
+++ b/src/DTO/Out/NotificationMarkAllOutDto.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\DTO\Out;
+
+final class NotificationMarkAllOutDto
+{
+    public int $marked;
+    public int $unreadCount;
+}

--- a/src/DTO/Out/NotificationOutDto.php
+++ b/src/DTO/Out/NotificationOutDto.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\DTO\Out;
+
+final class NotificationOutDto
+{
+    public string $id;
+    public string $type;
+    public string $level;
+    public string $title;
+    public ?string $body;
+    public ?string $link;
+    public bool $useRouter = true;
+    public ?array $data;
+    public string $audience;
+    public int $groupCount;
+    public ?int $environmentId;
+    public bool $read;
+    public string $createdAt;
+    public ?string $expiresAt;
+}

--- a/src/DTO/Out/NotificationReadOutDto.php
+++ b/src/DTO/Out/NotificationReadOutDto.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\DTO\Out;
+
+final class NotificationReadOutDto
+{
+    public string $id;
+    public bool $read;
+    public int $unreadCount;
+}

--- a/src/DTO/Out/NotificationStreamTicketOutDto.php
+++ b/src/DTO/Out/NotificationStreamTicketOutDto.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\DTO\Out;
+
+final class NotificationStreamTicketOutDto
+{
+    public string $ticket;
+    public int $expiresIn;
+}

--- a/src/DTO/Out/NotificationUnreadCountOutDto.php
+++ b/src/DTO/Out/NotificationUnreadCountOutDto.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\DTO\Out;
+
+final class NotificationUnreadCountOutDto
+{
+    public int $unreadCount;
+}

--- a/src/Entity/Notification.php
+++ b/src/Entity/Notification.php
@@ -1,0 +1,268 @@
+<?php
+
+namespace App\Entity;
+
+use App\Enums\NotificationAudienceEnum;
+use App\Enums\NotificationLevelEnum;
+use App\Enums\NotificationTypeEnum;
+use App\Repository\NotificationRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: NotificationRepository::class)]
+#[ORM\HasLifecycleCallbacks]
+class Notification
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 60, enumType: NotificationTypeEnum::class)]
+    private ?NotificationTypeEnum $type = null;
+
+    #[ORM\Column(length: 10, enumType: NotificationLevelEnum::class, options: ['default' => 'INFO'])]
+    private NotificationLevelEnum $level = NotificationLevelEnum::INFO;
+
+    #[ORM\Column(length: 10, enumType: NotificationAudienceEnum::class)]
+    private ?NotificationAudienceEnum $audience = null;
+
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(name: 'target_user_id', nullable: true, onDelete: 'CASCADE')]
+    private ?User $targetUser = null;
+
+    #[ORM\Column(name: 'target_role', length: 50, nullable: true)]
+    private ?string $targetRole = null;
+
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'CASCADE')]
+    private ?Client $client = null;
+
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
+    private ?Environment $environment = null;
+
+    #[ORM\Column(length: 180)]
+    private ?string $title = null;
+
+    #[ORM\Column(type: Types::TEXT, nullable: true)]
+    private ?string $body = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $link = null;
+
+    #[ORM\Column(type: Types::JSON, nullable: true)]
+    private ?array $data = null;
+
+    #[ORM\Column(name: 'group_key', length: 160, nullable: true)]
+    private ?string $groupKey = null;
+
+    #[ORM\Column(name: 'group_count', options: ['default' => 1])]
+    private int $groupCount = 1;
+
+    #[ORM\Column(name: 'created_at')]
+    private ?\DateTimeImmutable $createdAt = null;
+
+    #[ORM\Column(name: 'updated_at')]
+    private ?\DateTimeImmutable $updatedAt = null;
+
+    #[ORM\Column(name: 'expires_at', nullable: true)]
+    private ?\DateTimeImmutable $expiresAt = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getType(): ?NotificationTypeEnum
+    {
+        return $this->type;
+    }
+
+    public function setType(NotificationTypeEnum $type): static
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    public function getLevel(): NotificationLevelEnum
+    {
+        return $this->level;
+    }
+
+    public function setLevel(NotificationLevelEnum $level): static
+    {
+        $this->level = $level;
+
+        return $this;
+    }
+
+    public function getAudience(): ?NotificationAudienceEnum
+    {
+        return $this->audience;
+    }
+
+    public function setAudience(NotificationAudienceEnum $audience): static
+    {
+        $this->audience = $audience;
+
+        return $this;
+    }
+
+    public function getTargetUser(): ?User
+    {
+        return $this->targetUser;
+    }
+
+    public function setTargetUser(?User $targetUser): static
+    {
+        $this->targetUser = $targetUser;
+
+        return $this;
+    }
+
+    public function getTargetRole(): ?string
+    {
+        return $this->targetRole;
+    }
+
+    public function setTargetRole(?string $targetRole): static
+    {
+        $this->targetRole = $targetRole;
+
+        return $this;
+    }
+
+    public function getClient(): ?Client
+    {
+        return $this->client;
+    }
+
+    public function setClient(?Client $client): static
+    {
+        $this->client = $client;
+
+        return $this;
+    }
+
+    public function getEnvironment(): ?Environment
+    {
+        return $this->environment;
+    }
+
+    public function setEnvironment(?Environment $environment): static
+    {
+        $this->environment = $environment;
+
+        return $this;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): static
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    public function getBody(): ?string
+    {
+        return $this->body;
+    }
+
+    public function setBody(?string $body): static
+    {
+        $this->body = $body;
+
+        return $this;
+    }
+
+    public function getLink(): ?string
+    {
+        return $this->link;
+    }
+
+    public function setLink(?string $link): static
+    {
+        $this->link = $link;
+
+        return $this;
+    }
+
+    public function getData(): ?array
+    {
+        return $this->data;
+    }
+
+    public function setData(?array $data): static
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+
+    public function getGroupKey(): ?string
+    {
+        return $this->groupKey;
+    }
+
+    public function setGroupKey(?string $groupKey): static
+    {
+        $this->groupKey = $groupKey;
+
+        return $this;
+    }
+
+    public function getGroupCount(): int
+    {
+        return $this->groupCount;
+    }
+
+    public function setGroupCount(int $groupCount): static
+    {
+        $this->groupCount = $groupCount;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?\DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): ?\DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    public function getExpiresAt(): ?\DateTimeImmutable
+    {
+        return $this->expiresAt;
+    }
+
+    public function setExpiresAt(?\DateTimeImmutable $expiresAt): static
+    {
+        $this->expiresAt = $expiresAt;
+
+        return $this;
+    }
+
+    #[ORM\PrePersist]
+    public function setCreatedAtNow(): void
+    {
+        $this->createdAt = new \DateTimeImmutable('now');
+        $this->updatedAt = new \DateTimeImmutable('now');
+    }
+
+    #[ORM\PreUpdate]
+    #[ORM\PreFlush]
+    public function setUpdatedAtNow(): void
+    {
+        $this->updatedAt = new \DateTimeImmutable('now');
+    }
+}

--- a/src/Entity/NotificationReceipt.php
+++ b/src/Entity/NotificationReceipt.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\NotificationReceiptRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: NotificationReceiptRepository::class)]
+#[ORM\Table(name: 'notification_receipt')]
+#[ORM\UniqueConstraint(name: 'uq_notification_receipt', columns: ['notification_id', 'user_id'])]
+class NotificationReceipt
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private ?Notification $notification = null;
+
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private ?User $user = null;
+
+    #[ORM\Column(name: 'read_at', nullable: true)]
+    private ?\DateTimeImmutable $readAt = null;
+
+    #[ORM\Column(name: 'dismissed_at', nullable: true)]
+    private ?\DateTimeImmutable $dismissedAt = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getNotification(): ?Notification
+    {
+        return $this->notification;
+    }
+
+    public function setNotification(?Notification $notification): static
+    {
+        $this->notification = $notification;
+
+        return $this;
+    }
+
+    public function getUser(): ?User
+    {
+        return $this->user;
+    }
+
+    public function setUser(?User $user): static
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+
+    public function getReadAt(): ?\DateTimeImmutable
+    {
+        return $this->readAt;
+    }
+
+    public function setReadAt(?\DateTimeImmutable $readAt): static
+    {
+        $this->readAt = $readAt;
+
+        return $this;
+    }
+
+    public function getDismissedAt(): ?\DateTimeImmutable
+    {
+        return $this->dismissedAt;
+    }
+
+    public function setDismissedAt(?\DateTimeImmutable $dismissedAt): static
+    {
+        $this->dismissedAt = $dismissedAt;
+
+        return $this;
+    }
+}

--- a/src/Entity/NotificationStreamTicket.php
+++ b/src/Entity/NotificationStreamTicket.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\NotificationStreamTicketRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: NotificationStreamTicketRepository::class)]
+#[ORM\Table(name: 'notification_stream_ticket')]
+#[ORM\HasLifecycleCallbacks]
+class NotificationStreamTicket
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    /**
+     * Hash sha256 del ticket. El valor en claro solo se devuelve una vez al
+     * cliente y nunca se persiste, para que una fuga de la base de datos no
+     * permita abrir streams ajenos.
+     */
+    #[ORM\Column(length: 128, unique: true)]
+    private ?string $tokenHash = null;
+
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private ?User $user = null;
+
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
+    private ?Environment $environment = null;
+
+    #[ORM\Column(name: 'created_at')]
+    private ?\DateTimeImmutable $createdAt = null;
+
+    #[ORM\Column(name: 'expires_at')]
+    private ?\DateTimeImmutable $expiresAt = null;
+
+    #[ORM\Column(name: 'used_at', nullable: true)]
+    private ?\DateTimeImmutable $usedAt = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getTokenHash(): ?string
+    {
+        return $this->tokenHash;
+    }
+
+    public function setTokenHash(string $tokenHash): static
+    {
+        $this->tokenHash = $tokenHash;
+
+        return $this;
+    }
+
+    public function getUser(): ?User
+    {
+        return $this->user;
+    }
+
+    public function setUser(?User $user): static
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+
+    public function getEnvironment(): ?Environment
+    {
+        return $this->environment;
+    }
+
+    public function setEnvironment(?Environment $environment): static
+    {
+        $this->environment = $environment;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?\DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getExpiresAt(): ?\DateTimeImmutable
+    {
+        return $this->expiresAt;
+    }
+
+    public function setExpiresAt(\DateTimeImmutable $expiresAt): static
+    {
+        $this->expiresAt = $expiresAt;
+
+        return $this;
+    }
+
+    public function getUsedAt(): ?\DateTimeImmutable
+    {
+        return $this->usedAt;
+    }
+
+    public function setUsedAt(?\DateTimeImmutable $usedAt): static
+    {
+        $this->usedAt = $usedAt;
+
+        return $this;
+    }
+
+    public function isExpired(): bool
+    {
+        return $this->expiresAt !== null && $this->expiresAt < new \DateTimeImmutable();
+    }
+
+    public function isUsed(): bool
+    {
+        return $this->usedAt !== null;
+    }
+
+    #[ORM\PrePersist]
+    public function setCreatedAtNow(): void
+    {
+        $this->createdAt = new \DateTimeImmutable('now');
+    }
+}

--- a/src/Enums/NotificationAudienceEnum.php
+++ b/src/Enums/NotificationAudienceEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Enums;
+
+enum NotificationAudienceEnum: string
+{
+    case USER   = 'USER';
+    case ROLE   = 'ROLE';
+    case CLIENT = 'CLIENT';
+    case GLOBAL = 'GLOBAL';
+}

--- a/src/Enums/NotificationLevelEnum.php
+++ b/src/Enums/NotificationLevelEnum.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Enums;
+
+enum NotificationLevelEnum: string
+{
+    case INFO     = 'INFO';
+    case SUCCESS  = 'SUCCESS';
+    case WARNING  = 'WARNING';
+    case ERROR    = 'ERROR';
+    case CRITICAL = 'CRITICAL';
+}

--- a/src/Enums/NotificationTypeEnum.php
+++ b/src/Enums/NotificationTypeEnum.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Enums;
+
+enum NotificationTypeEnum: string
+{
+    case BALANCE_LOW                    = 'BALANCE_LOW';
+    case BALANCE_CRITICAL                = 'BALANCE_CRITICAL';
+    case SALE_FAILED                     = 'SALE_FAILED';
+    case RECHARGE_FAILED                 = 'RECHARGE_FAILED';
+    case SALE_RETRY_EXHAUSTED            = 'SALE_RETRY_EXHAUSTED';
+    case DISPATCH_PENDING                = 'DISPATCH_PENDING';
+    case CLIENT_CREATED                  = 'CLIENT_CREATED';
+    case ACCOUNT_ACTIVATED               = 'ACCOUNT_ACTIVATED';
+    case TWO_FACTOR_MANDATORY_PENDING    = 'TWO_FACTOR_MANDATORY_PENDING';
+    case PROMOTION_CREATED               = 'PROMOTION_CREATED';
+    case CUSTOM                          = 'CUSTOM';
+}

--- a/src/MessageHandler/AccountActivationMessageHandler.php
+++ b/src/MessageHandler/AccountActivationMessageHandler.php
@@ -2,7 +2,11 @@
 
 namespace App\MessageHandler;
 
+use App\DTO\NotificationDraft;
+use App\Enums\NotificationLevelEnum;
+use App\Enums\NotificationTypeEnum;
 use App\Message\AccountActivationMessage;
+use App\Service\NotificationCenterService;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Mailer\MailerInterface;
@@ -16,6 +20,7 @@ class AccountActivationMessageHandler
     public function __construct(
         private readonly MailerInterface $mailer,
         private readonly ParameterBagInterface $parameterBag,
+        private readonly NotificationCenterService $notificationCenter,
     ) {
     }
 
@@ -30,6 +35,16 @@ class AccountActivationMessageHandler
 
         $baseUrl = $this->parameterBag->get('app.dashboard.url.' . $contractWith);
         $activationUrl = $baseUrl . '/reset-password?email=' . urlencode($message->getEmail());
+
+        // Este handler dispara la INVITACIÓN a activar, no la confirmación de
+        // que ya se activó — por eso el aviso es solo para ROLE_ADMIN (visibilidad
+        // operativa) y no al propio usuario, que todavía no puede iniciar sesión.
+        $this->notificationCenter->notifyRole('ROLE_ADMIN', new NotificationDraft(
+            type: NotificationTypeEnum::ACCOUNT_ACTIVATED,
+            title: sprintf('Invitación de activación enviada a %s', $message->getEmail()),
+            level: NotificationLevelEnum::INFO,
+            link: '/apps/clients',
+        ));
 
         $mail = (new TemplatedEmail())
             ->from(new Address($this->parameterBag->get('app.email.from'), $senderName))

--- a/src/MessageHandler/BalanceMessageHandler.php
+++ b/src/MessageHandler/BalanceMessageHandler.php
@@ -2,11 +2,15 @@
 
 namespace App\MessageHandler;
 
+use App\DTO\NotificationDraft;
 use App\Entity\Account;
 use App\Entity\User;
 use App\Enums\JobPositionAreaEnum;
+use App\Enums\NotificationLevelEnum;
+use App\Enums\NotificationTypeEnum;
 use App\Message\BalanceMessage;
 use App\Repository\JobPositionRepository;
+use App\Service\NotificationCenterService;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
@@ -25,6 +29,7 @@ class BalanceMessageHandler
         private readonly LoggerInterface        $logger,
         private readonly ParameterBagInterface  $parameterBag,
         private readonly JobPositionRepository  $jobPositionRepository,
+        private readonly NotificationCenterService $notificationCenter,
     ) {
     }
 
@@ -52,6 +57,29 @@ class BalanceMessageHandler
                     $fullName = trim($user->getFirstName() . ' ' . $user->getLastName());
                     $recipients[] = new Address($user->getEmail(), $fullName);
                 }
+            }
+
+            // Notificación in-app: independiente del correo, así que se emite
+            // aunque no haya destinatarios de email (p. ej. cliente sin
+            // usuarios de finanzas todavía).
+            $isCritical = $message->getMessageType() === 'CRITICAL';
+            $draft = new NotificationDraft(
+                type: $isCritical ? NotificationTypeEnum::BALANCE_CRITICAL : NotificationTypeEnum::BALANCE_LOW,
+                title: sprintf('Saldo %s en %s', $isCritical ? 'crítico' : 'bajo', $client->getCompanyName()),
+                level: $isCritical ? NotificationLevelEnum::CRITICAL : NotificationLevelEnum::WARNING,
+                body: sprintf('El saldo disponible es %s %s.', $message->getCurrentBalance(), $message->getCurrency()),
+                link: '/dashboards/finance',
+                data: [
+                    'accountId' => $account->getId(),
+                    'clientId' => $client->getId(),
+                    'balance' => $message->getCurrentBalance(),
+                    'currency' => $message->getCurrency(),
+                ],
+                environmentId: $account->getEnvironment()?->getId(),
+            );
+            $this->notificationCenter->notifyUsers($financeUsers, $draft);
+            if ($isCritical) {
+                $this->notificationCenter->notifyRole('ROLE_ADMIN', $draft);
             }
 
             if (empty($recipients)) {

--- a/src/MessageHandler/ClientCreatedMessageHandler.php
+++ b/src/MessageHandler/ClientCreatedMessageHandler.php
@@ -2,7 +2,11 @@
 
 namespace App\MessageHandler;
 
+use App\DTO\NotificationDraft;
+use App\Enums\NotificationLevelEnum;
+use App\Enums\NotificationTypeEnum;
 use App\Message\ClientCreatedMessage;
+use App\Service\NotificationCenterService;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Mailer\MailerInterface;
@@ -16,6 +20,7 @@ class ClientCreatedMessageHandler
     public function __construct(
         private readonly MailerInterface       $mailer,
         private readonly ParameterBagInterface $parameterBag,
+        private readonly NotificationCenterService $notificationCenter,
     ) {}
 
     /**
@@ -28,6 +33,14 @@ class ClientCreatedMessageHandler
         $senderName   = $contractWith === 'comremit'
             ? 'No Reply (Comremit Solutions SL)'
             : 'No Reply - (SendMundo SL)';
+
+        $this->notificationCenter->notifyRole('ROLE_ADMIN', new NotificationDraft(
+            type: NotificationTypeEnum::CLIENT_CREATED,
+            title: sprintf('Nuevo cliente: %s', $message->getCompanyName()),
+            level: NotificationLevelEnum::SUCCESS,
+            link: '/apps/clients',
+            data: ['companyName' => $message->getCompanyName(), 'environmentType' => $message->getEnvironmentType()],
+        ));
 
         $mail = (new TemplatedEmail())
             ->from(new Address($this->parameterBag->get('app.email.from'), $senderName))

--- a/src/MessageHandler/DispatchPendingEmailHandler.php
+++ b/src/MessageHandler/DispatchPendingEmailHandler.php
@@ -2,7 +2,12 @@
 
 namespace App\MessageHandler;
 
+use App\DTO\NotificationDraft;
+use App\Enums\NotificationAudienceEnum;
+use App\Enums\NotificationLevelEnum;
+use App\Enums\NotificationTypeEnum;
 use App\Message\DispatchPendingEmailMessage;
+use App\Service\NotificationCenterService;
 use Psr\Log\LoggerInterface;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
@@ -18,10 +23,27 @@ class DispatchPendingEmailHandler
         private readonly MailerInterface $mailer,
         private readonly ParameterBagInterface $parameterBag,
         private readonly LoggerInterface $logger,
+        private readonly NotificationCenterService $notificationCenter,
     ) {}
 
     public function __invoke(DispatchPendingEmailMessage $message): void
     {
+        // Una sola entrada por día que se va actualizando (bumpGroup), en vez
+        // de una notificación por cada despacho.
+        $this->notificationCenter->bumpGroup(
+            'dispatch_pending:' . (new \DateTimeImmutable())->format('Y-m-d'),
+            NotificationAudienceEnum::ROLE,
+            new NotificationDraft(
+                type: NotificationTypeEnum::DISPATCH_PENDING,
+                title: sprintf('%d mensaje(s) despachados al API de comunicaciones hoy', $message->getTotal()),
+                level: NotificationLevelEnum::INFO,
+                link: '/security/communications-dispatch',
+                data: ['total' => $message->getTotal(), 'triggeredBy' => $message->getTriggeredBy()],
+                expiresAt: new \DateTimeImmutable('+2 days'),
+            ),
+            targetRole: 'ROLE_ADMIN',
+        );
+
         try {
             $from = $this->parameterBag->get('app.email.from');
 

--- a/src/MessageHandler/PromotionCreatedMessageHandler.php
+++ b/src/MessageHandler/PromotionCreatedMessageHandler.php
@@ -4,8 +4,14 @@ declare(strict_types=1);
 
 namespace App\MessageHandler;
 
+use App\DTO\NotificationDraft;
+use App\Entity\Client;
 use App\Entity\CommunicationPromotions;
+use App\Enums\NotificationAudienceEnum;
+use App\Enums\NotificationLevelEnum;
+use App\Enums\NotificationTypeEnum;
 use App\Message\PromotionCreatedMessage;
+use App\Service\NotificationCenterService;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
@@ -21,6 +27,7 @@ class PromotionCreatedMessageHandler
         private readonly MailerInterface $mailer,
         private readonly ParameterBagInterface $parameterBag,
         private readonly EntityManagerInterface $em,
+        private readonly NotificationCenterService $notificationCenter,
     ) {}
 
     public function __invoke(PromotionCreatedMessage $message): void
@@ -28,6 +35,26 @@ class PromotionCreatedMessageHandler
         $promotion = $this->em->getRepository(CommunicationPromotions::class)->find($message->getPromotionId());
         if ($promotion === null) {
             return;
+        }
+
+        // Este mensaje se despacha una vez por cada usuario técnico
+        // destinatario del mismo cliente (CommunicationPromotionService::
+        // dispatchPromotionEmails); bumpGroup colapsa esas N repeticiones en
+        // una sola notificación por promoción y cliente.
+        $client = $this->em->getRepository(Client::class)->find($message->getClientId());
+        if ($client !== null) {
+            $this->notificationCenter->bumpGroup(
+                'promotion_created:' . $message->getPromotionId() . ':' . $message->getClientId(),
+                NotificationAudienceEnum::CLIENT,
+                new NotificationDraft(
+                    type: NotificationTypeEnum::PROMOTION_CREATED,
+                    title: sprintf('Nueva promoción: %s', $promotion->getName()),
+                    level: NotificationLevelEnum::SUCCESS,
+                    link: '/apps/promotions',
+                    data: ['promotionId' => $promotion->getId()],
+                ),
+                client: $client,
+            );
         }
 
         $packages = [];

--- a/src/MessageHandler/TwoFactorMandatoryNotificationHandler.php
+++ b/src/MessageHandler/TwoFactorMandatoryNotificationHandler.php
@@ -2,7 +2,13 @@
 
 namespace App\MessageHandler;
 
+use App\DTO\NotificationDraft;
+use App\Entity\User;
+use App\Enums\NotificationLevelEnum;
+use App\Enums\NotificationTypeEnum;
 use App\Message\TwoFactorMandatoryNotificationMessage;
+use App\Service\NotificationCenterService;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Mailer\MailerInterface;
@@ -16,6 +22,8 @@ class TwoFactorMandatoryNotificationHandler
     public function __construct(
         private readonly MailerInterface       $mailer,
         private readonly ParameterBagInterface $params,
+        private readonly EntityManagerInterface $em,
+        private readonly NotificationCenterService $notificationCenter,
     ) {}
 
     public function __invoke(TwoFactorMandatoryNotificationMessage $msg): void
@@ -24,6 +32,20 @@ class TwoFactorMandatoryNotificationHandler
         $senderName = $brand === 'comremit'
             ? 'No Reply (Comremit Solutions SL)'
             : 'No Reply - (SendMundo SL)';
+
+        // A diferencia de la invitación de activación, aquí el usuario ya
+        // puede iniciar sesión: persiste hasta que resuelva su 2FA (sin
+        // expiresAt), por eso conviene buscarlo por email y avisarle in-app.
+        $user = $this->em->getRepository(User::class)->findOneBy(['email' => $msg->getEmail()]);
+        if ($user !== null) {
+            $this->notificationCenter->notifyUser($user, new NotificationDraft(
+                type: NotificationTypeEnum::TWO_FACTOR_MANDATORY_PENDING,
+                title: 'Verificación en dos pasos requerida',
+                level: NotificationLevelEnum::WARNING,
+                body: sprintf('Tu organización exige 2FA. Actívalo antes del %s.', $msg->getDeadline()),
+                link: '/settings/security',
+            ));
+        }
 
         $mail = (new TemplatedEmail())
             ->from(new Address($this->params->get('app.email.from'), $senderName))

--- a/src/Repository/NotificationReceiptRepository.php
+++ b/src/Repository/NotificationReceiptRepository.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\NotificationReceipt;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<NotificationReceipt>
+ *
+ * @method NotificationReceipt|null find($id, $lockMode = null, $lockVersion = null)
+ * @method NotificationReceipt|null findOneBy(array $criteria, array $orderBy = null)
+ * @method NotificationReceipt[]    findAll()
+ * @method NotificationReceipt[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class NotificationReceiptRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, NotificationReceipt::class);
+    }
+
+    public function findOneByNotificationAndUser(int $notificationId, int $userId): ?NotificationReceipt
+    {
+        return $this->findOneBy(['notification' => $notificationId, 'user' => $userId]);
+    }
+
+    /**
+     * Recibos del usuario para un lote de notificaciones (para pintar el
+     * listado sin hacer una consulta por fila).
+     *
+     * @param int[] $notificationIds
+     *
+     * @return NotificationReceipt[]
+     */
+    public function findByNotificationsAndUser(array $notificationIds, int $userId): array
+    {
+        if ($notificationIds === []) {
+            return [];
+        }
+
+        return $this->createQueryBuilder('r')
+            ->andWhere('r.user = :userId')
+            ->andWhere('r.notification IN (:ids)')
+            ->setParameter('userId', $userId)
+            ->setParameter('ids', $notificationIds)
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * Marca como leídas, de una vez, todas las notificaciones de la lista de
+     * IDs (ya resuelta por NotificationRepository::findVisibleUnreadIds con
+     * el predicado de visibilidad DQL, para no duplicarlo en SQL). Upsert
+     * nativo para no hidratar N entidades ni pagar N round-trips.
+     *
+     * @param int[] $notificationIds
+     */
+    public function markManyRead(array $notificationIds, int $userId): int
+    {
+        if ($notificationIds === []) {
+            return 0;
+        }
+
+        $conn = $this->getEntityManager()->getConnection();
+        $marked = 0;
+
+        // En lotes: un IN (...) de miles de IDs no aporta nada y complica el plan.
+        foreach (array_chunk($notificationIds, 500) as $chunk) {
+            $placeholders = implode(',', array_fill(0, count($chunk), '?'));
+            $sql = <<<SQL
+                INSERT INTO notification_receipt (notification_id, user_id, read_at)
+                SELECT id, ?, NOW() FROM notification WHERE id IN ({$placeholders})
+                ON CONFLICT (notification_id, user_id)
+                DO UPDATE SET read_at = EXCLUDED.read_at
+                WHERE notification_receipt.read_at IS NULL
+                   OR notification_receipt.read_at < EXCLUDED.read_at
+                SQL;
+
+            $marked += $conn->executeStatement($sql, [$userId, ...$chunk]);
+        }
+
+        return $marked;
+    }
+}

--- a/src/Repository/NotificationRepository.php
+++ b/src/Repository/NotificationRepository.php
@@ -1,0 +1,299 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Notification;
+use App\Entity\NotificationReceipt;
+use App\Enums\NotificationAudienceEnum;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\DBAL\ParameterType;
+use Doctrine\ORM\QueryBuilder;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Notification>
+ *
+ * @method Notification|null find($id, $lockMode = null, $lockVersion = null)
+ * @method Notification|null findOneBy(array $criteria, array $orderBy = null)
+ * @method Notification[]    findAll()
+ * @method Notification[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class NotificationRepository extends ServiceEntityRepository
+{
+    /**
+     * Ventana dura de retención: por diseño la bandeja nunca muestra nada más
+     * antiguo que esto, independientemente de la purga programada (que puede
+     * ir por detrás). Mantiene el conteo barato incluso si la purga falla.
+     */
+    private const RETENTION_DAYS = 90;
+
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Notification::class);
+    }
+
+    /**
+     * Construye el predicado de visibilidad de notificaciones para un usuario:
+     * globales, dirigidas a él, a un rol que alcanza (jerarquía ya expandida
+     * por el llamador con RoleHierarchyInterface) o al cliente al que pertenece.
+     *
+     * Se usa tanto para el listado paginado como para el conteo de no leídas,
+     * de modo que ambos vean exactamente el mismo universo de notificaciones.
+     *
+     * Recibe IDs primitivos, no la entidad User: el stream SSE llama a este
+     * predicado en un bucle con em->clear() en cada vuelta, y una entidad
+     * capturada antes del bucle quedaría desasociada — ver
+     * NotificationCenterService::pollForRaw().
+     *
+     * @param string[] $reachableRoles
+     */
+    public function applyVisibility(
+        QueryBuilder $qb,
+        string $alias,
+        int $userId,
+        ?int $clientId,
+        array $reachableRoles,
+        ?int $environmentId,
+    ): void {
+        $orX = $qb->expr()->orX(
+            $qb->expr()->eq("{$alias}.audience", ':audGlobal'),
+            $qb->expr()->andX(
+                $qb->expr()->eq("{$alias}.audience", ':audUser'),
+                $qb->expr()->eq("{$alias}.targetUser", ':uid'),
+            ),
+        );
+        $qb->setParameter('audGlobal', NotificationAudienceEnum::GLOBAL)
+            ->setParameter('audUser', NotificationAudienceEnum::USER)
+            ->setParameter('uid', $userId);
+
+        if ($reachableRoles !== []) {
+            $orX->add($qb->expr()->andX(
+                $qb->expr()->eq("{$alias}.audience", ':audRole'),
+                $qb->expr()->in("{$alias}.targetRole", ':roles'),
+            ));
+            $qb->setParameter('audRole', NotificationAudienceEnum::ROLE)
+                ->setParameter('roles', $reachableRoles);
+        }
+
+        if ($clientId !== null) {
+            $orX->add($qb->expr()->andX(
+                $qb->expr()->eq("{$alias}.audience", ':audClient'),
+                $qb->expr()->eq("{$alias}.client", ':clientId'),
+            ));
+            $qb->setParameter('audClient', NotificationAudienceEnum::CLIENT)
+                ->setParameter('clientId', $clientId);
+        }
+
+        $qb->andWhere($orX)
+            ->andWhere("{$alias}.createdAt >= :retentionFloor")
+            ->andWhere($qb->expr()->orX(
+                "{$alias}.expiresAt IS NULL",
+                "{$alias}.expiresAt > :now",
+            ))
+            ->setParameter('retentionFloor', new \DateTimeImmutable('-' . self::RETENTION_DAYS . ' days'))
+            ->setParameter('now', new \DateTimeImmutable());
+
+        if ($environmentId !== null) {
+            $qb->andWhere($qb->expr()->orX(
+                "{$alias}.environment IS NULL",
+                "{$alias}.environment = :envId",
+            ))->setParameter('envId', $environmentId);
+        }
+
+        // Descartar es permanente y personal: una vez con dismissedAt, la
+        // notificación desaparece de este usuario para siempre, no solo del
+        // conteo de no leídas — sea GLOBAL/ROLE/CLIENT y la vean otros o no.
+        $subQb = $this->getEntityManager()->createQueryBuilder();
+        $subQb->select('1')
+            ->from(NotificationReceipt::class, 'rd')
+            ->where("rd.notification = {$alias}")
+            ->andWhere('rd.user = :dismissUid')
+            ->andWhere('rd.dismissedAt IS NOT NULL');
+
+        $qb->andWhere($qb->expr()->not($qb->expr()->exists($subQb->getDQL())))
+            ->setParameter('dismissUid', $userId);
+    }
+
+    /**
+     * @param string[] $reachableRoles
+     *
+     * @return Notification[]
+     */
+    public function findVisiblePage(
+        int $userId,
+        ?int $clientId,
+        array $reachableRoles,
+        ?int $environmentId,
+        bool $onlyUnread,
+        ?string $type,
+        ?string $level,
+        int $page,
+        int $limit,
+        string $orderField,
+        string $orderDirection,
+    ): array {
+        $qb = $this->createQueryBuilder('n');
+        $this->applyVisibility($qb, 'n', $userId, $clientId, $reachableRoles, $environmentId);
+
+        if ($type !== null) {
+            $qb->andWhere('n.type = :type')->setParameter('type', $type);
+        }
+        if ($level !== null) {
+            $qb->andWhere('n.level = :level')->setParameter('level', $level);
+        }
+        if ($onlyUnread) {
+            $this->applyUnreadPredicate($qb, 'n', $userId);
+        }
+
+        return $qb->orderBy($orderField, $orderDirection)
+            ->setFirstResult($page * $limit)
+            ->setMaxResults($limit + 1)
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * Notificaciones visibles con id > $afterId, para el polling del stream.
+     *
+     * @param string[] $reachableRoles
+     *
+     * @return Notification[]
+     */
+    public function findVisibleSince(
+        int $userId,
+        ?int $clientId,
+        array $reachableRoles,
+        ?int $environmentId,
+        int $afterId,
+    ): array {
+        $qb = $this->createQueryBuilder('n')
+            ->andWhere('n.id > :afterId')
+            ->setParameter('afterId', $afterId)
+            ->orderBy('n.id', 'ASC');
+        $this->applyVisibility($qb, 'n', $userId, $clientId, $reachableRoles, $environmentId);
+
+        return $qb->getQuery()->getResult();
+    }
+
+    /**
+     * @param string[] $reachableRoles
+     */
+    public function countUnread(int $userId, ?int $clientId, array $reachableRoles, ?int $environmentId): int
+    {
+        $qb = $this->createQueryBuilder('n')->select('COUNT(n.id)');
+        $this->applyVisibility($qb, 'n', $userId, $clientId, $reachableRoles, $environmentId);
+        $this->applyUnreadPredicate($qb, 'n', $userId);
+
+        return (int) $qb->getQuery()->getSingleScalarResult();
+    }
+
+    /**
+     * IDs de todas las notificaciones visibles y no leídas de un usuario, para
+     * que "marcar todas como leídas" pueda hacer un upsert nativo (bulk) sobre
+     * un conjunto de IDs concreto sin duplicar el predicado de visibilidad en
+     * SQL crudo — una sola implementación (DQL) decide qué es visible.
+     *
+     * @param string[] $reachableRoles
+     *
+     * @return int[]
+     */
+    public function findVisibleUnreadIds(int $userId, ?int $clientId, array $reachableRoles, ?int $environmentId): array
+    {
+        $qb = $this->createQueryBuilder('n')->select('n.id');
+        $this->applyVisibility($qb, 'n', $userId, $clientId, $reachableRoles, $environmentId);
+        $this->applyUnreadPredicate($qb, 'n', $userId);
+
+        return array_column($qb->getQuery()->getScalarResult(), 'id');
+    }
+
+    /**
+     * @param string[] $reachableRoles
+     */
+    public function findVisibleById(int $id, int $userId, ?int $clientId, array $reachableRoles): ?Notification
+    {
+        $qb = $this->createQueryBuilder('n')->andWhere('n.id = :id')->setParameter('id', $id);
+        $this->applyVisibility($qb, 'n', $userId, $clientId, $reachableRoles, null);
+
+        return $qb->getQuery()->getOneOrNullResult();
+    }
+
+    /**
+     * Cuenta lo que purgeExpired() borraría, para --dry-run.
+     */
+    public function countExpired(int $retentionDays): int
+    {
+        $retentionFloor = new \DateTimeImmutable('-' . $retentionDays . ' days');
+        $expiredFloor = new \DateTimeImmutable('-7 days');
+
+        $qb = $this->createQueryBuilder('n')->select('COUNT(n.id)');
+        $qb->andWhere($qb->expr()->orX(
+            'n.expiresAt IS NOT NULL AND n.expiresAt < :expiredFloor',
+            'n.createdAt < :retentionFloor',
+        ))
+            ->setParameter('expiredFloor', $expiredFloor)
+            ->setParameter('retentionFloor', $retentionFloor);
+
+        return (int) $qb->getQuery()->getSingleScalarResult();
+    }
+
+    /**
+     * Purga en lotes (para no tomar locks largos): caducadas hace más de una
+     * semana, o fuera de la ventana de retención. Devuelve el total borrado.
+     * Los umbrales se calculan en PHP y se pasan como timestamps, para no
+     * depender de construir un INTERVAL a partir de un parámetro ligado.
+     */
+    public function purgeExpired(int $retentionDays, int $batchSize): int
+    {
+        $conn = $this->getEntityManager()->getConnection();
+        $deleted = 0;
+
+        $retentionFloor = new \DateTimeImmutable('-' . $retentionDays . ' days');
+        $expiredFloor = new \DateTimeImmutable('-7 days');
+
+        $sql = <<<'SQL'
+            DELETE FROM notification
+            WHERE id IN (
+                SELECT id FROM notification
+                WHERE (expires_at IS NOT NULL AND expires_at < ?)
+                   OR created_at < ?
+                LIMIT ?
+            )
+            SQL;
+
+        do {
+            $affected = $conn->executeStatement($sql, [
+                $expiredFloor->format('Y-m-d H:i:s'),
+                $retentionFloor->format('Y-m-d H:i:s'),
+                $batchSize,
+            ], [
+                ParameterType::STRING,
+                ParameterType::STRING,
+                ParameterType::INTEGER,
+            ]);
+            $deleted += $affected;
+        } while ($affected > 0);
+
+        return $deleted;
+    }
+
+    /**
+     * Excluye lo ya leído. Lo descartado ya ha quedado fuera por
+     * applyVisibility(), así que aquí basta con el estado de lectura.
+     *
+     * La comparación read_at >= updated_at (no "read_at IS NOT NULL") es
+     * deliberada: un digest agrupado (bumpGroup) que vuelve a incrementarse
+     * debe reaparecer como no leído.
+     */
+    private function applyUnreadPredicate(QueryBuilder $qb, string $alias, int $userId): void
+    {
+        $subQb = $this->getEntityManager()->createQueryBuilder();
+        $subQb->select('1')
+            ->from(NotificationReceipt::class, 'r')
+            ->where("r.notification = {$alias}")
+            ->andWhere('r.user = :readUid')
+            ->andWhere("r.readAt >= {$alias}.updatedAt");
+
+        $qb->andWhere($qb->expr()->not($qb->expr()->exists($subQb->getDQL())))
+            ->setParameter('readUid', $userId);
+    }
+}

--- a/src/Repository/NotificationStreamTicketRepository.php
+++ b/src/Repository/NotificationStreamTicketRepository.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\NotificationStreamTicket;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<NotificationStreamTicket>
+ *
+ * @method NotificationStreamTicket|null find($id, $lockMode = null, $lockVersion = null)
+ * @method NotificationStreamTicket|null findOneBy(array $criteria, array $orderBy = null)
+ * @method NotificationStreamTicket[]    findAll()
+ * @method NotificationStreamTicket[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class NotificationStreamTicketRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, NotificationStreamTicket::class);
+    }
+
+    public function findByTokenHash(string $tokenHash): ?NotificationStreamTicket
+    {
+        return $this->findOneBy(['tokenHash' => $tokenHash]);
+    }
+
+    /**
+     * Streams con un ticket consumido hace poco: proxy barato de "conexión
+     * probablemente todavía abierta", usado por la guardia de concurrencia
+     * del endpoint /stream (no hay forma más barata de contar sockets SSE
+     * abiertos sin un registro explícito en PHP-FPM).
+     */
+    public function countRecentlyUsed(\DateTimeImmutable $since): int
+    {
+        return (int) $this->createQueryBuilder('t')
+            ->select('COUNT(t.id)')
+            ->andWhere('t.usedAt >= :since')
+            ->setParameter('since', $since)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    /**
+     * Cuenta lo que purgeExpired() borraría, para --dry-run.
+     */
+    public function countExpired(): int
+    {
+        return (int) $this->createQueryBuilder('t')
+            ->select('COUNT(t.id)')
+            ->andWhere('t.expiresAt < :floor')
+            ->setParameter('floor', new \DateTimeImmutable('-1 hour'))
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    /**
+     * Tickets caducados hace más de una hora: ya no sirven ni para auditar
+     * un intento de reconexión tardío.
+     */
+    public function purgeExpired(): int
+    {
+        return $this->createQueryBuilder('t')
+            ->delete()
+            ->andWhere('t.expiresAt < :floor')
+            ->setParameter('floor', new \DateTimeImmutable('-1 hour'))
+            ->getQuery()
+            ->execute();
+    }
+}

--- a/src/Schedule/Task/PurgeNotificationsTask.php
+++ b/src/Schedule/Task/PurgeNotificationsTask.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Schedule\Task;
+
+use App\Service\NotificationCenterService;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Scheduler\Attribute\AsCronTask;
+
+/**
+ * Sin esta purga, notification_receipt crece sin límite y el anti-join del
+ * conteo de no leídas se degrada (ver NotificationRepository::applyVisibility).
+ * Cada 10 minutos es más que suficiente para una tabla de este volumen.
+ */
+#[AsCronTask('*/10 * * * *')]
+class PurgeNotificationsTask
+{
+    public function __construct(
+        private readonly NotificationCenterService $notificationCenter,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public function __invoke(): void
+    {
+        $result = $this->notificationCenter->purge();
+        if ($result['notifications'] > 0 || $result['tickets'] > 0) {
+            $this->logger->info('Notifications purge', $result);
+        }
+    }
+}

--- a/src/Service/CommunicationSaleService.php
+++ b/src/Service/CommunicationSaleService.php
@@ -3,6 +3,7 @@
 namespace App\Service;
 
 use ApiPlatform\Symfony\Security\Exception\AccessDeniedException;
+use App\DTO\NotificationDraft;
 use App\DTO\ReserveRecharge;
 use App\Entity\Account;
 use App\Entity\BalanceOperation;
@@ -16,6 +17,8 @@ use App\Entity\CommunicationSalePackage;
 use App\Entity\CommunicationSaleRecharge;
 use App\Entity\Environment;
 use App\Enums\CommunicationStateEnum;
+use App\Enums\NotificationLevelEnum;
+use App\Enums\NotificationTypeEnum;
 use App\Exception\MyCurrentException;
 use App\Message\CheckSaleMessage;
 use App\Message\SalePackageMessage;
@@ -126,6 +129,7 @@ class CommunicationSaleService extends CommonService
         private readonly MessageBusInterface $messageBus,
         private readonly HistoricalSaleService $historicalSaleService,
         private readonly BalanceService $balanceService,
+        private readonly NotificationCenterService $notificationCenter,
     ) {
         parent::__construct(
             $em,
@@ -854,6 +858,22 @@ class CommunicationSaleService extends CommonService
         $sale->setTransactionStatus(['result' => ['message' => $reason]]);
         $this->em->flush();
         $this->logger->error("Sale {$sale->getId()} failed: {$reason}");
+
+        // Punto único por el que pasa toda transición a FAILED: aquí se
+        // engancha la notificación in-app, independiente del email.
+        $client = $sale->getTenant()?->getClient();
+        if ($client !== null) {
+            $isRecharge = $sale instanceof CommunicationSaleRecharge;
+            $this->notificationCenter->notifyClient($client, new NotificationDraft(
+                type: $isRecharge ? NotificationTypeEnum::RECHARGE_FAILED : NotificationTypeEnum::SALE_FAILED,
+                title: sprintf('%s fallida (#%d)', $isRecharge ? 'Recarga' : 'Venta', $sale->getId()),
+                level: NotificationLevelEnum::ERROR,
+                body: $reason,
+                link: '/apps/sales/' . $sale->getId(),
+                data: ['saleId' => $sale->getId(), 'transactionId' => $sale->getTransactionId(), 'reason' => $reason],
+                environmentId: $sale->getTenant()?->getEnvironment()?->getId(),
+            ));
+        }
     }
 
     /**

--- a/src/Service/NotificationCenterService.php
+++ b/src/Service/NotificationCenterService.php
@@ -1,0 +1,619 @@
+<?php
+
+namespace App\Service;
+
+use App\DTO\CreateNotificationDto;
+use App\DTO\NotificationDraft;
+use App\Entity\Client;
+use App\Entity\CommunicationSaleRecharge;
+use App\Entity\Environment;
+use App\Entity\Notification;
+use App\Entity\NotificationReceipt;
+use App\Entity\NotificationStreamTicket;
+use App\Entity\User;
+use App\Enums\NotificationAudienceEnum;
+use App\Enums\NotificationLevelEnum;
+use App\Enums\NotificationTypeEnum;
+use App\Exception\MyCurrentException;
+use App\Repository\NotificationReceiptRepository;
+use App\Repository\NotificationRepository;
+use App\Repository\NotificationStreamTicketRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Security\Core\Role\RoleHierarchyInterface;
+
+/**
+ * Centro de notificaciones in-app. Servicio nuevo con pocas dependencias:
+ * inyección directa, sin extender CommonService (CLAUDE.md §5).
+ *
+ * Toda emisión (notifyUser/notifyRole/notifyClient/notifyGlobal/bumpGroup)
+ * atrapa cualquier excepción y solo la registra: una notificación nunca debe
+ * hacer fallar el flujo de negocio que la origina.
+ */
+class NotificationCenterService
+{
+    private const ORDERABLE_FIELDS = [
+        'createdAt' => 'n.createdAt',
+        'level' => 'n.level',
+        'type' => 'n.type',
+    ];
+
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly NotificationRepository $notifications,
+        private readonly NotificationReceiptRepository $receipts,
+        private readonly NotificationStreamTicketRepository $streamTickets,
+        private readonly RoleHierarchyInterface $roleHierarchy,
+        private readonly LoggerInterface $logger,
+        private readonly int $streamTicketTtl = 30,
+        private readonly int $streamTtl = 270,
+        private readonly int $maxStreams = 20,
+    ) {
+    }
+
+    // -------------------------------------------------------------------
+    // Lectura
+    // -------------------------------------------------------------------
+
+    /**
+     * @return string[]
+     */
+    public function resolveReachableRoles(User $user): array
+    {
+        return $this->roleHierarchy->getReachableRoleNames($user->getRoles());
+    }
+
+    /**
+     * @return array{items: array<int, array<string, mixed>>, hasNext: bool}
+     */
+    public function list(
+        User $user,
+        ?int $environmentId,
+        int $page,
+        int $limit,
+        bool $onlyUnread,
+        ?string $type,
+        ?string $level,
+        string $orderBy,
+    ): array {
+        $roles = $this->resolveReachableRoles($user);
+        $clientId = $user->getCompany()?->getId();
+        [$field, $direction] = $this->parseOrderBy($orderBy);
+
+        $rows = $this->notifications->findVisiblePage(
+            $user->getId(),
+            $clientId,
+            $roles,
+            $environmentId,
+            $onlyUnread,
+            $type,
+            $level,
+            $page,
+            $limit,
+            $field,
+            $direction,
+        );
+
+        $hasNext = count($rows) > $limit;
+        if ($hasNext) {
+            array_pop($rows);
+        }
+
+        $readMap = $this->buildReadMap($rows, $user->getId());
+        $items = array_map(fn (Notification $n) => $this->serialize($n, $readMap[$n->getId()] ?? false), $rows);
+
+        return ['items' => $items, 'hasNext' => $hasNext];
+    }
+
+    public function unreadCount(User $user, ?int $environmentId): int
+    {
+        return $this->notifications->countUnread(
+            $user->getId(),
+            $user->getCompany()?->getId(),
+            $this->resolveReachableRoles($user),
+            $environmentId,
+        );
+    }
+
+    /**
+     * Variante del polling que solo trabaja con IDs primitivos y jamás
+     * conserva una referencia a la entidad User: el stream SSE llama a esto
+     * en un bucle que hace em->clear() en cada vuelta (ver
+     * DashboardNotificationsController::stream), y una entidad capturada
+     * antes del bucle quedaría desasociada del EntityManager.
+     *
+     * @param string[] $reachableRoles
+     *
+     * @return array{items: array<int, array<string, mixed>>, unreadCount: int, lastId: int}
+     */
+    public function pollForRaw(int $userId, ?int $clientId, array $reachableRoles, ?int $environmentId, int $lastId): array
+    {
+        $rows = $this->notifications->findVisibleSince($userId, $clientId, $reachableRoles, $environmentId, $lastId);
+        $readMap = $this->buildReadMap($rows, $userId);
+        $items = array_map(fn (Notification $n) => $this->serialize($n, $readMap[$n->getId()] ?? false), $rows);
+
+        $newLastId = $lastId;
+        foreach ($rows as $n) {
+            $newLastId = max($newLastId, (int) $n->getId());
+        }
+
+        return [
+            'items' => $items,
+            'unreadCount' => $this->notifications->countUnread($userId, $clientId, $reachableRoles, $environmentId),
+            'lastId' => $newLastId,
+        ];
+    }
+
+    // -------------------------------------------------------------------
+    // Escritura del usuario
+    // -------------------------------------------------------------------
+
+    /**
+     * @return array{id: string, read: bool, unreadCount: int}
+     */
+    public function markRead(User $user, int $id): array
+    {
+        $notification = $this->getVisibleOrFail($id, $user);
+        $receipt = $this->receipts->findOneByNotificationAndUser($id, $user->getId())
+            ?? (new NotificationReceipt())->setNotification($notification)->setUser($user);
+        $receipt->setReadAt(new \DateTimeImmutable());
+        $this->em->persist($receipt);
+        $this->em->flush();
+
+        return ['id' => (string) $id, 'read' => true, 'unreadCount' => $this->unreadCount($user, null)];
+    }
+
+    /**
+     * @return array{id: string, read: bool, unreadCount: int}
+     */
+    public function markUnread(User $user, int $id): array
+    {
+        $this->getVisibleOrFail($id, $user);
+        $receipt = $this->receipts->findOneByNotificationAndUser($id, $user->getId());
+        if ($receipt !== null) {
+            $receipt->setReadAt(null);
+            $this->em->flush();
+        }
+
+        return ['id' => (string) $id, 'read' => false, 'unreadCount' => $this->unreadCount($user, null)];
+    }
+
+    /**
+     * @return array{marked: int, unreadCount: int}
+     */
+    public function markAllRead(User $user, ?int $environmentId): array
+    {
+        $roles = $this->resolveReachableRoles($user);
+        $clientId = $user->getCompany()?->getId();
+        $ids = $this->notifications->findVisibleUnreadIds($user->getId(), $clientId, $roles, $environmentId);
+        $marked = $this->receipts->markManyRead($ids, $user->getId());
+
+        return [
+            'marked' => $marked,
+            'unreadCount' => $this->notifications->countUnread($user->getId(), $clientId, $roles, $environmentId),
+        ];
+    }
+
+    /**
+     * @return array{deleted: bool, unreadCount: int}
+     */
+    public function dismiss(User $user, int $id): array
+    {
+        $notification = $this->getVisibleOrFail($id, $user);
+        $receipt = $this->receipts->findOneByNotificationAndUser($id, $user->getId())
+            ?? (new NotificationReceipt())->setNotification($notification)->setUser($user);
+        $receipt->setDismissedAt(new \DateTimeImmutable());
+        $this->em->persist($receipt);
+        $this->em->flush();
+
+        return ['deleted' => true, 'unreadCount' => $this->unreadCount($user, null)];
+    }
+
+    private function getVisibleOrFail(int $id, User $user): Notification
+    {
+        $notification = $this->notifications->findVisibleById(
+            $id,
+            $user->getId(),
+            $user->getCompany()?->getId(),
+            $this->resolveReachableRoles($user),
+        );
+        if ($notification === null) {
+            // Mismo código para "no existe" y "existe pero no es de este usuario":
+            // no hay que filtrar existencia entre tenants.
+            throw new MyCurrentException('NOTIFICATION_NOT_FOUND', 'Notification not found', 404);
+        }
+
+        return $notification;
+    }
+
+    // -------------------------------------------------------------------
+    // Stream (SSE)
+    // -------------------------------------------------------------------
+
+    /**
+     * @return array{ticket: string, expiresIn: int}
+     */
+    public function issueStreamTicket(User $user, ?int $environmentId): array
+    {
+        $raw = bin2hex(random_bytes(32));
+
+        $ticket = new NotificationStreamTicket();
+        $ticket->setTokenHash(hash('sha256', $raw))
+            ->setUser($user)
+            ->setExpiresAt(new \DateTimeImmutable('+' . $this->streamTicketTtl . ' seconds'));
+
+        if ($environmentId !== null) {
+            $ticket->setEnvironment($this->em->getReference(Environment::class, $environmentId));
+        }
+
+        $this->em->persist($ticket);
+        $this->em->flush();
+
+        return ['ticket' => $raw, 'expiresIn' => $this->streamTicketTtl];
+    }
+
+    /**
+     * Valida, marca como usado y devuelve el ticket. Un ticket inválido,
+     * caducado o ya usado es siempre el mismo error genérico: no hay que dar
+     * pistas sobre cuál de los tres casos ocurrió.
+     */
+    public function consumeStreamTicket(string $rawTicket): NotificationStreamTicket
+    {
+        $ticket = $this->streamTickets->findByTokenHash(hash('sha256', $rawTicket));
+        if ($ticket === null || $ticket->isExpired() || $ticket->isUsed()) {
+            throw new MyCurrentException('INVALID_STREAM_TICKET', 'Invalid or expired stream ticket', 401);
+        }
+
+        $ticket->setUsedAt(new \DateTimeImmutable());
+        $this->em->flush();
+
+        return $ticket;
+    }
+
+    /**
+     * Guardia de concurrencia: por debajo de este límite de streams
+     * "probablemente abiertos" (tickets consumidos hace menos de streamTtl
+     * segundos), se admite una conexión más.
+     */
+    public function hasCapacityForNewStream(): bool
+    {
+        $since = new \DateTimeImmutable('-' . $this->streamTtl . ' seconds');
+
+        return $this->streamTickets->countRecentlyUsed($since) < $this->maxStreams;
+    }
+
+    public function getStreamTtl(): int
+    {
+        return $this->streamTtl;
+    }
+
+    /**
+     * @return array{notifications: int, tickets: int}
+     */
+    public function purge(int $retentionDays = 90, bool $dryRun = false): array
+    {
+        if ($dryRun) {
+            return [
+                'notifications' => $this->notifications->countExpired($retentionDays),
+                'tickets' => $this->streamTickets->countExpired(),
+            ];
+        }
+
+        return [
+            'notifications' => $this->notifications->purgeExpired($retentionDays, 5000),
+            'tickets' => $this->streamTickets->purgeExpired(),
+        ];
+    }
+
+    /**
+     * Contador en vivo de recargas entrantes, para el evento "live" del
+     * stream. No persiste nada: cero filas nuevas, cero impacto en el badge.
+     * Solo tiene sentido para ROLE_ADMIN (lo decide el llamador).
+     *
+     * @return array{count: int, since: string, last: array<string, mixed>|null}
+     */
+    public function countRecentRecharges(?int $environmentId, \DateTimeImmutable $since): array
+    {
+        $qb = $this->em->getRepository(CommunicationSaleRecharge::class)->createQueryBuilder('s')
+            ->leftJoin('s.tenant', 'a')
+            ->andWhere('s.createdAt > :since')
+            ->setParameter('since', $since)
+            ->orderBy('s.createdAt', 'DESC');
+
+        if ($environmentId !== null) {
+            $qb->andWhere('a.environment = :envId')->setParameter('envId', $environmentId);
+        }
+
+        /** @var CommunicationSaleRecharge[] $rows */
+        $rows = $qb->getQuery()->getResult();
+
+        if ($rows === []) {
+            return ['count' => 0, 'since' => $since->format('c'), 'last' => null];
+        }
+
+        $last = $rows[0];
+
+        return [
+            'count' => count($rows),
+            'since' => $since->format('c'),
+            'last' => [
+                'saleId' => $last->getId(),
+                'amount' => $last->getAmount(),
+                'currency' => $last->getCurrency(),
+            ],
+        ];
+    }
+
+    // -------------------------------------------------------------------
+    // Difusión manual (ROLE_ADMIN)
+    // -------------------------------------------------------------------
+
+    public function createManual(CreateNotificationDto $dto, User $actor): Notification
+    {
+        $audience = NotificationAudienceEnum::from((string) $dto->getAudience());
+        $level = NotificationLevelEnum::from($dto->getLevel() ?? 'INFO');
+        $draft = new NotificationDraft(
+            type: NotificationTypeEnum::CUSTOM,
+            title: (string) $dto->getTitle(),
+            level: $level,
+            body: $dto->getBody(),
+            link: $dto->getLink(),
+            data: $dto->getData(),
+            environmentId: $dto->getEnvironmentId(),
+        );
+
+        $notification = match ($audience) {
+            NotificationAudienceEnum::USER => $this->notifyUser($this->resolveUser($dto->getTargetUserId()), $draft),
+            NotificationAudienceEnum::ROLE => $this->notifyRole($this->resolveRole($dto->getTargetRole()), $draft),
+            NotificationAudienceEnum::CLIENT => $this->notifyClient($this->resolveClient($dto->getClientId()), $draft),
+            NotificationAudienceEnum::GLOBAL => $this->notifyGlobal($draft),
+        };
+
+        if ($notification === null) {
+            // safeEmit solo atrapa fallos inesperados de persistencia; aquí sí
+            // queremos que el admin sepa que su difusión no se guardó.
+            throw new MyCurrentException('NOTIFICATION_CREATE_FAILED', 'Could not create notification', 500);
+        }
+
+        $this->logger->info('Manual notification broadcast', [
+            'actor' => $actor->getEmail(),
+            'audience' => $audience->value,
+            'notificationId' => $notification->getId(),
+        ]);
+
+        return $notification;
+    }
+
+    private function resolveUser(?int $id): User
+    {
+        $user = $id !== null ? $this->em->getRepository(User::class)->find($id) : null;
+        if ($user === null) {
+            throw new MyCurrentException('NOTIFICATION_TARGET_NOT_FOUND', 'Target user not found', 404);
+        }
+
+        return $user;
+    }
+
+    private function resolveClient(?int $id): Client
+    {
+        $client = $id !== null ? $this->em->getRepository(Client::class)->find($id) : null;
+        if ($client === null) {
+            throw new MyCurrentException('NOTIFICATION_TARGET_NOT_FOUND', 'Target client not found', 404);
+        }
+
+        return $client;
+    }
+
+    private function resolveRole(?string $role): string
+    {
+        if ($role === null || trim($role) === '') {
+            throw new MyCurrentException('NOTIFICATION_TARGET_NOT_FOUND', 'Target role is required', 400);
+        }
+
+        return $role;
+    }
+
+    // -------------------------------------------------------------------
+    // Emisión desde eventos de dominio
+    // -------------------------------------------------------------------
+
+    public function notifyUser(User $user, NotificationDraft $draft): ?Notification
+    {
+        return $this->safeEmit(fn () => $this->persist(NotificationAudienceEnum::USER, $draft, targetUser: $user));
+    }
+
+    /**
+     * Recibe un iterable sin tipar en el PHPDoc a propósito: los repositorios
+     * que resuelven destinatarios (p. ej. getFinanceUsers() en
+     * BalanceMessageHandler) devuelven `array` sin generics, y el guard
+     * instanceof es la única garantía real de que solo se notifique a User.
+     *
+     * @param iterable<mixed> $users
+     */
+    public function notifyUsers(iterable $users, NotificationDraft $draft): void
+    {
+        foreach ($users as $user) {
+            if ($user instanceof User) {
+                $this->notifyUser($user, $draft);
+            }
+        }
+    }
+
+    public function notifyRole(string $role, NotificationDraft $draft): ?Notification
+    {
+        return $this->safeEmit(fn () => $this->persist(NotificationAudienceEnum::ROLE, $draft, targetRole: $role));
+    }
+
+    public function notifyClient(Client $client, NotificationDraft $draft): ?Notification
+    {
+        return $this->safeEmit(fn () => $this->persist(NotificationAudienceEnum::CLIENT, $draft, client: $client));
+    }
+
+    public function notifyGlobal(NotificationDraft $draft): ?Notification
+    {
+        return $this->safeEmit(fn () => $this->persist(NotificationAudienceEnum::GLOBAL, $draft));
+    }
+
+    /**
+     * Upsert nativo: una sola fila por group_key que se incrementa en lugar
+     * de crear una nueva notificación cada vez (dispatch pendiente diario,
+     * reintentos de venta agotados). updated_at avanza en cada bump, así que
+     * una notificación ya leída vuelve a contar como no leída al recibir un
+     * nuevo incremento (ver NotificationRepository::applyUnreadPredicate).
+     */
+    public function bumpGroup(
+        string $groupKey,
+        NotificationAudienceEnum $audience,
+        NotificationDraft $draft,
+        ?User $targetUser = null,
+        ?string $targetRole = null,
+        ?Client $client = null,
+    ): void {
+        $this->safeEmit(function () use ($groupKey, $audience, $draft, $targetUser, $targetRole, $client) {
+            $now = new \DateTimeImmutable();
+            $this->em->getConnection()->executeStatement(
+                <<<'SQL'
+                    INSERT INTO notification (
+                        type, level, audience, target_user_id, target_role, client_id, environment_id,
+                        title, body, link, data, group_key, group_count, created_at, updated_at, expires_at
+                    )
+                    VALUES (:type, :level, :audience, :targetUserId, :targetRole, :clientId, :environmentId,
+                            :title, :body, :link, :data, :groupKey, 1, :now, :now, :expiresAt)
+                    ON CONFLICT (group_key) WHERE group_key IS NOT NULL
+                    DO UPDATE SET
+                        group_count = notification.group_count + 1,
+                        updated_at = EXCLUDED.updated_at,
+                        title = EXCLUDED.title,
+                        body = EXCLUDED.body,
+                        data = EXCLUDED.data
+                    SQL,
+                [
+                    'type' => $draft->type->value,
+                    'level' => $draft->level->value,
+                    'audience' => $audience->value,
+                    'targetUserId' => $targetUser?->getId(),
+                    'targetRole' => $targetRole,
+                    'clientId' => $client?->getId(),
+                    'environmentId' => $draft->environmentId,
+                    'title' => $draft->title,
+                    'body' => $draft->body,
+                    'link' => $draft->link,
+                    'data' => $draft->data !== null ? json_encode($draft->data) : null,
+                    'groupKey' => $groupKey,
+                    'now' => $now->format('Y-m-d H:i:s'),
+                    'expiresAt' => $draft->expiresAt?->format('Y-m-d H:i:s'),
+                ],
+            );
+
+            return null;
+        });
+    }
+
+    private function persist(
+        NotificationAudienceEnum $audience,
+        NotificationDraft $draft,
+        ?User $targetUser = null,
+        ?string $targetRole = null,
+        ?Client $client = null,
+    ): Notification {
+        $notification = new Notification();
+        $notification->setType($draft->type)
+            ->setLevel($draft->level)
+            ->setAudience($audience)
+            ->setTargetUser($targetUser)
+            ->setTargetRole($targetRole)
+            ->setClient($client)
+            ->setTitle($draft->title)
+            ->setBody($draft->body)
+            ->setLink($draft->link)
+            ->setData($draft->data)
+            ->setExpiresAt($draft->expiresAt);
+
+        if ($draft->environmentId !== null) {
+            $notification->setEnvironment($this->em->getReference(Environment::class, $draft->environmentId));
+        }
+
+        $this->em->persist($notification);
+        $this->em->flush();
+
+        return $notification;
+    }
+
+    /**
+     * @template T
+     *
+     * @param callable(): T $emit
+     *
+     * @return T|null
+     */
+    private function safeEmit(callable $emit)
+    {
+        try {
+            return $emit();
+        } catch (\Throwable $e) {
+            $this->logger->error('Failed to emit in-app notification', ['exception' => $e]);
+
+            return null;
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Utilidades
+    // -------------------------------------------------------------------
+
+    /**
+     * @param Notification[] $notifications
+     *
+     * @return array<int, bool>
+     */
+    private function buildReadMap(array $notifications, int $userId): array
+    {
+        if ($notifications === []) {
+            return [];
+        }
+
+        $ids = array_map(fn (Notification $n) => $n->getId(), $notifications);
+        $receipts = $this->receipts->findByNotificationsAndUser($ids, $userId);
+
+        $map = [];
+        foreach ($receipts as $receipt) {
+            $notification = $receipt->getNotification();
+            if ($notification === null) {
+                continue;
+            }
+            $isRead = $receipt->getReadAt() !== null && $receipt->getReadAt() >= $notification->getUpdatedAt();
+            $map[$notification->getId()] = $isRead;
+        }
+
+        return $map;
+    }
+
+    private function parseOrderBy(string $orderBy): array
+    {
+        $parts = explode(' ', trim($orderBy));
+        $field = self::ORDERABLE_FIELDS[$parts[0]] ?? self::ORDERABLE_FIELDS['createdAt'];
+        $direction = strtoupper($parts[1] ?? 'DESC') === 'ASC' ? 'ASC' : 'DESC';
+
+        return [$field, $direction];
+    }
+
+    public function serialize(Notification $n, bool $read): array
+    {
+        return [
+            'id' => (string) $n->getId(),
+            'type' => $n->getType()?->value,
+            'level' => $n->getLevel()->value,
+            'title' => $n->getTitle(),
+            'body' => $n->getBody(),
+            'link' => $n->getLink(),
+            'useRouter' => true,
+            'data' => $n->getData(),
+            'audience' => $n->getAudience()?->value,
+            'groupCount' => $n->getGroupCount(),
+            'environmentId' => $n->getEnvironment()?->getId(),
+            'read' => $read,
+            'createdAt' => $n->getCreatedAt()?->format('c'),
+            'expiresAt' => $n->getExpiresAt()?->format('c'),
+        ];
+    }
+}

--- a/tests/MessageHandler/BalanceMessageHandlerTest.php
+++ b/tests/MessageHandler/BalanceMessageHandlerTest.php
@@ -9,6 +9,7 @@ use App\Enums\JobPositionAreaEnum;
 use App\Message\BalanceMessage;
 use App\MessageHandler\BalanceMessageHandler;
 use App\Repository\JobPositionRepository;
+use App\Service\NotificationCenterService;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -28,6 +29,7 @@ class BalanceMessageHandlerTest extends TestCase
     private LoggerInterface&MockObject $logger;
     private ParameterBagInterface&MockObject $parameterBag;
     private JobPositionRepository&MockObject $jobPositionRepository;
+    private NotificationCenterService&MockObject $notificationCenter;
     private BalanceMessageHandler $handler;
 
     protected function setUp(): void
@@ -40,6 +42,7 @@ class BalanceMessageHandlerTest extends TestCase
         $this->jobPositionRepository->method('findByArea')
             ->with(JobPositionAreaEnum::FINANCE)
             ->willReturn([]);
+        $this->notificationCenter = $this->createMock(NotificationCenterService::class);
 
         $this->handler = new BalanceMessageHandler(
             $this->em,
@@ -47,6 +50,7 @@ class BalanceMessageHandlerTest extends TestCase
             $this->logger,
             $this->parameterBag,
             $this->jobPositionRepository,
+            $this->notificationCenter,
         );
     }
 
@@ -110,6 +114,11 @@ class BalanceMessageHandlerTest extends TestCase
                 return true;
             }));
 
+        // Saldo crítico: notifica in-app a finanzas y además a ROLE_ADMIN.
+        $this->notificationCenter->expects($this->once())->method('notifyUsers');
+        $this->notificationCenter->expects($this->once())->method('notifyRole')
+            ->with('ROLE_ADMIN');
+
         $message = new BalanceMessage('CRITICAL', 5.0, 'USD', 10);
         ($this->handler)($message);
     }
@@ -142,6 +151,10 @@ class BalanceMessageHandlerTest extends TestCase
                 $this->assertStringContainsString('[RISK]', $email->getSubject());
                 return true;
             }));
+
+        // Saldo de riesgo (no crítico): notifica in-app a finanzas, pero NO a ROLE_ADMIN.
+        $this->notificationCenter->expects($this->once())->method('notifyUsers');
+        $this->notificationCenter->expects($this->never())->method('notifyRole');
 
         $message = new BalanceMessage('RISK', 200.0, 'EUR', 20);
         ($this->handler)($message);


### PR DESCRIPTION
Añade un sistema de notificaciones dirigidas a usuario, rol, cliente o global, con recibos de lectura por usuario y un stream en tiempo real autenticado por ticket de un solo uso (EventSource no puede enviar Authorization). Incluye:

- Modelo: notification, notification_receipt, notification_stream_ticket con índices parciales por audiencia para que el conteo de no leídas sea barato.
- NotificationCenterService: listado paginado, marcar leída/no leída, marcar todas, descartar (permanente por usuario), emisión por evento (notifyUser/notifyRole/notifyClient/notifyGlobal) y bumpGroup para colapsar eventos repetidos (dispatch diario, promociones, reintentos de venta) en una sola fila que se actualiza.
- DashboardNotificationsController: CRUD de la bandeja + difusión manual (ROLE_ADMIN) + GET /notifications/stream (SSE) con guardia de concurrencia y contador en vivo de recargas entrantes que nunca persiste.
- Pool PHP-FPM dedicado (stream.conf) y location de nginx para que las conexiones largas del stream no agoten los workers del tráfico normal.
- Enganches en BalanceMessageHandler, CommunicationSaleService::failSale, TrySaleAgainCommand y los handlers de cliente/activación/2FA/promoción, para que los eventos de dominio ya existentes generen notificaciones in-app además de los correos que ya enviaban.
- Comando de purga (app:notifications-purge) y tarea programada cada 10 minutos.
- Corrige de paso el lock de sesión del stream de dispatch existente (session_write_close antes de iniciar el bucle).