### PR TITLE
fix(deploy): limita --force-recreate a los servicios de aplicación

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -56,15 +56,20 @@ jobs:
               --env-file .env.vps run --rm -T php-fpm php bin/console doctrine:migrations:migrate --no-interaction --allow-no-migration
 
             echo "=== Deploying ==="
-            # Sin lista de servicios: aplica a TODOS los definidos en la
-            # config combinada, incluidos los 6 worker-* de
-            # docker-compose.vps.prod.yaml. --force-recreate garantiza que
-            # cada worker se reinicie con la imagen recién construida en el
-            # paso anterior, aunque su definición de compose no haya
-            # cambiado. Si algún día se scopea este comando a servicios
-            # específicos, hay que seguir incluyendo todos los worker-*.
+            # Limitado a los servicios que corren la imagen recién construida
+            # (php-fpm, nginx y los 6 worker-*) — NO a database/rabbitmq/traefik,
+            # que no cambian de imagen en cada deploy. --force-recreate en el
+            # comando sin acotar los recreaba a todos, matando las conexiones
+            # activas a Postgres (incl. streams SSE de larga duración como
+            # /dashboard/api/notifications/stream) en cada deploy sin necesidad
+            # — visto en prod el 2026-08-03 (ConnectionLost a mitad de deploy).
+            # --remove-orphans se mantiene: solo afecta a contenedores de
+            # servicios que ya no existen en la config, no a los excluidos aquí.
+            # Si se añade un worker-* nuevo, hay que incluirlo en esta lista.
             docker compose -f docker-compose.vps.yaml -f docker-compose.vps.prod.yaml \
-              --env-file .env.vps up -d --remove-orphans --force-recreate
+              --env-file .env.vps up -d --remove-orphans --force-recreate \
+              php-fpm nginx worker-notifications worker-clients worker-packages \
+              worker-check-status worker-balance worker-scheduler
 
             echo "=== Clearing cache ==="
             docker compose -f docker-compose.vps.yaml -f docker-compose.vps.prod.yaml \


### PR DESCRIPTION
## Resumen

Encontrado revisando un correo de alerta de prod: el deploy de hoy (PR #88, merge a las 20:26 UTC) disparó un `Doctrine\DBAL\Exception\ConnectionLost` (`FATAL: terminating connection due to administrator command`) a las 20:32:17 UTC, en pleno stream SSE de `/dashboard/api/notifications/stream`.

Causa: el paso final del deploy hacía `docker compose up -d --remove-orphans --force-recreate` **sin lista de servicios**, así que recreaba *todos* los definidos en la config combinada — incluidos `database` y `rabbitmq`, que no cambian de imagen en cada deploy. Recrear el contenedor de Postgres mata cualquier conexión activa, incluidas las de larga duración como el stream de notificaciones.

Este PR acota el `--force-recreate` a los servicios que sí corren la imagen recién construida: `php-fpm`, `nginx` y los 6 `worker-*`. `database`/`rabbitmq` ya quedan levantados por el paso de migraciones anterior (`up -d --wait database rabbitmq`) y no se tocan aquí; `traefik` tampoco (usa `traefik:latest`, sin build propio — recrearlo cortaría el proxy para todo el tráfico sin necesidad).

`--remove-orphans` se mantiene: solo afecta a contenedores de servicios que ya no existen en la config combinada, no a los excluidos explícitamente de esta lista.

## Test plan

- [x] YAML validado con `python3 -c "import yaml; yaml.safe_load(...)"`.
- [x] Solo cambia el workflow de deploy, sin tocar código PHP — PHPStan/lint no aplican pero pasan igual (el hook pre-commit los corre siempre).
- [ ] Verificar en el próximo deploy real a prod que `database`/`rabbitmq`/`traefik` no se reinician y que los 8 servicios de aplicación sí.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
