### PR TITLE
Sync mensual prod→staging con saneo de credenciales + fix de memoria en worker-balance

### DIFF
--- a/docker-compose.vps.prod.yaml
+++ b/docker-compose.vps.prod.yaml
@@ -119,12 +119,12 @@ services:
     command: >
       sh -c "until nc -z rabbitmq 5672 2>/dev/null; do sleep 2; done &&
       php bin/console messenger:consume async_send_notification
-      --time-limit=3600 --memory-limit=128M -vv"
+      --time-limit=3600 --memory-limit=192M -vv"
     deploy:
       resources:
         limits:
           cpus: "0.5"
-          memory: 128M
+          memory: 256M
 
   worker-scheduler:
     <<: *worker-base

--- a/scripts/staging-sync-dispatch.sh
+++ b/scripts/staging-sync-dispatch.sh
@@ -24,13 +24,34 @@ case "${SSH_ORIGINAL_COMMAND:-}" in
             exit 1
         fi
 
-        ./deploy.sh staging --restore "$LATEST"
-
+        COMPOSE=(docker compose -f docker-compose.vps.yaml -f docker-compose.vps.staging.yaml --env-file .env.vps)
         PG_USER=$(grep ^POSTGRES_USER= .env.vps | cut -d= -f2)
         PG_DB=$(grep ^POSTGRES_DB= .env.vps | cut -d= -f2)
 
-        docker compose -f docker-compose.vps.yaml -f docker-compose.vps.staging.yaml \
-            --env-file .env.vps exec -T database psql -U "$PG_USER" -d "$PG_DB" -c "
+        # deploy.sh --restore hace "psql < dump" a secas, sin vaciar antes: si
+        # staging ya tiene su propio esquema (siempre lo tiene, salvo la primera
+        # vez), cientos de "already exists"/FK/PK duplicados hacen que tablas
+        # completas (account, notification, communication_sale_info...) queden
+        # vacías en silencio. Se vacia el schema primero para que sea idempotente
+        # mes a mes.
+        echo "Deteniendo app para el restore..."
+        "${COMPOSE[@]}" stop php-fpm worker nginx
+
+        echo "Vaciando schema public..."
+        "${COMPOSE[@]}" exec -T database psql -U "$PG_USER" -d "$PG_DB" -c "
+            DROP SCHEMA public CASCADE;
+            CREATE SCHEMA public;
+            GRANT ALL ON SCHEMA public TO $PG_USER;
+        "
+
+        ./deploy.sh staging --restore "$LATEST"
+
+        echo "Reiniciando app y aplicando migraciones pendientes de develop..."
+        "${COMPOSE[@]}" start php-fpm worker nginx
+        "${COMPOSE[@]}" exec -T php-fpm php bin/console doctrine:migrations:migrate --no-interaction --allow-no-migration
+
+        echo "Saneando environment (PROD -> TEST, credenciales anuladas)..."
+        "${COMPOSE[@]}" exec -T database psql -U "$PG_USER" -d "$PG_DB" -c "
                 UPDATE environment
                 SET type = 'TEST',
                     client_secret = 'DISABLED_BY_STAGING_SYNC',
@@ -38,6 +59,8 @@ case "${SSH_ORIGINAL_COMMAND:-}" in
                     base_path = 'https://staging-sync-disabled.invalid'
                 WHERE type = 'PROD';
             "
+
+        "${COMPOSE[@]}" exec -T php-fpm php bin/console cache:clear
 
         rm -f "$LATEST"
         echo "RESTORE_AND_SANITIZE_OK"

--- a/scripts/staging-sync-dispatch.sh
+++ b/scripts/staging-sync-dispatch.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Forced command para la clave SSH "prod-to-staging-sync" (ver authorized_keys
+# de deploy@staging): esa clave vive en el host de prod para el sync mensual y
+# NUNCA debe poder ejecutar un comando arbitrario. Solo permite dos cosas:
+#   1. Recibir el dump vía rsync hacia backups/incoming/
+#   2. Disparar RESTORE_AND_SANITIZE, que restaura el dump más reciente y
+#      neutraliza los environment que eran PROD (type, client_secret,
+#      client_id, base_path) para que staging no pueda golpear APIs reales.
+
+cd /opt/api-transferencias
+
+case "${SSH_ORIGINAL_COMMAND:-}" in
+    rsync\ --server*)
+        exec $SSH_ORIGINAL_COMMAND
+        ;;
+    RESTORE_AND_SANITIZE)
+        # || true: con set -e + pipefail, el glob sin coincidencias hace que
+        # "ls" falle y aborte el script ANTES de llegar al mensaje de abajo.
+        LATEST=$(ls -t backups/incoming/*.sql.gz 2>/dev/null | head -1) || true
+        if [ -z "$LATEST" ]; then
+            echo "No hay ningun dump en backups/incoming/" >&2
+            exit 1
+        fi
+
+        ./deploy.sh staging --restore "$LATEST"
+
+        PG_USER=$(grep ^POSTGRES_USER= .env.vps | cut -d= -f2)
+        PG_DB=$(grep ^POSTGRES_DB= .env.vps | cut -d= -f2)
+
+        docker compose -f docker-compose.vps.yaml -f docker-compose.vps.staging.yaml \
+            --env-file .env.vps exec -T database psql -U "$PG_USER" -d "$PG_DB" -c "
+                UPDATE environment
+                SET type = 'TEST',
+                    client_secret = 'DISABLED_BY_STAGING_SYNC',
+                    client_id = 'DISABLED_BY_STAGING_SYNC',
+                    base_path = 'https://staging-sync-disabled.invalid'
+                WHERE type = 'PROD';
+            "
+
+        rm -f "$LATEST"
+        echo "RESTORE_AND_SANITIZE_OK"
+        ;;
+    *)
+        echo "Comando no permitido para esta clave (solo rsync o RESTORE_AND_SANITIZE)." >&2
+        exit 1
+        ;;
+esac

--- a/scripts/sync-prod-to-staging.sh
+++ b/scripts/sync-prod-to-staging.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ===========================================
+# Sincroniza un backup de prod hacia staging, una vez al mes.
+# Corre EN EL HOST DE PROD (via cron, ver crontab de deploy@).
+# ===========================================
+#
+# 1. Genera un backup fresco de la BD de prod (reutiliza deploy.sh --backup).
+# 2. Lo transfiere a staging por rsync, usando una clave SSH dedicada
+#    (prod-to-staging-sync) restringida en staging a un forced command
+#    (scripts/staging-sync-dispatch.sh): solo puede recibir el rsync o
+#    disparar RESTORE_AND_SANITIZE, nunca ejecutar un comando arbitrario.
+# 3. RESTORE_AND_SANITIZE en staging restaura el dump y neutraliza los
+#    environment que eran PROD (type, client_secret, client_id, base_path):
+#    sin esto, staging con datos reales podria terminar llamando a las APIs
+#    reales de pago/comunicaciones con las credenciales reales.
+
+PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$PROJECT_DIR"
+
+STAGING_HOST="${STAGING_SYNC_HOST:-69.62.70.58}"
+STAGING_USER="${STAGING_SYNC_USER:-deploy}"
+STAGING_KEY="${STAGING_SYNC_KEY:-$HOME/.ssh/prod_to_staging_sync_ed25519}"
+SSH_OPTS=(-o BatchMode=yes -o IdentitiesOnly=yes -o ConnectTimeout=30 -i "$STAGING_KEY")
+
+log()  { echo "[sync-prod-to-staging] $1"; }
+error(){ echo "[sync-prod-to-staging][ERROR] $1" >&2; exit 1; }
+
+log "Generando backup de prod..."
+./deploy.sh prod --backup
+
+DUMP_FILE=$(ls -t backups/prod/db_*.sql.gz 2>/dev/null | head -1)
+[ -z "$DUMP_FILE" ] && error "No se encontro ningun dump recien creado en backups/prod/"
+log "Dump a sincronizar: $DUMP_FILE"
+
+log "Transfiriendo a staging ($STAGING_HOST)..."
+rsync -az -e "ssh ${SSH_OPTS[*]}" \
+  "$DUMP_FILE" "$STAGING_USER@$STAGING_HOST:backups/incoming/$(basename "$DUMP_FILE")"
+
+log "Disparando restore + saneo de environment en staging..."
+ssh "${SSH_OPTS[@]}" "$STAGING_USER@$STAGING_HOST" RESTORE_AND_SANITIZE
+
+log "Sincronizacion completa."


### PR DESCRIPTION
## Resumen
- Tarea programada mensual (cron en el host de prod, día 2) que respalda la BD de prod, la restaura en staging y neutraliza las credenciales/endpoints de los `environment` que eran PROD (`type`, `client_secret`, `client_id`, `base_path`), para que staging con datos reales no pueda golpear las APIs reales de pago/comunicaciones.
- Fix: `deploy.sh --restore` no vaciaba el schema destino antes de restaurar, dejando tablas completas en 0 filas sin que el script fallara. Ahora el sync hace `DROP SCHEMA public CASCADE` antes de restaurar, idempotente mes a mes.
- Fix: `worker-balance` en prod tenía el límite del contenedor (128M) igual al `--memory-limit` de Symfony Messenger, sin margen para que el worker se recicle solo antes de que el OOM-killer del contenedor lo mate a mitad de un mensaje. Investigado tras una notificación de saldo crítico cuyo email nunca salió. Sube a 256M/192M.

## Test plan
- [x] PHPStan + suite completa (258 tests) en verde en cada commit
- [x] Sync prod→staging verificado con una corrida real completa (conteos de filas consistentes con prod, saneo de `environment` aplicado correctamente)
- [x] `docker-compose.vps.prod.yaml` validado como YAML válido

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>