### PR TITLE
Notificaciones: ROLE_ADMIN, vista sin filtro de entorno, fix migración y CI de staging

### DIFF
--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -14,65 +14,64 @@ permissions:
 jobs:
   deploy:
     name: Deploy to Staging VPS
-    runs-on: ubuntu-24.04
+    # Runner self-hosted en el propio VPS de staging: Hostinger bloquea a nivel
+    # de red las conexiones entrantes desde los runners de GitHub-hosted
+    # (rangos de IP de Azure), así que appleboy/ssh-action nunca podía
+    # conectar (i/o timeout, ni siquiera llegaba a sshd). El runner corre
+    # localmente y hace la conexión saliente hacia GitHub, que sí funciona.
+    runs-on: [self-hosted, staging]
     environment: staging
 
     steps:
-      - name: Deploy via SSH
-        uses: appleboy/ssh-action@v1
-        with:
-          host: ${{ secrets.STAGING_HOST }}
-          username: ${{ secrets.STAGING_USER }}
-          key: ${{ secrets.STAGING_SSH_KEY }}
-          port: ${{ secrets.STAGING_SSH_PORT || 22 }}
-          # El default de appleboy/ssh-action es 10m; el build en frío compila
-          # extensiones PHP core (sockets) desde fuente y lo supera. Igual que prod.
-          command_timeout: 30m
-          script: |
-            set -e
-            cd ${{ secrets.STAGING_APP_PATH || '/opt/api-transferencias' }}
+      - name: Deploy
+        run: |
+          set -e
+          cd /opt/api-transferencias
 
-            echo "=== Creating pre-deploy backup ==="
-            TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-            mkdir -p backups/staging
-            docker compose -f docker-compose.vps.yaml -f docker-compose.vps.staging.yaml \
-              --env-file .env.vps exec -T database \
-              pg_dump -U $(grep ^POSTGRES_USER .env.vps | cut -d= -f2) \
-              $(grep ^POSTGRES_DB .env.vps | cut -d= -f2) \
-              | gzip > "backups/staging/db_${TIMESTAMP}.sql.gz"
-            echo "Backup: backups/staging/db_${TIMESTAMP}.sql.gz"
-            # Retain last 7 backups
-            ls -t backups/staging/db_*.sql.gz 2>/dev/null | tail -n +8 | xargs -r rm
+          echo "=== Creating pre-deploy backup ==="
+          TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+          mkdir -p backups/staging
+          docker compose -f docker-compose.vps.yaml -f docker-compose.vps.staging.yaml \
+            --env-file .env.vps exec -T database \
+            pg_dump -U $(grep ^POSTGRES_USER .env.vps | cut -d= -f2) \
+            $(grep ^POSTGRES_DB .env.vps | cut -d= -f2) \
+            | gzip > "backups/staging/db_${TIMESTAMP}.sql.gz"
+          echo "Backup: backups/staging/db_${TIMESTAMP}.sql.gz"
+          # Retain last 7 backups
+          ls -t backups/staging/db_*.sql.gz 2>/dev/null | tail -n +8 | xargs -r rm
 
-            echo "=== Pulling latest changes ==="
-            git fetch origin develop
-            git checkout develop
-            git pull origin develop
+          echo "=== Pulling latest changes ==="
+          git fetch origin develop
+          git checkout develop
+          git pull origin develop
 
-            echo "=== Building images ==="
-            docker compose -f docker-compose.vps.yaml -f docker-compose.vps.staging.yaml \
-              --env-file .env.vps build
+          echo "=== Building images ==="
+          docker compose -f docker-compose.vps.yaml -f docker-compose.vps.staging.yaml \
+            --env-file .env.vps build
 
-            echo "=== Deploying ==="
-            docker compose -f docker-compose.vps.yaml -f docker-compose.vps.staging.yaml \
-              --env-file .env.vps up -d --remove-orphans --force-recreate
+          echo "=== Deploying ==="
+          docker compose -f docker-compose.vps.yaml -f docker-compose.vps.staging.yaml \
+            --env-file .env.vps up -d --remove-orphans --force-recreate
 
-            echo "=== Running migrations ==="
-            docker compose -f docker-compose.vps.yaml -f docker-compose.vps.staging.yaml \
-              --env-file .env.vps exec -T php-fpm php bin/console doctrine:migrations:migrate --no-interaction --allow-no-migration
+          echo "=== Running migrations ==="
+          docker compose -f docker-compose.vps.yaml -f docker-compose.vps.staging.yaml \
+            --env-file .env.vps exec -T php-fpm php bin/console doctrine:migrations:migrate --no-interaction --allow-no-migration
 
-            echo "=== Clearing cache ==="
-            docker compose -f docker-compose.vps.yaml -f docker-compose.vps.staging.yaml \
-              --env-file .env.vps exec -T php-fpm php bin/console cache:clear
+          echo "=== Clearing cache ==="
+          docker compose -f docker-compose.vps.yaml -f docker-compose.vps.staging.yaml \
+            --env-file .env.vps exec -T php-fpm php bin/console cache:clear
 
-            echo "=== Cleanup ==="
-            docker image prune -f
+          echo "=== Cleanup ==="
+          docker image prune -f
 
-            echo "=== Health check ==="
-            sleep 5
-            curl -sf http://localhost/health/ready || exit 1
+          echo "=== Health check ==="
+          sleep 5
+          # nginx no publica el puerto 80 al host: solo Traefik lo hace, y
+          # enruta por Host header. Sin el dominio real, esto pega contra
+          # Traefik sin matchear ninguna regla (404), nunca contra la app.
+          curl -sf https://staging-api.comremit.com/health/ready || exit 1
 
-            echo "=== Deploy complete ==="
+          echo "=== Deploy complete ==="
 
       - name: Notify deployment
         if: always()

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -23,6 +23,13 @@ jobs:
     environment: staging
 
     steps:
+      # /opt/api-transferencias no es un checkout git (se provisionó por rsync
+      # para no arrastrar el historial completo al VPS) y el runner self-hosted
+      # no tiene credenciales propias hacia GitHub. actions/checkout resuelve
+      # esto con el token efímero del job, sin necesitar una deploy key nueva.
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Deploy
         run: |
           set -e
@@ -40,10 +47,15 @@ jobs:
           # Retain last 7 backups
           ls -t backups/staging/db_*.sql.gz 2>/dev/null | tail -n +8 | xargs -r rm
 
-          echo "=== Pulling latest changes ==="
-          git fetch origin develop
-          git checkout develop
-          git pull origin develop
+          echo "=== Syncing latest changes ==="
+          # Sincroniza el checkout (hecho por actions/checkout en el workspace
+          # del job) hacia el directorio real de deploy, preservando lo que no
+          # viene del repo: el .env.vps con los secretos y los backups locales.
+          rsync -a --delete \
+            --exclude='.git' \
+            --exclude='.env.vps' \
+            --exclude='backups' \
+            "${{ github.workspace }}/" ./
 
           echo "=== Building images ==="
           docker compose -f docker-compose.vps.yaml -f docker-compose.vps.staging.yaml \

--- a/migrations/Version20240908131909.php
+++ b/migrations/Version20240908131909.php
@@ -27,6 +27,12 @@ final class Version20240908131909 extends AbstractMigration
         $this->addSql('ALTER TABLE client ADD currency VARCHAR(3) DEFAULT NULL');
         $this->addSql('ALTER TABLE client ADD is_alert BOOLEAN DEFAULT NULL');
         $this->addSql("INSERT INTO sys_config(id, property_name, property_value, created_at, updated_at, is_active) VALUES (2, 'client.min.balance.operation', '300', '2024-09-08 11:25:12', '2024-09-08 11:25:12', true),(3, 'client.critical.balance.operation', '100', '2024-09-08 11:25:12', '2024-09-08 11:25:12', true); ");
+
+        // Los IDs de arriba son explícitos, no vía la secuencia: en una base
+        // nueva sys_config_id_seq se queda en 1 y el próximo nextval() (ej.
+        // Version20260720000000 sembrando 2fa.*) choca con el id=2 insertado
+        // aquí. Se realinea la secuencia al mayor id realmente presente.
+        $this->addSql("SELECT setval('sys_config_id_seq', (SELECT MAX(id) FROM sys_config))");
     }
 
     public function down(Schema $schema): void


### PR DESCRIPTION
## Resumen
- Los avisos de saldo (`BalanceMessageHandler`) ahora llegan a `ROLE_ADMIN` en ambos niveles (LOW/CRITICAL), agrupados por cliente+nivel+día.
- La bandeja de notificaciones admite `?environment=all` para consultarla sin el filtro de `X-Environment-Id`.
- Fix de migración: `Version20240908131909` realinea `sys_config_id_seq` tras insertar IDs explícitos (rompía en bases de datos nuevas).
- CI: `deploy-staging.yaml` ahora usa un runner self-hosted en el VPS de staging (Hostinger bloquea SSH entrante desde runners GitHub-hosted) con `actions/checkout` + `rsync` en vez de `git pull` directo, y corrige el health check final (apunta al dominio público en vez de `localhost`, que nunca pegaba contra la app real).

## Test plan
- [x] Tests unitarios relevantes en verde (BalanceMessageHandler, PHPStan)
- [x] Suite completa vía pre-push hook (258 tests) en cada commit
- [x] Deploy real verificado en staging (`https://staging-api.comremit.com/health/ready` → 200, contenedores recreados con el código de cada commit)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>