### PR TITLE
feat(csq): añade terminal al esquema de credenciales

### DIFF
--- a/src/Provider/Csq/CsqCommunicationProvider.php
+++ b/src/Provider/Csq/CsqCommunicationProvider.php
@@ -50,6 +50,7 @@ final class CsqCommunicationProvider implements CommunicationProviderInterface
             new ProviderConfigField('base_url', 'URL base', required: true, secret: false),
             new ProviderConfigField('username', 'Usuario (U)', required: true, secret: true),
             new ProviderConfigField('password', 'Password', required: true, secret: true),
+            new ProviderConfigField('terminal', 'Terminal ID', required: true, secret: false),
         ];
     }
 

--- a/src/Provider/Csq/CsqHttpClient.php
+++ b/src/Provider/Csq/CsqHttpClient.php
@@ -16,20 +16,23 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
  * Cliente HTTP de bajo nivel para la API "eVSB" de CSQ
- * (https://csq-docs.apidog.io). A fecha de esta integración, la única
- * especificación pública disponible cubre el esquema de autenticación y un
- * endpoint de health-check (`/ping/{echo}`) — los métodos de negocio reales
- * (recarga, venta de paquetes, saldo, catálogo) se entregan por contrato/NDA
- * y todavía no están documentados aquí. Ver CsqCommunicationProvider — hoy
- * expone `getCapabilities(): []` a propósito, sin implementar ninguna
- * interfaz de negocio (RechargeProviderInterface, etc.) hasta tener esa
- * especificación.
+ * (https://csq-docs.apidog.io — el índice completo con los métodos de
+ * negocio, antes no enlazado desde las páginas iniciales, está en
+ * `https://csq-docs.apidog.io/llms.txt`). Solo `ping()` está implementado
+ * aquí; los métodos de negocio reales (recarga, venta de paquetes, saldo,
+ * catálogo) ya están documentados públicamente pero pendientes de
+ * implementar. Ver CsqCommunicationProvider — hoy expone
+ * `getCapabilities(): []` a propósito, sin implementar ninguna interfaz de
+ * negocio (RechargeProviderInterface, etc.) hasta que se construyan.
  *
  * Credenciales via ProviderCredentialsResolver, mismo esquema genérico
  * `provider.csq.{type}.{campo}` que ETECSA/DTOne, pero con los nombres
  * reales de CSQ (ver CsqCommunicationProvider::getConfigSchema()):
  * `username` = usuario "U" asignado por CSQ, `password` = usado para
- * calcular la firma SH.
+ * calcular la firma SH, `terminal` = terminalId asignado por CSQ — no es un
+ * header, es parámetro de path en los métodos de negocio (p.ej.
+ * `/pre-paid/recharge/products/{terminal}/{operatorId}/{account}`); `ping()`
+ * no lo necesita, pero ya se resuelve junto al resto de credenciales.
  */
 class CsqHttpClient
 {

--- a/tests/Provider/Csq/CsqCommunicationProviderTest.php
+++ b/tests/Provider/Csq/CsqCommunicationProviderTest.php
@@ -33,6 +33,24 @@ class CsqCommunicationProviderTest extends TestCase
         $this->assertSame([], $this->provider->getCapabilities());
     }
 
+    public function testGetConfigSchemaIncludesTerminal(): void
+    {
+        $keys = array_map(static fn ($field) => $field->key, $this->provider->getConfigSchema());
+
+        $this->assertContains('terminal', $keys);
+    }
+
+    public function testTerminalIsRequiredAndNotSecret(): void
+    {
+        $terminal = array_values(array_filter(
+            $this->provider->getConfigSchema(),
+            static fn ($field) => $field->key === 'terminal',
+        ))[0];
+
+        $this->assertTrue($terminal->required);
+        $this->assertFalse($terminal->secret);
+    }
+
     public function testPingDelegatesToHttpClient(): void
     {
         $context = new ProviderContext(provider: CommunicationProviderEnum::CSQ, environmentType: 'TEST');


### PR DESCRIPTION
## Resumen

Follow-up pequeño de #85 (ya mergeado). Al probar la integración de CSQ contra su sandbox real, se confirmó que los endpoints de negocio (`Get Products`, `Get Parameters`, etc.) requieren un `terminalId` como parámetro de path — dato obligatorio que faltaba en `CsqCommunicationProvider::getConfigSchema()`.

- Se añade `terminal` con el mismo patrón que `base_url` (`required: true`, `secret: false`), resuelto vía `ProviderCredentialsResolver` como `provider.csq.{type}.terminal` — sin tocar ningún otro mecanismo (fluye automático a la pantalla de "Configuración de proveedores" del dashboard, que renderiza el schema dinámicamente).
- Se actualiza el docblock de `CsqHttpClient`: la doc pública de CSQ sí cubre los métodos de negocio (antes se creía solo bajo NDA), solo no estaba enlazada desde las páginas iniciales de `csq-docs.apidog.io`.
- `ping()` no necesita `terminal`, pero ya se resuelve junto al resto de credenciales sin problema.

## Test plan

- [x] `vendor/bin/phpstan analyse` — sin errores
- [x] `php bin/phpunit --no-coverage` — 536/536 tests en verde (2 nuevos cubriendo el campo `terminal`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
