### PR TITLE
fix(notifications): no emitir el evento live del stream cuando no hay…

### DIFF
--- a/src/Controller/DashboardNotificationsController.php
+++ b/src/Controller/DashboardNotificationsController.php
@@ -238,8 +238,10 @@ class DashboardNotificationsController extends AbstractController
 
                 if ($isAdmin) {
                     $live = $service->countRecentRecharges($environmentId, $streamStart);
-                    echo "event: live\n";
-                    echo 'data: ' . json_encode(['recharges' => $live]) . "\n\n";
+                    if ($live['count'] > 0) {
+                        echo "event: live\n";
+                        echo 'data: ' . json_encode(['recharges' => $live]) . "\n\n";
+                    }
                 }
 
                 echo ": ping\n\n";


### PR DESCRIPTION
… recargas

El stream mandaba `event: live` con count:0 en cada ciclo para ROLE_ADMIN, haciendo que el panel mostrara "Recargas en vivo: 0" permanentemente en vez de solo cuando hay recargas entrantes reales.