### PR TITLE
docs(deploy): documenta que el deploy a prod ya reinicia todos los workers con build nuevo

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -56,6 +56,13 @@ jobs:
               --env-file .env.vps run --rm -T php-fpm php bin/console doctrine:migrations:migrate --no-interaction --allow-no-migration
 
             echo "=== Deploying ==="
+            # Sin lista de servicios: aplica a TODOS los definidos en la
+            # config combinada, incluidos los 6 worker-* de
+            # docker-compose.vps.prod.yaml. --force-recreate garantiza que
+            # cada worker se reinicie con la imagen recién construida en el
+            # paso anterior, aunque su definición de compose no haya
+            # cambiado. Si algún día se scopea este comando a servicios
+            # específicos, hay que seguir incluyendo todos los worker-*.
             docker compose -f docker-compose.vps.yaml -f docker-compose.vps.prod.yaml \
               --env-file .env.vps up -d --remove-orphans --force-recreate
 


### PR DESCRIPTION
## Resumen

Verificación pedida: ¿el deploy a prod garantiza que todos los workers se reinicien con la imagen recién construida? Revisé `deploy-prod.yaml` y **ya lo hace**, solo no estaba explícito:

- `docker compose ... build` reconstruye las imágenes de los 6 `worker-*` de `docker-compose.vps.prod.yaml` (todos comparten build context vía el anchor `&worker-base`, apuntando a `docker/php-fpm/Dockerfile` target `app`, que hace `COPY . .` — el caché de Docker se invalida correctamente con cada cambio de código).
- `docker compose ... up -d --remove-orphans --force-recreate` **no especifica servicios**, así que aplica a todos los definidos en la config combinada (php-fpm, nginx, y los 6 workers), forzándolos a recrearse con la imagen recién construida.

Solo cambio de comentario, sin tocar el comportamiento — para que quede documentado y nadie lo rompa sin querer si en el futuro alguien scopea ese `up` a servicios específicos.

## Test plan

- [x] Solo comentario YAML, sin lógica que probar. `PHPStan`/lint pasan (no tocan código PHP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
