### PR TITLE
feat(providers): ping periódico y habilitación automática del despacho

### DIFF
--- a/migrations/Version20260804130000.php
+++ b/migrations/Version20260804130000.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Ping periódico de proveedores: tabla provider_availability. Guarda solo el
+ * estado AUTO (lo que decide el último ping) y la auditoría del último
+ * cambio manual — el interruptor MANUAL en sí sigue viviendo en sys_config
+ * (provider.{code}.{type}.active), esta tabla no lo escribe ni lo lee.
+ *
+ * Aditiva y sin efecto hasta que exista una fila: mientras no haya fila para
+ * un (provider, environment_type), App\Service\Provider\ProviderAvailabilityService
+ * trata auto_enabled como true (no bloquea nada nuevo).
+ */
+final class Version20260804130000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Crea provider_availability (estado AUTO del ping periódico de proveedores)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE SEQUENCE IF NOT EXISTS provider_availability_id_seq INCREMENT BY 1 MINVALUE 1 START 1');
+
+        $this->addSql(<<<'SQL'
+            CREATE TABLE IF NOT EXISTS provider_availability (
+                id                    INT          NOT NULL,
+                provider              VARCHAR(20)  NOT NULL,
+                environment_type      VARCHAR(10)  NOT NULL,
+                auto_enabled          BOOLEAN      NOT NULL DEFAULT TRUE,
+                last_action_type      VARCHAR(10)      NULL,
+                last_action_by_id     INT              NULL,
+                last_action_at        TIMESTAMP(0) WITHOUT TIME ZONE NULL,
+                last_action_reason    VARCHAR(255)     NULL,
+                last_ping_at          TIMESTAMP(0) WITHOUT TIME ZONE NULL,
+                last_ping_success     BOOLEAN          NULL,
+                last_ping_latency_ms  INT              NULL,
+                last_ping_error       TEXT             NULL,
+                last_ping_details     JSON             NULL,
+                created_at            TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                updated_at            TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                PRIMARY KEY (id)
+            )
+        SQL);
+
+        $this->addSql(<<<'SQL'
+            ALTER TABLE provider_availability
+                ADD CONSTRAINT FK_PA_USER FOREIGN KEY (last_action_by_id) REFERENCES "user" (id)
+                NOT DEFERRABLE INITIALLY IMMEDIATE
+        SQL);
+
+        $this->addSql(<<<'SQL'
+            CREATE UNIQUE INDEX IF NOT EXISTS uniq_provider_availability
+                ON provider_availability (provider, environment_type)
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE IF EXISTS provider_availability');
+        $this->addSql('DROP SEQUENCE IF EXISTS provider_availability_id_seq');
+    }
+}

--- a/migrations/Version20260804140000.php
+++ b/migrations/Version20260804140000.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Siembra el item de menú "Disponibilidad de proveedores" — pantalla nueva
+ * (dashboard-cm) que muestra la matriz de disponibilidad por proveedor x
+ * entorno (ping periódico, interruptor manual auditado) y permite forzar un
+ * ping o cambiar el interruptor manual. Mismo grupo padre y mismo criterio
+ * de localización por `title` que Version20260801210000 (provider-settings).
+ */
+final class Version20260804140000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Siembra el item de navegación "Disponibilidad de proveedores" (menu.apps.provider-availability.title) y su permiso ROLE_ADMIN';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            INSERT INTO navigation_item (
+                id, parent_id, title, type, icon, link, is_active, created_at, updated_at, order_value
+            )
+            SELECT
+                nextval('navigation_item_id_seq'),
+                parent.id,
+                'menu.apps.provider-availability.title',
+                'basic',
+                'heroicons_outline:signal',
+                '/apps/provider-availability',
+                TRUE,
+                NOW(),
+                NOW(),
+                '00126'
+            FROM navigation_item parent
+            WHERE parent.title = 'menu.apps.sys-config.title'
+              AND NOT EXISTS (
+                  SELECT 1 FROM navigation_item ni WHERE ni.title = 'menu.apps.provider-availability.title'
+              )
+        SQL);
+
+        $this->addSql(<<<'SQL'
+            INSERT INTO user_permission (id, item_id, client_id, user_info_id, is_active, min_role_required, created_at, updated_at)
+            SELECT
+                nextval('user_permission_id_seq'),
+                item.id,
+                NULL,
+                NULL,
+                TRUE,
+                'ROLE_ADMIN',
+                NOW(),
+                NOW()
+            FROM navigation_item item
+            WHERE item.title = 'menu.apps.provider-availability.title'
+              AND NOT EXISTS (
+                  SELECT 1 FROM user_permission up
+                  WHERE up.item_id = item.id AND up.min_role_required = 'ROLE_ADMIN' AND up.client_id IS NULL AND up.user_info_id IS NULL
+              )
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            DELETE FROM user_permission
+            WHERE item_id IN (SELECT id FROM navigation_item WHERE title = 'menu.apps.provider-availability.title')
+        SQL);
+        $this->addSql("DELETE FROM navigation_item WHERE title = 'menu.apps.provider-availability.title'");
+    }
+}

--- a/src/Controller/DashboardProviderAvailabilityController.php
+++ b/src/Controller/DashboardProviderAvailabilityController.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Controller;
+
+use App\DTO\SetProviderAvailabilityDto;
+use App\Enums\CommunicationProviderEnum;
+use App\Exception\MyCurrentException;
+use App\OpenApi\Attribute\DashboardEndpoint;
+use App\Service\CommunicationsDispatchService;
+use App\Service\Provider\ProviderAvailabilityService;
+use App\Service\Provider\ProviderPingService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * Ping periódico de proveedores y el gate que habilita/deshabilita el
+ * despacho de transacciones. No sustituye a DashboardProviderRoutingController
+ * (que administra credenciales y enrutado por cliente) — este controlador es
+ * solo el estado de disponibilidad: la matriz proveedor x entorno, el toggle
+ * manual auditado, y el ping forzado.
+ *
+ * Lectura: ROLE_ADMIN. Escritura (toggle manual): ROLE_SUPER_ADMIN, mismo
+ * criterio que el resto de endpoints que afectan el envío de transacciones.
+ */
+#[Route('/admin/providers/availability')]
+#[IsGranted('ROLE_ADMIN')]
+class DashboardProviderAvailabilityController extends AbstractController
+{
+    public function __construct(
+        private readonly ProviderAvailabilityService $availabilityService,
+        private readonly ProviderPingService $pingService,
+        private readonly CommunicationsDispatchService $dispatchService,
+    ) {
+    }
+
+    #[Route('', name: 'dashboard_provider_availability_matrix', methods: ['GET'])]
+    #[DashboardEndpoint(summary: 'Matriz de disponibilidad proveedor x entorno', tag: 'Provider Availability', responseIsArray: true)]
+    public function matrix(): JsonResponse
+    {
+        return $this->json($this->availabilityService->statusMatrix());
+    }
+
+    #[Route('/{code}/{environmentType}/manual', name: 'dashboard_provider_availability_set_manual', methods: ['PATCH'], requirements: ['code' => 'ETECSA|DTONE|CSQ', 'environmentType' => 'TEST|PROD'])]
+    #[IsGranted('ROLE_SUPER_ADMIN')]
+    #[DashboardEndpoint(summary: 'Activar o desactivar manualmente el despacho hacia un proveedor, auditado', tag: 'Provider Availability')]
+    public function setManual(string $code, string $environmentType, SetProviderAvailabilityDto $dto): JsonResponse
+    {
+        $provider = CommunicationProviderEnum::tryFrom($code);
+        if ($provider === null) {
+            return $this->json(['error' => ['message' => 'Proveedor no encontrado']], Response::HTTP_NOT_FOUND);
+        }
+
+        try {
+            $this->availabilityService->setManual($provider, $environmentType, $dto->getActive() ?? true, $dto->getReason());
+        } catch (MyCurrentException $e) {
+            return $this->json(['error' => ['message' => $e->getMessage()]], $e->getCode());
+        }
+
+        return $this->json($this->availabilityService->statusMatrix());
+    }
+
+    #[Route('/{code}/{environmentType}/ping', name: 'dashboard_provider_availability_force_ping', methods: ['POST'], requirements: ['code' => 'ETECSA|DTONE|CSQ', 'environmentType' => 'TEST|PROD'])]
+    #[DashboardEndpoint(summary: 'Forzar un ping inmediato y registrar el resultado', tag: 'Provider Availability')]
+    public function forcePing(string $code, string $environmentType): JsonResponse
+    {
+        $provider = CommunicationProviderEnum::tryFrom($code);
+        if ($provider === null) {
+            return $this->json(['error' => ['message' => 'Proveedor no encontrado']], Response::HTTP_NOT_FOUND);
+        }
+
+        $result = $this->pingService->ping($provider, $environmentType);
+        $justRecovered = $this->availabilityService->recordPing($provider, $environmentType, $result);
+
+        if ($justRecovered) {
+            $this->dispatchService->redispatchPendingFor($provider->value, $environmentType);
+        }
+
+        return $this->json($this->availabilityService->statusMatrix());
+    }
+}

--- a/src/Controller/DashboardProviderRoutingController.php
+++ b/src/Controller/DashboardProviderRoutingController.php
@@ -23,6 +23,7 @@ use App\Repository\ClientProviderRoutingRepository;
 use App\Repository\CurrencyExchangeRateRepository;
 use App\Repository\SysConfigRepository;
 use App\Service\Provider\CurrencyExchangeRateSyncService;
+use App\Service\Provider\ProviderAvailabilityService;
 use App\Service\Provider\ProviderConnectionTestService;
 use App\Service\Provider\ProviderCredentialsAdminService;
 use App\Service\ProviderRoutingAdminService;
@@ -63,6 +64,7 @@ class DashboardProviderRoutingController extends AbstractController
         private readonly CurrencyExchangeRateRepository $exchangeRateRepo,
         private readonly ProviderCredentialsAdminService $credentialsAdminService,
         private readonly ProviderConnectionTestService $connectionTestService,
+        private readonly ProviderAvailabilityService $availabilityService,
     ) {
     }
 
@@ -135,7 +137,15 @@ class DashboardProviderRoutingController extends AbstractController
             return $this->json(['error' => ['message' => 'Proveedor no encontrado']], Response::HTTP_NOT_FOUND);
         }
 
-        $this->credentialsAdminService->setActive($provider, $environmentType, $dto->getActive() ?? true);
+        try {
+            // Pasa por ProviderAvailabilityService (no directo a
+            // ProviderCredentialsAdminService) para que audite el usuario y
+            // aplique el requisito "no se puede activar el despacho si el
+            // proveedor no está bien configurado" (409 PROVIDER_NOT_CONFIGURED).
+            $this->availabilityService->setManual($provider, $environmentType, $dto->getActive() ?? true);
+        } catch (MyCurrentException $e) {
+            return $this->json(['error' => ['message' => $e->getMessage()]], $e->getCode());
+        }
 
         return $this->json($this->credentialsAdminService->getStatus($provider));
     }

--- a/src/DTO/Out/DispatchPendingOutDto.php
+++ b/src/DTO/Out/DispatchPendingOutDto.php
@@ -14,4 +14,8 @@ final class DispatchPendingOutDto
 
     #[OAProperty(description: 'Total de mensajes encolados')]
     public int $total;
+
+    /** @var array<string, int> */
+    #[OAProperty(description: 'Ventas saltadas por proveedor no despachable, agrupadas por "PROVIDER|ENVIRONMENT_TYPE"')]
+    public array $skipped;
 }

--- a/src/DTO/Out/ProviderAvailabilityOutDto.php
+++ b/src/DTO/Out/ProviderAvailabilityOutDto.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\DTO\Out;
+
+use App\OpenApi\Attribute\OAProperty;
+
+/**
+ * Una fila de la matriz proveedor x entorno — ver
+ * App\Service\Provider\ProviderAvailabilityService::statusMatrix().
+ */
+final class ProviderAvailabilityOutDto
+{
+    #[OAProperty(description: 'Código de proveedor (ETECSA, DTONE, CSQ)')]
+    public string $provider;
+
+    #[OAProperty(description: 'TEST o PROD')]
+    public string $environmentType;
+
+    #[OAProperty(description: 'Credenciales obligatorias completas para este entorno')]
+    public bool $configured;
+
+    #[OAProperty(description: 'Interruptor MANUAL (sys_config provider.{code}.{type}.active)')]
+    public bool $manualActive;
+
+    #[OAProperty(description: 'Estado AUTO — lo último que decidió el ping periódico')]
+    public bool $autoEnabled;
+
+    #[OAProperty(description: 'Despachable ahora mismo: global && configured && manual && auto')]
+    public bool $effective;
+
+    #[OAProperty(description: 'MANUAL o AUTO — origen del último cambio')]
+    public ?string $lastActionType;
+
+    #[OAProperty(description: 'Identificador del usuario que hizo el último cambio manual (null si fue AUTO)')]
+    public ?string $lastActionBy;
+
+    #[OAProperty(description: 'Fecha/hora ISO-8601 del último cambio')]
+    public ?string $lastActionAt;
+
+    #[OAProperty(description: 'Motivo del último cambio')]
+    public ?string $lastActionReason;
+
+    #[OAProperty(description: 'Fecha/hora ISO-8601 del último ping')]
+    public ?string $lastPingAt;
+
+    #[OAProperty(description: 'Resultado del último ping (null si fue inconclusive)')]
+    public ?bool $lastPingSuccess;
+
+    #[OAProperty(description: 'Latencia del último ping, en milisegundos')]
+    public ?int $lastPingLatencyMs;
+
+    #[OAProperty(description: 'Error del último ping, si lo hubo')]
+    public ?string $lastPingError;
+}

--- a/src/DTO/SetProviderActiveDto.php
+++ b/src/DTO/SetProviderActiveDto.php
@@ -5,11 +5,11 @@ namespace App\DTO;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
- * Activa o desactiva manualmente un proveedor para un entorno (TEST/PROD),
- * independientemente de si tiene sus claves obligatorias configuradas —
- * ver ProviderCredentialsResolver::isActive(). Sirve para apagar un
- * proveedor puntualmente (p.ej. incidencia con CSQ) sin borrar sus
- * credenciales.
+ * Activa o desactiva manualmente un proveedor para un entorno (TEST/PROD).
+ * Sirve para apagar un proveedor puntualmente (p.ej. incidencia con CSQ) sin
+ * borrar sus credenciales. Activar (`active: true`) requiere que el
+ * proveedor tenga sus claves obligatorias configuradas para ese entorno —
+ * ver App\Service\Provider\ProviderAvailabilityService::setManual().
  */
 class SetProviderActiveDto implements IInput
 {

--- a/src/DTO/SetProviderAvailabilityDto.php
+++ b/src/DTO/SetProviderAvailabilityDto.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\DTO;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Toggle MANUAL de disponibilidad, auditado (usuario + motivo opcional) —
+ * ver App\Service\Provider\ProviderAvailabilityService::setManual(). Activar
+ * (`active: true`) requiere que el proveedor tenga sus claves obligatorias
+ * configuradas para ese entorno, o falla con 409 PROVIDER_NOT_CONFIGURED.
+ */
+class SetProviderAvailabilityDto implements IInput
+{
+    #[Assert\NotNull]
+    protected ?bool $active;
+
+    #[Assert\Length(max: 255)]
+    protected ?string $reason;
+
+    public function __construct(?bool $active = null, ?string $reason = null)
+    {
+        $this->active = $active;
+        $this->reason = $reason;
+    }
+
+    public function getActive(): ?bool
+    {
+        return $this->active;
+    }
+
+    public function setActive(?bool $active): void
+    {
+        $this->active = $active;
+    }
+
+    public function getReason(): ?string
+    {
+        return $this->reason;
+    }
+
+    public function setReason(?string $reason): void
+    {
+        $this->reason = $reason;
+    }
+}

--- a/src/Entity/ProviderAvailability.php
+++ b/src/Entity/ProviderAvailability.php
@@ -1,0 +1,242 @@
+<?php
+
+namespace App\Entity;
+
+use App\Enums\ProviderActionTypeEnum;
+use App\Repository\ProviderAvailabilityRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Estado AUTO (ping) de disponibilidad de un proveedor por entorno. El
+ * interruptor MANUAL sigue viviendo en sys_config
+ * (provider.{code}.{type}.active, ver App\Provider\ProviderCredentialsResolver)
+ * — esta tabla nunca lo escribe ni lo lee, solo guarda lo que decidió el
+ * último ping y quién hizo el último cambio manual, para auditoría y para
+ * mostrar en el dashboard. Ver App\Service\Provider\ProviderAvailabilityService
+ * para cómo se combinan ambos flags.
+ */
+#[ORM\Entity(repositoryClass: ProviderAvailabilityRepository::class)]
+#[ORM\UniqueConstraint(name: 'uniq_provider_availability', columns: ['provider', 'environment_type'])]
+class ProviderAvailability
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 20)]
+    private ?string $provider = null;
+
+    #[ORM\Column(name: 'environment_type', length: 10)]
+    private ?string $environmentType = null;
+
+    #[ORM\Column(name: 'auto_enabled')]
+    private bool $autoEnabled = true;
+
+    #[ORM\Column(name: 'last_action_type', length: 10, enumType: ProviderActionTypeEnum::class, nullable: true)]
+    private ?ProviderActionTypeEnum $lastActionType = null;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(name: 'last_action_by_id', nullable: true)]
+    private ?User $lastActionBy = null;
+
+    #[ORM\Column(name: 'last_action_at', nullable: true)]
+    private ?\DateTimeImmutable $lastActionAt = null;
+
+    #[ORM\Column(name: 'last_action_reason', length: 255, nullable: true)]
+    private ?string $lastActionReason = null;
+
+    #[ORM\Column(name: 'last_ping_at', nullable: true)]
+    private ?\DateTimeImmutable $lastPingAt = null;
+
+    #[ORM\Column(name: 'last_ping_success', nullable: true)]
+    private ?bool $lastPingSuccess = null;
+
+    #[ORM\Column(name: 'last_ping_latency_ms', nullable: true)]
+    private ?int $lastPingLatencyMs = null;
+
+    #[ORM\Column(name: 'last_ping_error', type: Types::TEXT, nullable: true)]
+    private ?string $lastPingError = null;
+
+    #[ORM\Column(name: 'last_ping_details', type: Types::JSON, nullable: true)]
+    private ?array $lastPingDetails = null;
+
+    #[ORM\Column(name: 'created_at')]
+    private ?\DateTimeImmutable $createdAt = null;
+
+    #[ORM\Column(name: 'updated_at')]
+    private ?\DateTimeImmutable $updatedAt = null;
+
+    public function __construct()
+    {
+        $this->createdAt = new \DateTimeImmutable('now');
+        $this->updatedAt = new \DateTimeImmutable('now');
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getProvider(): ?string
+    {
+        return $this->provider;
+    }
+
+    public function setProvider(string $provider): static
+    {
+        $this->provider = $provider;
+
+        return $this;
+    }
+
+    public function getEnvironmentType(): ?string
+    {
+        return $this->environmentType;
+    }
+
+    public function setEnvironmentType(string $environmentType): static
+    {
+        $this->environmentType = $environmentType;
+
+        return $this;
+    }
+
+    public function isAutoEnabled(): bool
+    {
+        return $this->autoEnabled;
+    }
+
+    public function setAutoEnabled(bool $autoEnabled): static
+    {
+        $this->autoEnabled = $autoEnabled;
+
+        return $this;
+    }
+
+    public function getLastActionType(): ?ProviderActionTypeEnum
+    {
+        return $this->lastActionType;
+    }
+
+    public function setLastActionType(?ProviderActionTypeEnum $lastActionType): static
+    {
+        $this->lastActionType = $lastActionType;
+
+        return $this;
+    }
+
+    public function getLastActionBy(): ?User
+    {
+        return $this->lastActionBy;
+    }
+
+    public function setLastActionBy(?User $lastActionBy): static
+    {
+        $this->lastActionBy = $lastActionBy;
+
+        return $this;
+    }
+
+    public function getLastActionAt(): ?\DateTimeImmutable
+    {
+        return $this->lastActionAt;
+    }
+
+    public function setLastActionAt(?\DateTimeImmutable $lastActionAt): static
+    {
+        $this->lastActionAt = $lastActionAt;
+
+        return $this;
+    }
+
+    public function getLastActionReason(): ?string
+    {
+        return $this->lastActionReason;
+    }
+
+    public function setLastActionReason(?string $lastActionReason): static
+    {
+        $this->lastActionReason = $lastActionReason;
+
+        return $this;
+    }
+
+    public function getLastPingAt(): ?\DateTimeImmutable
+    {
+        return $this->lastPingAt;
+    }
+
+    public function setLastPingAt(?\DateTimeImmutable $lastPingAt): static
+    {
+        $this->lastPingAt = $lastPingAt;
+
+        return $this;
+    }
+
+    public function isLastPingSuccess(): ?bool
+    {
+        return $this->lastPingSuccess;
+    }
+
+    public function setLastPingSuccess(?bool $lastPingSuccess): static
+    {
+        $this->lastPingSuccess = $lastPingSuccess;
+
+        return $this;
+    }
+
+    public function getLastPingLatencyMs(): ?int
+    {
+        return $this->lastPingLatencyMs;
+    }
+
+    public function setLastPingLatencyMs(?int $lastPingLatencyMs): static
+    {
+        $this->lastPingLatencyMs = $lastPingLatencyMs;
+
+        return $this;
+    }
+
+    public function getLastPingError(): ?string
+    {
+        return $this->lastPingError;
+    }
+
+    public function setLastPingError(?string $lastPingError): static
+    {
+        $this->lastPingError = $lastPingError;
+
+        return $this;
+    }
+
+    public function getLastPingDetails(): ?array
+    {
+        return $this->lastPingDetails;
+    }
+
+    public function setLastPingDetails(?array $lastPingDetails): static
+    {
+        $this->lastPingDetails = $lastPingDetails;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?\DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): ?\DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    public function touch(): static
+    {
+        $this->updatedAt = new \DateTimeImmutable('now');
+
+        return $this;
+    }
+}

--- a/src/Enums/NotificationTypeEnum.php
+++ b/src/Enums/NotificationTypeEnum.php
@@ -14,5 +14,7 @@ enum NotificationTypeEnum: string
     case ACCOUNT_ACTIVATED               = 'ACCOUNT_ACTIVATED';
     case TWO_FACTOR_MANDATORY_PENDING    = 'TWO_FACTOR_MANDATORY_PENDING';
     case PROMOTION_CREATED               = 'PROMOTION_CREATED';
+    case PROVIDER_UNAVAILABLE            = 'PROVIDER_UNAVAILABLE';
+    case PROVIDER_RECOVERED              = 'PROVIDER_RECOVERED';
     case CUSTOM                          = 'CUSTOM';
 }

--- a/src/Enums/ProviderActionTypeEnum.php
+++ b/src/Enums/ProviderActionTypeEnum.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * Origen del último cambio de disponibilidad de un proveedor
+ * (App\Entity\ProviderAvailability). MANUAL lo escribe un admin desde el
+ * dashboard (se audita el usuario); AUTO lo escribe el ping periódico
+ * (App\Schedule\Task\PingProvidersTask). Ver App\Service\Provider\ProviderAvailabilityService
+ * para la regla de precedencia entre ambos.
+ */
+enum ProviderActionTypeEnum: string
+{
+    case MANUAL = 'MANUAL';
+    case AUTO = 'AUTO';
+}

--- a/src/Provider/Contract/ProviderHealthCheckInterface.php
+++ b/src/Provider/Contract/ProviderHealthCheckInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Provider\Contract;
+
+/**
+ * Proveedores con un endpoint de ping dedicado (más barato y más fiel que
+ * usar getPlatformBalance() como prueba de vida). Implementada hoy por ETECSA
+ * y CSQ; DTOne no la implementa y cae al fallback de
+ * App\Service\Provider\ProviderPingService.
+ */
+interface ProviderHealthCheckInterface extends CommunicationProviderInterface
+{
+    public function checkHealth(ProviderContext $context): ProviderPingResult;
+}

--- a/src/Provider/Contract/ProviderPingResult.php
+++ b/src/Provider/Contract/ProviderPingResult.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Provider\Contract;
+
+/**
+ * Resultado de un ping de disponibilidad. Tres estados, no dos:
+ * `inconclusive` es distinto de `unavailable` porque significa que nuestra
+ * credencial o configuración está mal (401/403/409, sin configurar), no que
+ * el proveedor esté caído — App\Service\Provider\ProviderAvailabilityService
+ * nunca apaga un proveedor por un resultado inconclusive.
+ */
+final readonly class ProviderPingResult
+{
+    /**
+     * @param array<string, mixed> $details
+     */
+    private function __construct(
+        public bool $available,
+        public bool $inconclusive,
+        public ?int $latencyMs,
+        public ?string $error,
+        public \DateTimeImmutable $checkedAt,
+        public array $details = [],
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $details
+     */
+    public static function available(?int $latencyMs = null, array $details = []): self
+    {
+        return new self(true, false, $latencyMs, null, new \DateTimeImmutable('now'), $details);
+    }
+
+    /**
+     * @param array<string, mixed> $details
+     */
+    public static function unavailable(?string $error, ?int $latencyMs = null, array $details = []): self
+    {
+        return new self(false, false, $latencyMs, $error, new \DateTimeImmutable('now'), $details);
+    }
+
+    /**
+     * @param array<string, mixed> $details
+     */
+    public static function inconclusive(?string $error, array $details = []): self
+    {
+        return new self(false, true, null, $error, new \DateTimeImmutable('now'), $details);
+    }
+}

--- a/src/Provider/Csq/CsqCommunicationProvider.php
+++ b/src/Provider/Csq/CsqCommunicationProvider.php
@@ -4,9 +4,12 @@ namespace App\Provider\Csq;
 
 use App\Enums\CommunicationProviderEnum;
 use App\Enums\ProviderCapabilityEnum;
+use App\Exception\MyCurrentException;
 use App\Provider\Contract\CommunicationProviderInterface;
 use App\Provider\Contract\ProviderConfigField;
 use App\Provider\Contract\ProviderContext;
+use App\Provider\Contract\ProviderHealthCheckInterface;
+use App\Provider\Contract\ProviderPingResult;
 
 /**
  * Adaptador de CSQ ("eVSB") a la abstracción de proveedor. Implementa
@@ -21,7 +24,7 @@ use App\Provider\Contract\ProviderContext;
  * del dashboard — así se pueden cargar y probar sus credenciales desde ya,
  * aunque todavía no participe en el enrutado real de ventas.
  */
-final class CsqCommunicationProvider implements CommunicationProviderInterface
+final class CsqCommunicationProvider implements CommunicationProviderInterface, ProviderHealthCheckInterface
 {
     public function __construct(
         private readonly CsqHttpClient $client,
@@ -60,5 +63,25 @@ final class CsqCommunicationProvider implements CommunicationProviderInterface
     public function ping(ProviderContext $context, string $echo = 'pong'): array
     {
         return $this->client->ping($context, $echo);
+    }
+
+    /**
+     * Delega en el ping propio de CSQ (GET /ping/{echo}), midiendo latencia
+     * localmente porque la API no la devuelve. Un ping fallido de CSQ
+     * significa transporte/servidor caído (CsqHttpClient::ping() ya traduce
+     * cualquier fallo HTTP a MyCurrentException('CSQ_REQUEST_FAILED')), no
+     * un problema de credenciales — no hay clasificación inconclusive aquí.
+     */
+    public function checkHealth(ProviderContext $context): ProviderPingResult
+    {
+        $start = microtime(true);
+
+        try {
+            $this->client->ping($context);
+        } catch (MyCurrentException $e) {
+            return ProviderPingResult::unavailable($e->getMessage());
+        }
+
+        return ProviderPingResult::available((int) round((microtime(true) - $start) * 1000));
     }
 }

--- a/src/Provider/Etecsa/EtecsaCommunicationProvider.php
+++ b/src/Provider/Etecsa/EtecsaCommunicationProvider.php
@@ -16,6 +16,8 @@ use App\Provider\Contract\ProviderCatalogInterface;
 use App\Provider\Contract\ProviderConfigField;
 use App\Provider\Contract\ProviderContext;
 use App\Provider\Contract\ProviderDispatchResult;
+use App\Provider\Contract\ProviderHealthCheckInterface;
+use App\Provider\Contract\ProviderPingResult;
 use App\Provider\Contract\ProviderProductDto;
 use App\Provider\Contract\ProviderStatusQuery;
 use App\Provider\Contract\ProviderStatusResult;
@@ -57,7 +59,8 @@ final class EtecsaCommunicationProvider implements
     ProviderBalanceInterface,
     ProviderCatalogInterface,
     TouristSimProviderInterface,
-    GeoCatalogProviderInterface
+    GeoCatalogProviderInterface,
+    ProviderHealthCheckInterface
 {
     public function __construct(
         private readonly EtecsaGatewayClient $client,
@@ -172,6 +175,43 @@ final class EtecsaCommunicationProvider implements
             amounts: ['CUP' => $balance->cupAmount, 'USD' => $balance->usdAmount],
             fetchedAt: $balance->fetchedAt,
         );
+    }
+
+    /**
+     * GET /ping. 200 y 503 comparten forma de respuesta — el status HTTP y
+     * `available` en el body son la misma señal, redundante. 401/403/409
+     * significan credencial/permiso mal configurado, no un ETECSA caído:
+     * se reportan como inconclusive para que
+     * App\Service\Provider\ProviderAvailabilityService no apague el
+     * proveedor por un falso positivo nuestro.
+     */
+    public function checkHealth(ProviderContext $context): ProviderPingResult
+    {
+        $env = $this->resolveEnvironment($context);
+
+        try {
+            $result = $this->client->ping($env);
+        } catch (MyCurrentException $e) {
+            return ProviderPingResult::unavailable($e->getMessage());
+        }
+
+        $status = $result['status'];
+        $body = $result['body'];
+        $latencyMs = isset($body['latencyMs']) && is_numeric($body['latencyMs']) ? (int) $body['latencyMs'] : null;
+
+        return match (true) {
+            $status === 200 => ProviderPingResult::available($latencyMs, $body),
+            $status === 503 => ProviderPingResult::unavailable(
+                is_string($body['error'] ?? null) ? $body['error'] : 'ETECSA: servicio no disponible',
+                $latencyMs,
+                $body,
+            ),
+            in_array($status, [401, 403, 409], true) => ProviderPingResult::inconclusive(
+                "ETECSA ping: respuesta HTTP {$status} — revisar credenciales/scope",
+                $body,
+            ),
+            default => ProviderPingResult::inconclusive("ETECSA ping: status HTTP inesperado {$status}", $body),
+        };
     }
 
     public function fetchProducts(ProviderContext $context): iterable

--- a/src/Repository/CommunicationSaleInfoRepository.php
+++ b/src/Repository/CommunicationSaleInfoRepository.php
@@ -34,13 +34,20 @@ class CommunicationSaleInfoRepository extends ServiceEntityRepository
 
     /**
      * Ventas en estado PENDING con stateProcess=CREATED: fueron persistidas pero nunca encoladas
-     * (porque el dispatch estaba deshabilitado cuando se crearon).
+     * (porque el dispatch estaba deshabilitado, o el proveedor no estaba despachable, cuando se crearon).
+     *
+     * Trae tenant/environment con fetch-join: CommunicationsDispatchService::dispatchPending()
+     * necesita el environmentType de cada venta para decidir si es despachable
+     * (App\Service\Provider\ProviderAvailabilityService::canDispatchTo()) — sin este join
+     * sería un N+1 por cada venta pendiente.
      *
      * @return CommunicationSaleInfo[]
      */
     public function findPendingUndispatched(): array
     {
         return $this->createQueryBuilder('s')
+            ->leftJoin('s.tenant', 't')->addSelect('t')
+            ->leftJoin('t.environment', 'e')->addSelect('e')
             ->andWhere('s.state = :state')
             ->andWhere('s.stateProcess = :stateProcess')
             ->setParameter('state', CommunicationStateEnum::PENDING)
@@ -48,6 +55,40 @@ class CommunicationSaleInfoRepository extends ServiceEntityRepository
             ->orderBy('s.createdAt', 'ASC')
             ->getQuery()
             ->getResult();
+    }
+
+    /**
+     * Igual que findPendingUndispatched() pero acotado a un proveedor y
+     * entorno concretos — usado al recuperarse un proveedor
+     * (ProviderAvailabilityService::recordPing()) para reencolar solo sus
+     * pendientes, no las de todos. `provider IS NULL` se trata como ETECSA
+     * (filas antiguas anteriores al enrutado multi-proveedor).
+     *
+     * @return CommunicationSaleInfo[]
+     */
+    public function findPendingUndispatchedByProvider(string $provider, ?string $environmentType, int $limit = 500): array
+    {
+        $qb = $this->createQueryBuilder('s')
+            ->leftJoin('s.tenant', 't')->addSelect('t')
+            ->leftJoin('t.environment', 'e')->addSelect('e')
+            ->andWhere('s.state = :state')
+            ->andWhere('s.stateProcess = :stateProcess')
+            ->setParameter('state', CommunicationStateEnum::PENDING)
+            ->setParameter('stateProcess', CommunicationStateEnum::CREATED->value)
+            ->orderBy('s.createdAt', 'ASC')
+            ->setMaxResults($limit);
+
+        if ($provider === 'ETECSA') {
+            $qb->andWhere('s.provider = :provider OR s.provider IS NULL')->setParameter('provider', $provider);
+        } else {
+            $qb->andWhere('s.provider = :provider')->setParameter('provider', $provider);
+        }
+
+        if ($environmentType !== null) {
+            $qb->andWhere('e.type = :environmentType')->setParameter('environmentType', $environmentType);
+        }
+
+        return $qb->getQuery()->getResult();
     }
 
     /**

--- a/src/Repository/ProviderAvailabilityRepository.php
+++ b/src/Repository/ProviderAvailabilityRepository.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\ProviderAvailability;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<ProviderAvailability>
+ *
+ * @method ProviderAvailability|null find($id, $lockMode = null, $lockVersion = null)
+ * @method ProviderAvailability|null findOneBy(array $criteria, array $orderBy = null)
+ * @method ProviderAvailability[]    findAll()
+ * @method ProviderAvailability[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class ProviderAvailabilityRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, ProviderAvailability::class);
+    }
+
+    /**
+     * Sin caché deliberadamente: se consulta en el camino caliente de cada
+     * venta (App\Service\Provider\ProviderAvailabilityService::canDispatchTo())
+     * y cache.app es de sistema de ficheros por proceso — un flag cacheado
+     * quedaría obsoleto justo en el worker que despacha. La tabla tiene a lo
+     * sumo unas pocas filas (proveedores x entornos) con índice único.
+     */
+    public function findOneByProviderAndType(string $provider, string $environmentType): ?ProviderAvailability
+    {
+        return $this->findOneBy(['provider' => $provider, 'environmentType' => $environmentType]);
+    }
+
+    /**
+     * @return array<string, ProviderAvailability> indexado por "PROVIDER|TYPE"
+     */
+    public function findAllIndexed(): array
+    {
+        $indexed = [];
+        foreach ($this->findAll() as $row) {
+            $indexed[$row->getProvider() . '|' . $row->getEnvironmentType()] = $row;
+        }
+
+        return $indexed;
+    }
+}

--- a/src/Schedule/Task/PingProvidersTask.php
+++ b/src/Schedule/Task/PingProvidersTask.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Schedule\Task;
+
+use App\Provider\ProviderCredentialsResolver;
+use App\Provider\ProviderRegistry;
+use App\Service\CommunicationsDispatchService;
+use App\Service\Provider\ProviderAvailabilityService;
+use App\Service\Provider\ProviderPingService;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Scheduler\Attribute\AsCronTask;
+
+/**
+ * Ping cada 15 minutos a cada proveedor registrado, por entorno (TEST/PROD).
+ * Solo pinguea los que tienen credenciales completas — un proveedor sin
+ * configurar no es "caído", es "no aplica" (ProviderPingService ya lo trata
+ * como inconclusive, pero evitamos la llamada HTTP innecesaria).
+ *
+ * Un proveedor que lanza no debe impedir pinguear al resto: cada par
+ * (proveedor, entorno) se captura por separado. Sin riesgo de solape: este
+ * transport (scheduler_default) lo consume un único worker-scheduler de
+ * forma secuencial (ver docker-compose.vps.prod.yaml) — una ejecución lenta
+ * solo retrasa el siguiente disparo, nunca corre en paralelo consigo misma.
+ */
+#[AsCronTask('*/15 * * * *', 'America/Havana')]
+class PingProvidersTask
+{
+    private const ENVIRONMENT_TYPES = ['TEST', 'PROD'];
+
+    public function __construct(
+        private readonly ProviderRegistry $registry,
+        private readonly ProviderCredentialsResolver $credentialsResolver,
+        private readonly ProviderPingService $pingService,
+        private readonly ProviderAvailabilityService $availabilityService,
+        private readonly CommunicationsDispatchService $dispatchService,
+        #[Autowire('@monolog.logger.provider')] private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public function __invoke(): void
+    {
+        foreach ($this->registry->registered() as $provider) {
+            foreach (self::ENVIRONMENT_TYPES as $environmentType) {
+                try {
+                    if (!$this->credentialsResolver->isFullyConfigured($provider, $environmentType)) {
+                        continue;
+                    }
+
+                    $result = $this->pingService->ping($provider, $environmentType);
+                    $justRecovered = $this->availabilityService->recordPing($provider, $environmentType, $result);
+
+                    if ($justRecovered) {
+                        $this->dispatchService->redispatchPendingFor($provider->value, $environmentType);
+                    }
+                } catch (\Throwable $e) {
+                    $this->logger->error('Ping de proveedor falló inesperadamente', [
+                        'provider' => $provider->value,
+                        'environmentType' => $environmentType,
+                        'error' => $e->getMessage(),
+                    ]);
+                }
+            }
+        }
+    }
+}

--- a/src/Service/CommunicationSaleService.php
+++ b/src/Service/CommunicationSaleService.php
@@ -38,6 +38,7 @@ use App\Provider\ProviderResolver;
 use App\Repository\BalanceOperationRepository;
 use App\Repository\EnvironmentRepository;
 use App\Repository\SysConfigRepository;
+use App\Service\Provider\ProviderAvailabilityService;
 use Doctrine\DBAL\Exception;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
@@ -87,6 +88,7 @@ class CommunicationSaleService extends CommonService
         private readonly HistoricalSaleService $historicalSaleService,
         private readonly BalanceService $balanceService,
         private readonly NotificationCenterService $notificationCenter,
+        private readonly ProviderAvailabilityService $availabilityService,
     ) {
         parent::__construct(
             $em,
@@ -101,11 +103,27 @@ class CommunicationSaleService extends CommonService
         );
     }
 
-    private const DISPATCH_ENABLED_KEY = 'communications.dispatch.enabled';
-
-    private function isDispatchEnabled(): bool
+    /**
+     * Único punto de despacho/diferido: encola el mensaje si el proveedor de
+     * la venta está despachable (App\Service\Provider\ProviderAvailabilityService::canDispatchTo() —
+     * switch global, credenciales+manual, y AUTO del ping), o la deja
+     * PENDING para que la recuperación del proveedor (o dispatchPending())
+     * la reencole más tarde.
+     *
+     * $messageFactory es un closure, no el mensaje ya construido: construirlo
+     * de forma perezosa evita evaluar getId() cuando todavía puede ser null
+     * (justo antes de un flush) en la rama que ni siquiera va a despachar.
+     */
+    private function dispatchOrDefer(CommunicationSaleInfo $sale, \Closure $messageFactory): void
     {
-        return $this->sysConfigRepo->findCachedValue(self::DISPATCH_ENABLED_KEY) !== '0';
+        $provider = $sale->getProvider() ?? CommunicationProviderEnum::ETECSA->value;
+        $environmentType = $sale->getTenant()?->getEnvironment()?->getType();
+
+        if ($this->availabilityService->canDispatchTo($provider, $environmentType)) {
+            $this->messageBus->dispatch($messageFactory());
+        } else {
+            $this->logger->info("Communications dispatch disabled or provider unavailable: sale {$sale->getId()} saved, pending dispatch.");
+        }
     }
 
     /**
@@ -145,12 +163,8 @@ class CommunicationSaleService extends CommonService
 
         $this->em->flush();
 
-        if ($this->isDispatchEnabled()) {
-            foreach ($toDispatch as $sale) {
-                $this->messageBus->dispatch(new SaleRechargeMessage($sale->getId()));
-            }
-        } else {
-            $this->logger->info('Communications dispatch disabled: ' . count($toDispatch) . ' activated sale(s) queued in DB, pending dispatch.');
+        foreach ($toDispatch as $sale) {
+            $this->dispatchOrDefer($sale, fn () => new SaleRechargeMessage($sale->getId()));
         }
 
         return $activated;
@@ -325,11 +339,7 @@ class CommunicationSaleService extends CommonService
             throw $ex;
         }
 
-        if ($this->isDispatchEnabled()) {
-            $this->messageBus->dispatch(new SaleRechargeMessage($recharge->getId()));
-        } else {
-            $this->logger->info("Communications dispatch disabled: recharge {$recharge->getId()} saved, pending dispatch.");
-        }
+        $this->dispatchOrDefer($recharge, fn () => new SaleRechargeMessage($recharge->getId()));
 
         return $recharge;
     }
@@ -383,6 +393,15 @@ class CommunicationSaleService extends CommonService
                 ];
                 $saleRecharge->setTransactionStatus($rechargeInfo);
                 $this->em->flush();
+
+                return;
+            }
+            // Chequeo ANTES de claimForSending(): un mensaje que ya estaba en
+            // RabbitMQ cuando el proveedor cayó no debe consumir la venta —
+            // se deja en CREATED (sin reclamar) para que dispatchOrDefer()/
+            // dispatchPending() la reencolen cuando el proveedor se recupere.
+            if (!$this->availabilityService->canDispatchTo($saleRecharge->getProvider(), $user->getEnvironment()?->getType())) {
+                $this->logger->info("Skipping recharge {$saleId}: provider not dispatchable right now, left pending for recovery.");
 
                 return;
             }
@@ -661,11 +680,7 @@ class CommunicationSaleService extends CommonService
             throw $ex;
         }
 
-        if ($this->isDispatchEnabled()) {
-            $this->messageBus->dispatch(new SalePackageMessage($sale->getId()));
-        } else {
-            $this->logger->info("Communications dispatch disabled: sale package {$sale->getId()} saved, pending dispatch.");
-        }
+        $this->dispatchOrDefer($sale, fn () => new SalePackageMessage($sale->getId()));
 
         return $sale;
     }
@@ -685,6 +700,14 @@ class CommunicationSaleService extends CommonService
             'id' => $saleId
         ]);
         if (is_null($sale) || $sale->getState() !== CommunicationStateEnum::PENDING) {
+            return;
+        }
+        // Chequeo ANTES de claimForSending(): ver invokeRechargeCommunication()
+        // para la misma justificación (no consumir un mensaje ya encolado si
+        // el proveedor no es despachable ahora mismo).
+        if (!$this->availabilityService->canDispatchTo($sale->getProvider(), $sale->getTenant()?->getEnvironment()?->getType())) {
+            $this->logger->info("Skipping sale {$saleId}: provider not dispatchable right now, left pending for recovery.");
+
             return;
         }
         if (!$this->claimForSending($sale)) {

--- a/src/Service/CommunicationsDispatchService.php
+++ b/src/Service/CommunicationsDispatchService.php
@@ -6,13 +6,17 @@ use App\Entity\CommunicationSaleInfo;
 use App\Entity\CommunicationSalePackage;
 use App\Entity\CommunicationSaleRecharge;
 use App\Entity\SysConfig;
+use App\Enums\CommunicationProviderEnum;
 use App\Exception\MyCurrentException;
 use App\Message\DispatchPendingEmailMessage;
 use App\Message\SalePackageMessage;
 use App\Message\SaleRechargeMessage;
 use App\Repository\CommunicationSaleInfoRepository;
 use App\Repository\SysConfigRepository;
+use App\Service\Provider\ProviderAvailabilityService;
 use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Messenger\MessageBusInterface;
 
@@ -24,6 +28,8 @@ class CommunicationsDispatchService
         private readonly EntityManagerInterface $em,
         private readonly SysConfigRepository $sysConfigRepo,
         private readonly MessageBusInterface $messageBus,
+        private readonly ProviderAvailabilityService $availabilityService,
+        #[Autowire('@monolog.logger.provider')] private readonly LoggerInterface $logger,
     ) {}
 
     public function invalidateCache(): void
@@ -57,9 +63,13 @@ class CommunicationsDispatchService
 
     /**
      * Encola en RabbitMQ todas las ventas que quedaron sin despachar y envía un email de resumen.
+     * Salta (no encola) las ventas cuyo proveedor no esté despachable ahora mismo
+     * (App\Service\Provider\ProviderAvailabilityService::canDispatchTo()) — global
+     * apagado, proveedor mal configurado/inactivo, o ping en rojo — y las reporta
+     * en `skipped`, agrupadas por "PROVIDER|ENVIRONMENT_TYPE".
      * Lanza MyCurrentException si el dispatch está deshabilitado.
      *
-     * @return array{recharges: int, packages: int, total: int}
+     * @return array{recharges: int, packages: int, total: int, skipped: array<string, int>}
      * @throws MyCurrentException
      */
     public function dispatchPending(?string $triggeredBy = null): array
@@ -79,8 +89,18 @@ class CommunicationsDispatchService
         $recharges      = 0;
         $packages       = 0;
         $transactionIds = [];
+        $skipped        = [];
 
         foreach ($sales as $sale) {
+            $provider        = $sale->getProvider() ?? CommunicationProviderEnum::ETECSA->value;
+            $environmentType = $sale->getTenant()?->getEnvironment()?->getType();
+
+            if (!$this->availabilityService->canDispatchTo($provider, $environmentType)) {
+                $key = $provider . '|' . ($environmentType ?? 'PROD');
+                $skipped[$key] = ($skipped[$key] ?? 0) + 1;
+                continue;
+            }
+
             if ($sale instanceof CommunicationSaleRecharge) {
                 $this->messageBus->dispatch(new SaleRechargeMessage($sale->getId()));
                 $recharges++;
@@ -106,6 +126,41 @@ class CommunicationsDispatchService
             ));
         }
 
-        return ['recharges' => $recharges, 'packages' => $packages, 'total' => $total];
+        return ['recharges' => $recharges, 'packages' => $packages, 'total' => $total, 'skipped' => $skipped];
+    }
+
+    /**
+     * Reencola las ventas PENDING sin despachar de un proveedor/entorno
+     * concreto. Lo llama App\Schedule\Task\PingProvidersTask (y el ping
+     * forzado del dashboard) justo después de un ping que recupera un
+     * proveedor — nunca esta clase por sí sola, para no formar un ciclo de
+     * dependencia con ProviderAvailabilityService.
+     */
+    public function redispatchPendingFor(string $provider, ?string $environmentType): int
+    {
+        /** @var CommunicationSaleInfoRepository $repo */
+        $repo = $this->em->getRepository(CommunicationSaleInfo::class);
+        $sales = $repo->findPendingUndispatchedByProvider($provider, $environmentType);
+
+        $count = 0;
+        foreach ($sales as $sale) {
+            if ($sale instanceof CommunicationSaleRecharge) {
+                $this->messageBus->dispatch(new SaleRechargeMessage($sale->getId()));
+                $count++;
+            } elseif ($sale instanceof CommunicationSalePackage) {
+                $this->messageBus->dispatch(new SalePackageMessage($sale->getId()));
+                $count++;
+            }
+        }
+
+        if ($count > 0) {
+            $this->logger->info('Reencoladas ventas pendientes tras recuperación de proveedor', [
+                'provider' => $provider,
+                'environmentType' => $environmentType,
+                'count' => $count,
+            ]);
+        }
+
+        return $count;
     }
 }

--- a/src/Service/Etecsa/EtecsaGatewayClient.php
+++ b/src/Service/Etecsa/EtecsaGatewayClient.php
@@ -18,6 +18,7 @@ use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
@@ -254,11 +255,71 @@ class EtecsaGatewayClient extends CommonService
         return $this->post($env, '/tur/batch-info', $body);
     }
 
+    /**
+     * GET /ping — health-check documentado en
+     * https://communications.comremit.com/api/doc#tag/ping. Sin body ni
+     * query, solo X-Api-Key. A diferencia de post()/rawPost(), un 503 es una
+     * respuesta VÁLIDA que hay que leer (misma forma que el 200: environment,
+     * available, ticketId, latencyMs, error, breakerOpen, breakerFailures,
+     * checkedAt), no una excepción — por eso no reutiliza rawPost(), que
+     * lanza en 5xx. Ver App\Provider\Etecsa\EtecsaCommunicationProvider::checkHealth()
+     * para el mapeo de status a ProviderPingResult.
+     *
+     * @return array{status: int, body: array<string, mixed>}
+     */
+    public function ping(Environment $env): array
+    {
+        return $this->rawGet($env, '/ping');
+    }
+
     // -------------------------------------------------------------------------
 
     private function post(Environment $env, string $path, array $body): array
     {
         return (array) json_decode($this->rawPost($env, $path, $body), true);
+    }
+
+    /**
+     * @return array{status: int, body: array<string, mixed>}
+     */
+    private function rawGet(Environment $env, string $path): array
+    {
+        $credentials = $this->credentialsResolver->get(CommunicationProviderEnum::ETECSA, $env->getType());
+        $baseUrl = $credentials['base_url'] ?? $env->getBasePath();
+        $url = $baseUrl . $path;
+        $start = microtime(true);
+
+        $apiKey = $credentials['api_key']
+            ?? $this->sysConfigRepo->findCachedValue('api.' . strtolower($env->getType()) . '.communications.key', mustBeActive: true);
+        $headers = ['Accept' => 'application/json'];
+        if ($apiKey !== null && $apiKey !== '') {
+            $headers['X-Api-Key'] = $apiKey;
+        }
+
+        try {
+            $response = $this->httpClient->request('GET', $url, [
+                'headers' => $headers,
+                'timeout' => 5,
+            ]);
+
+            // toArray(false): no lanza por el status HTTP (queremos leer el
+            // cuerpo también en 401/403/409/503), solo por fallos de
+            // transporte/decodificación reales.
+            $status = $response->getStatusCode();
+            $body = $response->toArray(false);
+
+            $this->etecsaLogger->info('ETECSA gateway ping', [
+                'path' => $path,
+                'env' => $env->getType(),
+                'ms' => round((microtime(true) - $start) * 1000),
+                'status' => $status,
+            ]);
+
+            return ['status' => $status, 'body' => $body];
+        } catch (TransportExceptionInterface | DecodingExceptionInterface $e) {
+            $this->etecsaLogger->error('ETECSA ping transport error', ['path' => $path, 'error' => $e->getMessage()]);
+            throw new MyCurrentException('ETECSA_GATEWAY_TIMEOUT', $e->getMessage(), 503);
+        }
     }
 
     private function rawPost(Environment $env, string $path, array $body): string

--- a/src/Service/Provider/ProviderAvailabilityService.php
+++ b/src/Service/Provider/ProviderAvailabilityService.php
@@ -1,0 +1,312 @@
+<?php
+
+namespace App\Service\Provider;
+
+use App\DTO\NotificationDraft;
+use App\Entity\ProviderAvailability;
+use App\Entity\User;
+use App\Enums\CommunicationProviderEnum;
+use App\Enums\NotificationAudienceEnum;
+use App\Enums\NotificationLevelEnum;
+use App\Enums\NotificationTypeEnum;
+use App\Enums\ProviderActionTypeEnum;
+use App\Exception\MyCurrentException;
+use App\Provider\Contract\ProviderPingResult;
+use App\Provider\ProviderCredentialsResolver;
+use App\Provider\ProviderRegistry;
+use App\Repository\ProviderAvailabilityRepository;
+use App\Repository\SysConfigRepository;
+use App\Service\CommunicationsDispatchService;
+use App\Service\NotificationCenterService;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Combina tres condiciones en AND para decidir si se puede despachar hacia
+ * un proveedor/entorno — ver el modelo completo en el plan de
+ * implementación (ping periódico de proveedores):
+ *
+ *   despachable = dispatchGloballyEnabled() && credentialsResolver->isEnabled() && auto_enabled
+ *
+ * Invariante de escritura: esta clase solo escribe auto_enabled (vía
+ * recordPing(), llamado por el ping). El interruptor MANUAL en sí sigue
+ * viviendo en sys_config (provider.{code}.{type}.active) y solo lo escribe
+ * setManual(), vía ProviderCredentialsAdminService — nunca al revés. Así el
+ * ping nunca invalida el tag de caché `sys_config` (que purgaría TODA la
+ * config cacheada de la app cada 15 min).
+ *
+ * No depende de CommunicationsDispatchService (solo referencia su constante
+ * CONFIG_KEY) a propósito: CommunicationsDispatchService::dispatchPending()
+ * necesita canDispatchTo(), así que una dependencia en el otro sentido
+ * formaría un ciclo. El reencolado de pendientes al recuperarse un proveedor
+ * lo dispara el llamador de recordPing() (ver App\Schedule\Task\PingProvidersTask)
+ * cuando esta devuelve true, no esta clase.
+ */
+class ProviderAvailabilityService
+{
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly ProviderAvailabilityRepository $repository,
+        private readonly ProviderCredentialsResolver $credentialsResolver,
+        private readonly ProviderCredentialsAdminService $credentialsAdminService,
+        private readonly ProviderRegistry $registry,
+        private readonly SysConfigRepository $sysConfigRepo,
+        private readonly NotificationCenterService $notificationCenter,
+        private readonly Security $security,
+        #[Autowire('@monolog.logger.provider')] private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public function canDispatchTo(?string $providerRaw, ?string $environmentType): bool
+    {
+        $provider = CommunicationProviderEnum::tryFrom($providerRaw ?? '') ?? CommunicationProviderEnum::ETECSA;
+        $environmentType = $environmentType ?? 'PROD';
+
+        if (!$this->dispatchGloballyEnabled()) {
+            return false;
+        }
+
+        // isEnabled() = isFullyConfigured() && isActive(): cubre a la vez el
+        // requisito de "no despachar si no está bien configurado" y el
+        // interruptor MANUAL.
+        if (!$this->credentialsResolver->isEnabled($provider, $environmentType)) {
+            return false;
+        }
+
+        $row = $this->repository->findOneByProviderAndType($provider->value, $environmentType);
+
+        return $row === null || $row->isAutoEnabled();
+    }
+
+    /**
+     * Registra el resultado de un ping y aplica la transición AUTO
+     * correspondiente. Devuelve true si, con este ping, el proveedor pasó a
+     * ser despachable de verdad (recuperación real: también manual y global
+     * están en verde) — el llamador debe entonces reencolar sus pendientes
+     * (CommunicationsDispatchService::redispatchPendingFor()).
+     */
+    public function recordPing(CommunicationProviderEnum $provider, string $environmentType, ProviderPingResult $result): bool
+    {
+        $row = $this->repository->findOneByProviderAndType($provider->value, $environmentType);
+        if ($row === null) {
+            $row = (new ProviderAvailability())
+                ->setProvider($provider->value)
+                ->setEnvironmentType($environmentType);
+            $this->em->persist($row);
+        }
+
+        $row->setLastPingAt($result->checkedAt)
+            ->setLastPingSuccess($result->inconclusive ? null : $result->available)
+            ->setLastPingLatencyMs($result->latencyMs)
+            ->setLastPingError($result->error)
+            ->setLastPingDetails($result->details === [] ? null : $result->details)
+            ->touch();
+
+        if ($result->inconclusive) {
+            // Nuestra credencial/config está mal, no el proveedor: no se
+            // toca auto_enabled — apagarlo por esto sería un falso positivo.
+            $this->logger->error('Ping de proveedor inconcluso', [
+                'provider' => $provider->value,
+                'environmentType' => $environmentType,
+                'error' => $result->error,
+            ]);
+            $this->notifyAdmins(
+                NotificationTypeEnum::CUSTOM,
+                NotificationLevelEnum::WARNING,
+                sprintf('Ping de %s (%s) inconcluso — revisar credenciales', $provider->value, $environmentType),
+                $result->error,
+                $provider,
+                $environmentType,
+            );
+
+            $this->flushSafely($provider, $environmentType);
+
+            return false;
+        }
+
+        $wasAutoEnabled = $row->isAutoEnabled();
+        $justRecovered = false;
+
+        if (!$result->available && $wasAutoEnabled) {
+            $row->setAutoEnabled(false)
+                ->setLastActionType(ProviderActionTypeEnum::AUTO)
+                ->setLastActionBy(null)
+                ->setLastActionAt($result->checkedAt)
+                ->setLastActionReason($result->error);
+
+            $this->logger->error('Proveedor deshabilitado automáticamente: ping fallido', [
+                'provider' => $provider->value,
+                'environmentType' => $environmentType,
+                'error' => $result->error,
+            ]);
+            $this->notifyAdmins(
+                NotificationTypeEnum::PROVIDER_UNAVAILABLE,
+                NotificationLevelEnum::CRITICAL,
+                sprintf('Proveedor %s (%s) deshabilitado automáticamente', $provider->value, $environmentType),
+                $result->error,
+                $provider,
+                $environmentType,
+            );
+        } elseif ($result->available && !$wasAutoEnabled) {
+            $row->setAutoEnabled(true)
+                ->setLastActionType(ProviderActionTypeEnum::AUTO)
+                ->setLastActionBy(null)
+                ->setLastActionAt($result->checkedAt)
+                ->setLastActionReason('Ping recuperado');
+
+            $this->notifyAdmins(
+                NotificationTypeEnum::PROVIDER_RECOVERED,
+                NotificationLevelEnum::SUCCESS,
+                sprintf('Proveedor %s (%s) recuperado', $provider->value, $environmentType),
+                null,
+                $provider,
+                $environmentType,
+            );
+
+            // Solo cuenta como recuperación real de despacho si con esto
+            // queda despachable (manual y global también en verde) — si un
+            // admin lo apagó a mano, AUTO puede volver a true sin que se
+            // reencole nada (requisito 4).
+            $justRecovered = $this->canDispatchTo($provider->value, $environmentType);
+        }
+
+        if (!$this->flushSafely($provider, $environmentType)) {
+            return false;
+        }
+
+        return $justRecovered;
+    }
+
+    /**
+     * Interruptor MANUAL, auditado. Un enable resetea AUTO (el siguiente
+     * ping lo volverá a apagar si de verdad sigue caído) para que un falso
+     * positivo del ping nunca le impida a un admin encender el proveedor —
+     * un disable nunca toca AUTO.
+     */
+    public function setManual(CommunicationProviderEnum $provider, string $environmentType, bool $active, ?string $reason = null): void
+    {
+        if ($active && !$this->credentialsResolver->isFullyConfigured($provider, $environmentType)) {
+            throw new MyCurrentException(
+                'PROVIDER_NOT_CONFIGURED',
+                'El proveedor no tiene credenciales completas para este entorno; no se puede activar el despacho.',
+                Response::HTTP_CONFLICT,
+            );
+        }
+
+        $this->credentialsAdminService->setActive($provider, $environmentType, $active);
+
+        $row = $this->repository->findOneByProviderAndType($provider->value, $environmentType);
+        if ($row === null) {
+            $row = (new ProviderAvailability())
+                ->setProvider($provider->value)
+                ->setEnvironmentType($environmentType);
+            $this->em->persist($row);
+        }
+
+        $user = $this->security->getUser();
+        $row->setLastActionType(ProviderActionTypeEnum::MANUAL)
+            ->setLastActionBy($user instanceof User ? $user : null)
+            ->setLastActionAt(new \DateTimeImmutable('now'))
+            ->setLastActionReason($reason)
+            ->touch();
+
+        if ($active) {
+            $row->setAutoEnabled(true);
+        }
+
+        $this->em->flush();
+    }
+
+    /**
+     * @return list<array{
+     *     provider: string, environmentType: string, configured: bool,
+     *     manualActive: bool, autoEnabled: bool, effective: bool,
+     *     lastActionType: ?string, lastActionBy: ?string, lastActionAt: ?string, lastActionReason: ?string,
+     *     lastPingAt: ?string, lastPingSuccess: ?bool, lastPingLatencyMs: ?int, lastPingError: ?string,
+     * }>
+     */
+    public function statusMatrix(): array
+    {
+        $matrix = [];
+        foreach ($this->registry->registered() as $provider) {
+            foreach (['TEST', 'PROD'] as $environmentType) {
+                $row = $this->repository->findOneByProviderAndType($provider->value, $environmentType);
+
+                $matrix[] = [
+                    'provider' => $provider->value,
+                    'environmentType' => $environmentType,
+                    'configured' => $this->credentialsResolver->isFullyConfigured($provider, $environmentType),
+                    'manualActive' => $this->credentialsResolver->isActive($provider, $environmentType),
+                    'autoEnabled' => $row?->isAutoEnabled() ?? true,
+                    'effective' => $this->canDispatchTo($provider->value, $environmentType),
+                    'lastActionType' => $row?->getLastActionType()?->value,
+                    'lastActionBy' => $row?->getLastActionBy()?->getUserIdentifier(),
+                    'lastActionAt' => $row?->getLastActionAt()?->format(DATE_ATOM),
+                    'lastActionReason' => $row?->getLastActionReason(),
+                    'lastPingAt' => $row?->getLastPingAt()?->format(DATE_ATOM),
+                    'lastPingSuccess' => $row?->isLastPingSuccess(),
+                    'lastPingLatencyMs' => $row?->getLastPingLatencyMs(),
+                    'lastPingError' => $row?->getLastPingError(),
+                ];
+            }
+        }
+
+        return $matrix;
+    }
+
+    private function dispatchGloballyEnabled(): bool
+    {
+        return $this->sysConfigRepo->findCachedValue(CommunicationsDispatchService::CONFIG_KEY) !== '0';
+    }
+
+    /**
+     * Protege el upsert contra la carrera entre el ping periódico y un ping
+     * forzado desde el dashboard corriendo casi a la vez para el mismo
+     * (provider, environmentType) — el índice único de la tabla la
+     * convertiría en una excepción de flush(), no algo que deba tumbar el
+     * ciclo de ping completo.
+     */
+    private function flushSafely(CommunicationProviderEnum $provider, string $environmentType): bool
+    {
+        try {
+            $this->em->flush();
+
+            return true;
+        } catch (UniqueConstraintViolationException) {
+            $this->em->clear();
+            $this->logger->warning('Carrera al persistir ProviderAvailability, se omite este ciclo', [
+                'provider' => $provider->value,
+                'environmentType' => $environmentType,
+            ]);
+
+            return false;
+        }
+    }
+
+    private function notifyAdmins(
+        NotificationTypeEnum $type,
+        NotificationLevelEnum $level,
+        string $title,
+        ?string $body,
+        CommunicationProviderEnum $provider,
+        string $environmentType,
+    ): void {
+        $this->notificationCenter->bumpGroup(
+            groupKey: sprintf('provider_availability:%s:%s', $provider->value, $environmentType),
+            audience: NotificationAudienceEnum::ROLE,
+            draft: new NotificationDraft(
+                type: $type,
+                title: $title,
+                level: $level,
+                body: $body,
+                link: '/providers/availability',
+                data: ['provider' => $provider->value, 'environmentType' => $environmentType],
+            ),
+            targetRole: 'ROLE_ADMIN',
+        );
+    }
+}

--- a/src/Service/Provider/ProviderConnectionTestService.php
+++ b/src/Service/Provider/ProviderConnectionTestService.php
@@ -3,22 +3,19 @@
 namespace App\Service\Provider;
 
 use App\Enums\CommunicationProviderEnum;
-use App\Provider\Contract\ProviderBalanceInterface;
-use App\Provider\ProviderContextFactory;
-use App\Provider\ProviderRegistry;
 
 /**
  * Prueba en vivo, bajo demanda, si las credenciales configuradas para un
- * proveedor/entorno funcionan — consultando el saldo de plataforma, la
- * operación de solo-lectura más barata disponible en todos los proveedores.
+ * proveedor/entorno funcionan. Delega el sondeo en ProviderPingService (la
+ * misma ruta que usa el ping periódico — un solo comportamiento) y adapta su
+ * ProviderPingResult a la forma de retorno histórica de este servicio.
  * No hay circuit breaker ni estado persistido: es una señal honesta del
  * instante en que se pulsa el botón, no un histórico de fiabilidad.
  */
 class ProviderConnectionTestService
 {
     public function __construct(
-        private readonly ProviderRegistry $providerRegistry,
-        private readonly ProviderContextFactory $contextFactory,
+        private readonly ProviderPingService $pingService,
     ) {
     }
 
@@ -27,20 +24,19 @@ class ProviderConnectionTestService
      */
     public function test(CommunicationProviderEnum $provider, string $environmentType): array
     {
-        try {
-            $adapter = $this->providerRegistry->getFor($provider, ProviderBalanceInterface::class);
-            $result = $adapter->getPlatformBalance($this->contextFactory->forEnvironmentType($provider, $environmentType));
+        $result = $this->pingService->ping($provider, $environmentType);
 
+        if ($result->available) {
             return [
                 'success' => true,
-                'amounts' => $result->amounts,
-                'fetchedAt' => $result->fetchedAt->format(DATE_ATOM),
-            ];
-        } catch (\Throwable $e) {
-            return [
-                'success' => false,
-                'message' => $e->getMessage(),
+                'amounts' => $result->details['amounts'] ?? [],
+                'fetchedAt' => $result->details['fetchedAt'] ?? $result->checkedAt->format(DATE_ATOM),
             ];
         }
+
+        return [
+            'success' => false,
+            'message' => $result->error ?? 'El proveedor no respondió',
+        ];
     }
 }

--- a/src/Service/Provider/ProviderPingService.php
+++ b/src/Service/Provider/ProviderPingService.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Service\Provider;
+
+use App\Enums\CommunicationProviderEnum;
+use App\Provider\Contract\ProviderBalanceInterface;
+use App\Provider\Contract\ProviderHealthCheckInterface;
+use App\Provider\Contract\ProviderPingResult;
+use App\Provider\ProviderContextFactory;
+use App\Provider\ProviderCredentialsResolver;
+use App\Provider\ProviderRegistry;
+
+/**
+ * Sondeo único de disponibilidad de un proveedor, usado tanto por el ping
+ * periódico (App\Schedule\Task\PingProvidersTask) como por el botón de
+ * "probar conexión" del dashboard (App\Service\Provider\ProviderConnectionTestService).
+ * Una sola ruta de sondeo, un solo comportamiento.
+ *
+ * Orden de preferencia: si el adaptador tiene un ping dedicado
+ * (ProviderHealthCheckInterface) se usa ese; si no, getPlatformBalance() como
+ * prueba de vida barata; si tampoco, inconclusive (no hay forma de sondear).
+ */
+class ProviderPingService
+{
+    public function __construct(
+        private readonly ProviderRegistry $registry,
+        private readonly ProviderCredentialsResolver $credentialsResolver,
+        private readonly ProviderContextFactory $contextFactory,
+    ) {
+    }
+
+    public function ping(CommunicationProviderEnum $provider, string $environmentType): ProviderPingResult
+    {
+        try {
+            if (!$this->credentialsResolver->isFullyConfigured($provider, $environmentType)) {
+                return ProviderPingResult::inconclusive('Proveedor sin credenciales completas para este entorno');
+            }
+
+            $adapter = $this->registry->get($provider);
+            $context = $this->contextFactory->forEnvironmentType($provider, $environmentType);
+
+            if ($adapter instanceof ProviderHealthCheckInterface) {
+                return $adapter->checkHealth($context);
+            }
+
+            if ($adapter instanceof ProviderBalanceInterface) {
+                $start = microtime(true);
+                $balance = $adapter->getPlatformBalance($context);
+
+                return ProviderPingResult::available(
+                    (int) round((microtime(true) - $start) * 1000),
+                    ['amounts' => $balance->amounts, 'fetchedAt' => $balance->fetchedAt->format(DATE_ATOM)],
+                );
+            }
+        } catch (\Throwable $e) {
+            return ProviderPingResult::unavailable($e->getMessage());
+        }
+
+        return ProviderPingResult::inconclusive('Proveedor sin ping ni prueba de saldo disponibles');
+    }
+}

--- a/tests/Controller/DashboardProviderRoutingControllerTest.php
+++ b/tests/Controller/DashboardProviderRoutingControllerTest.php
@@ -21,6 +21,7 @@ use App\Repository\ClientProviderRoutingRepository;
 use App\Repository\CurrencyExchangeRateRepository;
 use App\Repository\SysConfigRepository;
 use App\Service\Provider\CurrencyExchangeRateSyncService;
+use App\Service\Provider\ProviderAvailabilityService;
 use App\Service\Provider\ProviderConnectionTestService;
 use App\Service\Provider\ProviderCredentialsAdminService;
 use App\Service\ProviderRoutingAdminService;
@@ -44,6 +45,7 @@ class DashboardProviderRoutingControllerTest extends TestCase
     private CurrencyExchangeRateRepository&MockObject $exchangeRateRepo;
     private ProviderCredentialsAdminService&MockObject $credentialsAdminService;
     private ProviderConnectionTestService&MockObject $connectionTestService;
+    private ProviderAvailabilityService&MockObject $availabilityService;
     private DashboardProviderRoutingController $controller;
 
     protected function setUp(): void
@@ -55,6 +57,7 @@ class DashboardProviderRoutingControllerTest extends TestCase
         $this->exchangeRateRepo = $this->createMock(CurrencyExchangeRateRepository::class);
         $this->credentialsAdminService = $this->createMock(ProviderCredentialsAdminService::class);
         $this->connectionTestService = $this->createMock(ProviderConnectionTestService::class);
+        $this->availabilityService = $this->createMock(ProviderAvailabilityService::class);
 
         $etecsa = $this->createMock(CommunicationProviderInterface::class);
         $etecsa->method('getCode')->willReturn(CommunicationProviderEnum::ETECSA);
@@ -72,6 +75,7 @@ class DashboardProviderRoutingControllerTest extends TestCase
             $this->exchangeRateRepo,
             $this->credentialsAdminService,
             $this->connectionTestService,
+            $this->availabilityService,
         );
 
         $container = $this->createMock(ContainerInterface::class);
@@ -489,8 +493,8 @@ class DashboardProviderRoutingControllerTest extends TestCase
 
     public function testSetActiveDelegatesToServiceAndReturnsUpdatedStatus(): void
     {
-        $this->credentialsAdminService->expects($this->once())
-            ->method('setActive')
+        $this->availabilityService->expects($this->once())
+            ->method('setManual')
             ->with(CommunicationProviderEnum::DTONE, 'PROD', false);
         $this->credentialsAdminService->method('getStatus')->willReturn([
             'test' => [],

--- a/tests/Functional/Provider/DispatchPendingSkipsUnavailableFunctionalTest.php
+++ b/tests/Functional/Provider/DispatchPendingSkipsUnavailableFunctionalTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Tests\Functional\Provider;
+
+use App\Entity\CommunicationSaleRecharge;
+use App\Enums\CommunicationProviderEnum;
+use App\Provider\ProviderResolver;
+use App\Service\CommunicationSaleService;
+use App\Service\CommunicationsDispatchService;
+
+/**
+ * @covers \App\Service\CommunicationsDispatchService::dispatchPending
+ *
+ * Contra Postgres real: de dos ventas admitidas y diferidas (dispatch global
+ * apagado al crearlas), dispatchPending() debe encolar solo la del proveedor
+ * despachable y reportar la otra en `skipped`, sin tocar su estado.
+ */
+class DispatchPendingSkipsUnavailableFunctionalTest extends ProviderFunctionalTestCase
+{
+    private function saleService(): CommunicationSaleService
+    {
+        return self::getContainer()->get(CommunicationSaleService::class);
+    }
+
+    private function dispatchService(): CommunicationsDispatchService
+    {
+        return self::getContainer()->get(CommunicationsDispatchService::class);
+    }
+
+    private function rechargeRequest(int $packageId, string $suffix): CommunicationSaleRecharge
+    {
+        return (new CommunicationSaleRecharge())
+            ->setPackageId($packageId)
+            ->setClientTransactionId('functional-dispatch-skip-' . $suffix)
+            ->setPhoneNumber('5550000000');
+    }
+
+    public function testSkipsSaleOfUnconfiguredProviderAndDispatchesTheOther(): void
+    {
+        // Credenciales de ETECSA completas — despachable. DTOne se deja sin
+        // configurar a propósito: ProviderCredentialsResolver::isFullyConfigured()
+        // debe dar false y dispatchPending() debe saltarla (requisito: no
+        // despachar hacia un proveedor mal configurado).
+        $this->setSysConfig('provider.etecsa.test.base_url', 'https://etecsa.example.test');
+        $this->setSysConfig('provider.etecsa.test.api_key', 'functional-key');
+        $this->setSysConfig(ProviderResolver::ROUTING_ENABLED_KEY, '1');
+
+        // Dispatch global apagado al admitir: ambas ventas quedan PENDING/CREATED
+        // sin encolar, que es justo el estado que dispatchPending() recorre.
+        $this->setSysConfig('communications.dispatch.enabled', '0');
+
+        $client = $this->createClient();
+        $environment = $this->createEnvironment();
+        $account = $this->createAccount($client, $environment);
+        // uniq_cpr_scope es único por (client, environment, saleType) —
+        // saleType distinto solo para poder tener dos filas activas para el
+        // mismo cliente sin chocar; findActiveProviderCodesForClient() no
+        // filtra por scope, así que ambas cuentan igual como "permitido".
+        $this->createRouting($client, CommunicationProviderEnum::ETECSA->value);
+        $this->createRouting($client, CommunicationProviderEnum::DTONE->value, saleType: 'recharge');
+
+        $etecsaPackage = $this->createSellablePackage($environment, $account, CommunicationProviderEnum::ETECSA->value, amount: 0.0);
+        $dtonePackage = $this->createSellablePackage($environment, $account, CommunicationProviderEnum::DTONE->value, amount: 0.0);
+
+        $this->authenticateAs($account);
+
+        $etecsaSale = $this->saleService()->processRecharge($this->rechargeRequest($etecsaPackage->getId(), 'etecsa'));
+        $dtoneSale = $this->saleService()->processRecharge($this->rechargeRequest($dtonePackage->getId(), 'dtone'));
+
+        $this->setSysConfig('communications.dispatch.enabled', '1');
+
+        $result = $this->dispatchService()->dispatchPending();
+
+        $this->assertSame(1, $result['recharges']);
+        $this->assertSame(1, $result['skipped']['DTONE|TEST'] ?? null);
+        $this->assertArrayNotHasKey('ETECSA|TEST', $result['skipped']);
+
+        $this->em->refresh($dtoneSale);
+        $this->assertSame(\App\Enums\CommunicationStateEnum::CREATED->value, $dtoneSale->getStateProcess());
+    }
+}

--- a/tests/Functional/Provider/ProviderAvailabilityServiceFunctionalTest.php
+++ b/tests/Functional/Provider/ProviderAvailabilityServiceFunctionalTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Tests\Functional\Provider;
+
+use App\Enums\CommunicationProviderEnum;
+use App\Enums\ProviderActionTypeEnum;
+use App\Exception\MyCurrentException;
+use App\Provider\Contract\ProviderPingResult;
+use App\Repository\ProviderAvailabilityRepository;
+use App\Service\Provider\ProviderAvailabilityService;
+
+/**
+ * @covers \App\Service\Provider\ProviderAvailabilityService
+ *
+ * Contra Postgres real: verifica que el AND de tres condiciones (global,
+ * credenciales+manual, auto del ping) y la auditoría de setManual() escriben
+ * y leen de verdad, no solo en dobles (ver ProviderAvailabilityServiceTest,
+ * unitario, para la matriz de casos completa con mocks).
+ */
+class ProviderAvailabilityServiceFunctionalTest extends ProviderFunctionalTestCase
+{
+    private function service(): ProviderAvailabilityService
+    {
+        return self::getContainer()->get(ProviderAvailabilityService::class);
+    }
+
+    private function availabilityRepo(): ProviderAvailabilityRepository
+    {
+        return self::getContainer()->get(ProviderAvailabilityRepository::class);
+    }
+
+    private function configureEtecsaTest(): void
+    {
+        $this->setSysConfig('provider.etecsa.test.base_url', 'https://etecsa.example.test');
+        $this->setSysConfig('provider.etecsa.test.api_key', 'functional-key');
+    }
+
+    public function testSetManualRejectsActivatingUnconfiguredProvider(): void
+    {
+        // Fuerza explícitamente "sin configurar" (en vez de confiar en la
+        // ausencia de la fila): cache.sys_config es un caché de proceso, no
+        // ligado a la transacción/rollback de cada test, así que un valor
+        // cacheado por otro test de esta clase podría sobrevivir aquí.
+        $this->setSysConfig('provider.etecsa.test.base_url', '');
+        $this->setSysConfig('provider.etecsa.test.api_key', '');
+
+        $admin = $this->createAdminUser();
+        $this->authenticateAsAdmin($admin);
+
+        try {
+            $this->service()->setManual(CommunicationProviderEnum::ETECSA, 'TEST', true);
+            $this->fail('Se esperaba MyCurrentException por proveedor no configurado.');
+        } catch (MyCurrentException $e) {
+            $this->assertSame('PROVIDER_NOT_CONFIGURED', $e->getCodeWork());
+            $this->assertSame(409, $e->getCode());
+        }
+    }
+
+    public function testSetManualEnablePersistsAuditedRow(): void
+    {
+        $this->configureEtecsaTest();
+        $admin = $this->createAdminUser();
+        $this->authenticateAsAdmin($admin);
+
+        $this->service()->setManual(CommunicationProviderEnum::ETECSA, 'TEST', true, 'reactivación funcional');
+
+        $row = $this->availabilityRepo()->findOneByProviderAndType('ETECSA', 'TEST');
+
+        $this->assertNotNull($row);
+        $this->assertTrue($row->isAutoEnabled());
+        $this->assertSame(ProviderActionTypeEnum::MANUAL, $row->getLastActionType());
+        $this->assertSame($admin->getId(), $row->getLastActionBy()?->getId());
+        $this->assertSame('reactivación funcional', $row->getLastActionReason());
+
+        $this->assertTrue($this->service()->canDispatchTo('ETECSA', 'TEST'));
+    }
+
+    public function testCanDispatchToFalseWhenManuallyDisabled(): void
+    {
+        $this->configureEtecsaTest();
+        $admin = $this->createAdminUser();
+        $this->authenticateAsAdmin($admin);
+
+        $this->service()->setManual(CommunicationProviderEnum::ETECSA, 'TEST', false);
+
+        $this->assertFalse($this->service()->canDispatchTo('ETECSA', 'TEST'));
+    }
+
+    public function testRecordPingFailureDisablesAutoAndBlocksDispatch(): void
+    {
+        $this->configureEtecsaTest();
+
+        $this->service()->recordPing(CommunicationProviderEnum::ETECSA, 'TEST', ProviderPingResult::unavailable('timeout'));
+
+        $row = $this->availabilityRepo()->findOneByProviderAndType('ETECSA', 'TEST');
+        $this->assertNotNull($row);
+        $this->assertFalse($row->isAutoEnabled());
+        $this->assertSame(ProviderActionTypeEnum::AUTO, $row->getLastActionType());
+        $this->assertFalse($this->service()->canDispatchTo('ETECSA', 'TEST'));
+    }
+
+    public function testRecordPingRecoveryReturnsTrueOnlyWhenAlsoManuallyEnabled(): void
+    {
+        $this->configureEtecsaTest();
+
+        // Cae por ping...
+        $this->service()->recordPing(CommunicationProviderEnum::ETECSA, 'TEST', ProviderPingResult::unavailable('timeout'));
+        $this->assertFalse($this->service()->canDispatchTo('ETECSA', 'TEST'));
+
+        // ...y se recupera: con MANUAL en su default (activo), sí queda despachable.
+        $justRecovered = $this->service()->recordPing(CommunicationProviderEnum::ETECSA, 'TEST', ProviderPingResult::available(50));
+
+        $this->assertTrue($justRecovered);
+        $this->assertTrue($this->service()->canDispatchTo('ETECSA', 'TEST'));
+    }
+}

--- a/tests/Functional/Provider/ProviderFunctionalTestCase.php
+++ b/tests/Functional/Provider/ProviderFunctionalTestCase.php
@@ -9,6 +9,7 @@ use App\Entity\CommunicationClientPackage;
 use App\Entity\CommunicationPricePackage;
 use App\Entity\CommunicationProduct;
 use App\Entity\Environment;
+use App\Entity\User;
 use App\Tests\Functional\FunctionalTestCase;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -24,6 +25,37 @@ abstract class ProviderFunctionalTestCase extends FunctionalTestCase
     {
         $tokenStorage = self::getContainer()->get(TokenStorageInterface::class);
         $tokenStorage->setToken(new UsernamePasswordToken($account, 'main', $account->getRoles()));
+    }
+
+    /**
+     * Usuario admin del dashboard (distinto de Account, que autentica a
+     * clientes de la API móvil) — necesario para probar auditoría de
+     * acciones MANUAL (ProviderAvailabilityService::setManual()).
+     */
+    protected function createAdminUser(): User
+    {
+        static $counter = 0;
+        $counter++;
+
+        $user = (new User())
+            ->setEmail("admin-func-{$counter}@example.test")
+            ->setPassword('irrelevant-hash')
+            ->setFirstName('Admin')
+            ->setLastName("Funcional {$counter}")
+            ->setRoles(['ROLE_SUPER_ADMIN'])
+            ->setIsActive(true)
+            ->setIsCheckValidation(true);
+
+        $this->em->persist($user);
+        $this->em->flush();
+
+        return $user;
+    }
+
+    protected function authenticateAsAdmin(User $user): void
+    {
+        $tokenStorage = self::getContainer()->get(TokenStorageInterface::class);
+        $tokenStorage->setToken(new UsernamePasswordToken($user, 'main', $user->getRoles()));
     }
 
     protected function createClient(bool $isActive = true): Client

--- a/tests/Provider/Csq/CsqCommunicationProviderCheckHealthTest.php
+++ b/tests/Provider/Csq/CsqCommunicationProviderCheckHealthTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Tests\Provider\Csq;
+
+use App\Enums\CommunicationProviderEnum;
+use App\Exception\MyCurrentException;
+use App\Provider\Contract\ProviderContext;
+use App\Provider\Csq\CsqCommunicationProvider;
+use App\Provider\Csq\CsqHttpClient;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \App\Provider\Csq\CsqCommunicationProvider::checkHealth
+ */
+class CsqCommunicationProviderCheckHealthTest extends TestCase
+{
+    private CsqHttpClient&MockObject $client;
+    private CsqCommunicationProvider $provider;
+
+    protected function setUp(): void
+    {
+        $this->client = $this->createMock(CsqHttpClient::class);
+        $this->provider = new CsqCommunicationProvider($this->client);
+    }
+
+    private function context(): ProviderContext
+    {
+        return new ProviderContext(provider: CommunicationProviderEnum::CSQ, environmentType: 'TEST');
+    }
+
+    public function testAvailableWhenPingSucceeds(): void
+    {
+        $this->client->expects($this->once())->method('ping')->with($this->context())->willReturn(['rc' => 0]);
+
+        $result = $this->provider->checkHealth($this->context());
+
+        $this->assertTrue($result->available);
+        $this->assertFalse($result->inconclusive);
+        $this->assertIsInt($result->latencyMs);
+    }
+
+    public function testUnavailableWhenPingThrows(): void
+    {
+        $this->client->method('ping')->willThrowException(new MyCurrentException('CSQ_REQUEST_FAILED', 'boom', 502));
+
+        $result = $this->provider->checkHealth($this->context());
+
+        $this->assertFalse($result->available);
+        $this->assertFalse($result->inconclusive);
+        $this->assertSame('boom', $result->error);
+    }
+}

--- a/tests/Provider/Etecsa/EtecsaCommunicationProviderCheckHealthTest.php
+++ b/tests/Provider/Etecsa/EtecsaCommunicationProviderCheckHealthTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Tests\Provider\Etecsa;
+
+use App\Entity\Environment;
+use App\Enums\CommunicationProviderEnum;
+use App\Exception\MyCurrentException;
+use App\Provider\Contract\ProviderContext;
+use App\Provider\Etecsa\EtecsaCommunicationProvider;
+use App\Provider\Etecsa\EtecsaStatusMapper;
+use App\Repository\EnvironmentRepository;
+use App\Service\Etecsa\EtecsaGatewayClient;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \App\Provider\Etecsa\EtecsaCommunicationProvider::checkHealth
+ */
+class EtecsaCommunicationProviderCheckHealthTest extends TestCase
+{
+    private EtecsaGatewayClient&MockObject $client;
+    private EtecsaCommunicationProvider $provider;
+
+    protected function setUp(): void
+    {
+        $this->client = $this->createMock(EtecsaGatewayClient::class);
+
+        $environmentRepository = $this->createMock(EnvironmentRepository::class);
+        $environmentRepository->method('findOneBy')->willReturn((new Environment())->setType('TEST'));
+
+        // EtecsaStatusMapper es `final` y checkHealth() no la usa: se
+        // instancia real en vez de doblarla.
+        $this->provider = new EtecsaCommunicationProvider(
+            $this->client,
+            new EtecsaStatusMapper(),
+            $environmentRepository,
+        );
+    }
+
+    private function context(): ProviderContext
+    {
+        return new ProviderContext(provider: CommunicationProviderEnum::ETECSA, environmentType: 'TEST');
+    }
+
+    public function testMaps200ToAvailable(): void
+    {
+        $this->client->method('ping')->willReturn(['status' => 200, 'body' => ['available' => true, 'latencyMs' => 88]]);
+
+        $result = $this->provider->checkHealth($this->context());
+
+        $this->assertTrue($result->available);
+        $this->assertFalse($result->inconclusive);
+        $this->assertSame(88, $result->latencyMs);
+    }
+
+    public function testMaps503ToUnavailable(): void
+    {
+        $this->client->method('ping')->willReturn(['status' => 503, 'body' => ['available' => false, 'error' => 'breaker open']]);
+
+        $result = $this->provider->checkHealth($this->context());
+
+        $this->assertFalse($result->available);
+        $this->assertFalse($result->inconclusive);
+        $this->assertSame('breaker open', $result->error);
+    }
+
+    public function testMaps403ToInconclusive(): void
+    {
+        $this->client->method('ping')->willReturn(['status' => 403, 'body' => ['error' => 'missing scope']]);
+
+        $result = $this->provider->checkHealth($this->context());
+
+        $this->assertTrue($result->inconclusive);
+        $this->assertFalse($result->available);
+    }
+
+    public function testTransportExceptionMapsToUnavailable(): void
+    {
+        $this->client->method('ping')->willThrowException(new MyCurrentException('ETECSA_GATEWAY_TIMEOUT', 'timeout', 503));
+
+        $result = $this->provider->checkHealth($this->context());
+
+        $this->assertFalse($result->available);
+        $this->assertFalse($result->inconclusive);
+        $this->assertSame('timeout', $result->error);
+    }
+}

--- a/tests/Schedule/Task/PingProvidersTaskTest.php
+++ b/tests/Schedule/Task/PingProvidersTaskTest.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace App\Tests\Schedule\Task;
+
+use App\Enums\CommunicationProviderEnum;
+use App\Provider\Contract\CommunicationProviderInterface;
+use App\Provider\Contract\ProviderConfigField;
+use App\Provider\Contract\ProviderPingResult;
+use App\Provider\ProviderCredentialsResolver;
+use App\Provider\ProviderRegistry;
+use App\Repository\SysConfigRepository;
+use App\Schedule\Task\PingProvidersTask;
+use App\Service\CommunicationsDispatchService;
+use App\Service\Provider\ProviderAvailabilityService;
+use App\Service\Provider\ProviderPingService;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * @covers \App\Schedule\Task\PingProvidersTask
+ */
+class PingProvidersTaskTest extends TestCase
+{
+    // ProviderRegistry y ProviderCredentialsResolver son `final`: se
+    // construyen reales, con adaptadores fake de esquema vacío — así
+    // isFullyConfigured() siempre da true sin necesitar tocar sysConfigRepo.
+    private function fakeAdapter(CommunicationProviderEnum $code): CommunicationProviderInterface
+    {
+        return new class($code) implements CommunicationProviderInterface {
+            public function __construct(private readonly CommunicationProviderEnum $code)
+            {
+            }
+
+            public function getCode(): CommunicationProviderEnum
+            {
+                return $this->code;
+            }
+
+            public function getCapabilities(): array
+            {
+                return [];
+            }
+
+            public function getConfigSchema(): array
+            {
+                return [];
+            }
+        };
+    }
+
+    public function testOneProviderThrowingDoesNotStopTheOthersFromBeingPinged(): void
+    {
+        $registry = new ProviderRegistry([
+            $this->fakeAdapter(CommunicationProviderEnum::ETECSA),
+            $this->fakeAdapter(CommunicationProviderEnum::CSQ),
+        ]);
+        $credentialsResolver = new ProviderCredentialsResolver($this->createMock(SysConfigRepository::class), $registry);
+
+        $pingService = $this->createMock(ProviderPingService::class);
+        $pingService->expects($this->exactly(4)) // 2 proveedores x 2 entornos
+            ->method('ping')
+            ->willReturnCallback(function (CommunicationProviderEnum $provider) {
+                if ($provider === CommunicationProviderEnum::ETECSA) {
+                    throw new \RuntimeException('fallo inesperado de red');
+                }
+
+                return ProviderPingResult::available(10);
+            });
+
+        $availabilityService = $this->createMock(ProviderAvailabilityService::class);
+        $availabilityService->method('recordPing')->willReturn(false);
+        // Solo CSQ llega a recordPing() en cada entorno: ETECSA lanza antes.
+        $availabilityService->expects($this->exactly(2))->method('recordPing');
+
+        $dispatchService = $this->createMock(CommunicationsDispatchService::class);
+        $dispatchService->expects($this->never())->method('redispatchPendingFor');
+
+        $task = new PingProvidersTask(
+            $registry,
+            $credentialsResolver,
+            $pingService,
+            $availabilityService,
+            $dispatchService,
+            new NullLogger(),
+        );
+
+        // No debe propagar la excepción de ETECSA.
+        $task();
+    }
+
+    public function testRedispatchesPendingOnlyWhenRecordPingReportsRecovery(): void
+    {
+        $registry = new ProviderRegistry([$this->fakeAdapter(CommunicationProviderEnum::CSQ)]);
+        $credentialsResolver = new ProviderCredentialsResolver($this->createMock(SysConfigRepository::class), $registry);
+
+        $pingService = $this->createMock(ProviderPingService::class);
+        $pingService->method('ping')->willReturn(ProviderPingResult::available(5));
+
+        $availabilityService = $this->createMock(ProviderAvailabilityService::class);
+        $availabilityService->method('recordPing')->willReturnOnConsecutiveCalls(true, false);
+
+        $dispatchService = $this->createMock(CommunicationsDispatchService::class);
+        $dispatchService->expects($this->once())
+            ->method('redispatchPendingFor')
+            ->with('CSQ', $this->isType('string'));
+
+        $task = new PingProvidersTask($registry, $credentialsResolver, $pingService, $availabilityService, $dispatchService, new NullLogger());
+
+        $task();
+    }
+
+    public function testSkipsProvidersWithoutFullCredentials(): void
+    {
+        $adapter = new class implements CommunicationProviderInterface {
+            public function getCode(): CommunicationProviderEnum
+            {
+                return CommunicationProviderEnum::CSQ;
+            }
+
+            public function getCapabilities(): array
+            {
+                return [];
+            }
+
+            public function getConfigSchema(): array
+            {
+                return [new ProviderConfigField('token', 'Token', required: true, secret: false)];
+            }
+        };
+        $registry = new ProviderRegistry([$adapter]);
+        // sysConfigRepo mockeado sin ningún valor configurado: isFullyConfigured() da false para ambos entornos.
+        $credentialsResolver = new ProviderCredentialsResolver($this->createMock(SysConfigRepository::class), $registry);
+
+        $pingService = $this->createMock(ProviderPingService::class);
+        $pingService->expects($this->never())->method('ping');
+
+        $availabilityService = $this->createMock(ProviderAvailabilityService::class);
+        $availabilityService->expects($this->never())->method('recordPing');
+
+        $dispatchService = $this->createMock(CommunicationsDispatchService::class);
+
+        $task = new PingProvidersTask($registry, $credentialsResolver, $pingService, $availabilityService, $dispatchService, new NullLogger());
+
+        $task();
+    }
+}

--- a/tests/Service/CommunicationSaleServiceProviderGuardTest.php
+++ b/tests/Service/CommunicationSaleServiceProviderGuardTest.php
@@ -23,6 +23,7 @@ use App\Service\CommunicationSaleService;
 use App\Service\ConfigureSequenceService;
 use App\Service\HistoricalSaleService;
 use App\Service\NotificationCenterService;
+use App\Service\Provider\ProviderAvailabilityService;
 use App\Provider\ProviderContextFactory;
 use App\Provider\ProviderRegistry;
 use App\Provider\ProviderResolver;
@@ -54,6 +55,7 @@ class CommunicationSaleServiceProviderGuardTest extends TestCase
     private ClientProviderRoutingRepository&MockObject $routingRepo;
     private SysConfigRepository&MockObject $sysConfigRepo;
     private BalanceService&MockObject $balanceService;
+    private ProviderAvailabilityService&MockObject $availabilityService;
     private CommunicationSaleService $service;
 
     protected function setUp(): void
@@ -63,6 +65,7 @@ class CommunicationSaleServiceProviderGuardTest extends TestCase
         $this->routingRepo = $this->createMock(ClientProviderRoutingRepository::class);
         $this->sysConfigRepo = $this->createMock(SysConfigRepository::class);
         $this->balanceService = $this->createMock(BalanceService::class);
+        $this->availabilityService = $this->createMock(ProviderAvailabilityService::class);
 
         $parameters = $this->createMock(ParameterBagInterface::class);
         $mailer = $this->createMock(MailerInterface::class);
@@ -101,19 +104,19 @@ class CommunicationSaleServiceProviderGuardTest extends TestCase
             $historicalSaleService,
             $this->balanceService,
             $notificationCenter,
+            $this->availabilityService,
         );
     }
 
     /**
-     * Deshabilita el dispatch de mensajes (communications.dispatch.enabled='0')
-     * para evitar construir SaleRechargeMessage con un id nulo — en este test
-     * las entidades nunca pasan por un EntityManager real, así que su id
-     * autogenerado nunca se asigna. No es lo que se está probando aquí.
+     * Hace que canDispatchTo() devuelva false, para evitar construir
+     * SaleRechargeMessage con un id nulo — en este test las entidades nunca
+     * pasan por un EntityManager real, así que su id autogenerado nunca se
+     * asigna. No es lo que se está probando aquí (ver dispatchOrDefer()).
      */
     private function stubDispatchDisabled(): void
     {
-        $this->sysConfigRepo->method('findCachedValue')
-            ->willReturnCallback(fn (string $key) => $key === 'communications.dispatch.enabled' ? '0' : null);
+        $this->availabilityService->method('canDispatchTo')->willReturn(false);
     }
 
     private function accountWithClient(int $clientId): Account&MockObject

--- a/tests/Service/Etecsa/EtecsaGatewayClientPingTest.php
+++ b/tests/Service/Etecsa/EtecsaGatewayClientPingTest.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace App\Tests\Service\Etecsa;
+
+use App\Entity\Environment;
+use App\Enums\CommunicationProviderEnum;
+use App\Exception\MyCurrentException;
+use App\Provider\Contract\CommunicationProviderInterface;
+use App\Provider\Contract\ProviderConfigField;
+use App\Provider\ProviderCredentialsResolver;
+use App\Provider\ProviderRegistry;
+use App\Repository\EnvironmentRepository;
+use App\Repository\SysConfigRepository;
+use App\Service\Etecsa\EtecsaGatewayClient;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * @covers \App\Service\Etecsa\EtecsaGatewayClient::ping
+ */
+class EtecsaGatewayClientPingTest extends TestCase
+{
+    private function credentialsResolver(?string $apiKey = 'k3y', ?string $baseUrl = 'https://etecsa.example'): ProviderCredentialsResolver
+    {
+        $sysConfigRepo = $this->createMock(SysConfigRepository::class);
+        $sysConfigRepo->method('findCachedValue')->willReturnMap([
+            ['provider.etecsa.test.base_url', true, $baseUrl],
+            ['provider.etecsa.test.api_key', true, $apiKey],
+        ]);
+
+        $adapter = new class implements CommunicationProviderInterface {
+            public function getCode(): CommunicationProviderEnum
+            {
+                return CommunicationProviderEnum::ETECSA;
+            }
+
+            public function getCapabilities(): array
+            {
+                return [];
+            }
+
+            public function getConfigSchema(): array
+            {
+                return [
+                    new ProviderConfigField('base_url', 'URL base', required: true, secret: false),
+                    new ProviderConfigField('api_key', 'API key', required: true, secret: true),
+                ];
+            }
+        };
+
+        return new ProviderCredentialsResolver($sysConfigRepo, new ProviderRegistry([$adapter]));
+    }
+
+    private function client(\Closure $responseFactory, ?string $apiKey = 'k3y'): EtecsaGatewayClient
+    {
+        return new EtecsaGatewayClient(
+            $this->createMock(EntityManagerInterface::class),
+            $this->createMock(Security::class),
+            $this->createMock(ParameterBagInterface::class),
+            $this->createMock(MailerInterface::class),
+            new NullLogger(),
+            $this->createMock(UserPasswordHasherInterface::class),
+            $this->createMock(EnvironmentRepository::class),
+            $this->createMock(SysConfigRepository::class),
+            $this->createMock(SerializerInterface::class),
+            new MockHttpClient($responseFactory),
+            $this->credentialsResolver(apiKey: $apiKey),
+            new NullLogger(),
+            'TEST_PHONE',
+        );
+    }
+
+    private function environment(): Environment
+    {
+        return (new Environment())->setType('TEST')->setBasePath('https://legacy.example');
+    }
+
+    public function testPingSendsApiKeyHeaderAndReturns200Body(): void
+    {
+        $requestHeaders = null;
+        $client = $this->client(function (string $method, string $url, array $options) use (&$requestHeaders) {
+            $requestHeaders = $options['normalized_headers'];
+            $this->assertSame('GET', $method);
+            $this->assertSame('https://etecsa.example/ping', $url);
+
+            return new MockResponse(json_encode(['environment' => 'TEST', 'available' => true, 'latencyMs' => 42]), ['http_code' => 200]);
+        });
+
+        $result = $client->ping($this->environment());
+
+        $this->assertSame(200, $result['status']);
+        $this->assertTrue($result['body']['available']);
+        $this->assertSame(['X-Api-Key: k3y'], $requestHeaders['x-api-key']);
+    }
+
+    public function testPingReadsBodyOn503WithoutThrowing(): void
+    {
+        $client = $this->client(function () {
+            return new MockResponse(
+                json_encode(['environment' => 'TEST', 'available' => false, 'error' => 'breaker open']),
+                ['http_code' => 503],
+            );
+        });
+
+        $result = $client->ping($this->environment());
+
+        $this->assertSame(503, $result['status']);
+        $this->assertFalse($result['body']['available']);
+        $this->assertSame('breaker open', $result['body']['error']);
+    }
+
+    public function testPingReadsBodyOn403WithoutThrowing(): void
+    {
+        $client = $this->client(function () {
+            return new MockResponse(json_encode(['error' => 'missing scope ping:read']), ['http_code' => 403]);
+        });
+
+        $result = $client->ping($this->environment());
+
+        $this->assertSame(403, $result['status']);
+    }
+
+    public function testPingWrapsTransportFailureAsGatewayTimeout(): void
+    {
+        $client = $this->client(function () {
+            return new MockResponse('', ['error' => 'Connection refused']);
+        });
+
+        $this->expectException(MyCurrentException::class);
+
+        $client->ping($this->environment());
+    }
+}

--- a/tests/Service/Provider/ProviderAvailabilityServiceTest.php
+++ b/tests/Service/Provider/ProviderAvailabilityServiceTest.php
@@ -1,0 +1,320 @@
+<?php
+
+namespace App\Tests\Service\Provider;
+
+use App\Entity\ProviderAvailability;
+use App\Entity\User;
+use App\Enums\CommunicationProviderEnum;
+use App\Enums\ProviderActionTypeEnum;
+use App\Exception\MyCurrentException;
+use App\Provider\Contract\CommunicationProviderInterface;
+use App\Provider\Contract\ProviderConfigField;
+use App\Provider\Contract\ProviderPingResult;
+use App\Provider\ProviderCredentialsResolver;
+use App\Provider\ProviderRegistry;
+use App\Repository\ProviderAvailabilityRepository;
+use App\Repository\SysConfigRepository;
+use App\Service\Provider\ProviderAvailabilityService;
+use App\Service\Provider\ProviderCredentialsAdminService;
+use App\Service\NotificationCenterService;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Bundle\SecurityBundle\Security;
+
+/**
+ * @covers \App\Service\Provider\ProviderAvailabilityService
+ */
+class ProviderAvailabilityServiceTest extends TestCase
+{
+    private function fakeAdapter(): CommunicationProviderInterface
+    {
+        return new class implements CommunicationProviderInterface {
+            public function getCode(): CommunicationProviderEnum
+            {
+                return CommunicationProviderEnum::CSQ;
+            }
+
+            public function getCapabilities(): array
+            {
+                return [];
+            }
+
+            public function getConfigSchema(): array
+            {
+                return [new ProviderConfigField('token', 'Token', required: true, secret: false)];
+            }
+        };
+    }
+
+    /**
+     * @param array<string, ?string> $sysConfigValues
+     */
+    private function makeService(
+        array $sysConfigValues,
+        ?ProviderAvailabilityRepository $repository = null,
+        ?EntityManagerInterface $em = null,
+        ?ProviderCredentialsAdminService $credentialsAdminService = null,
+        ?NotificationCenterService $notificationCenter = null,
+        ?Security $security = null,
+    ): ProviderAvailabilityService {
+        $sysConfigRepo = $this->createMock(SysConfigRepository::class);
+        $sysConfigRepo->method('findCachedValue')
+            ->willReturnCallback(static fn (string $key, bool $mustBeActive = false) => $sysConfigValues[$key] ?? null);
+
+        $registry = new ProviderRegistry([$this->fakeAdapter()]);
+        $credentialsResolver = new ProviderCredentialsResolver($sysConfigRepo, $registry);
+
+        return new ProviderAvailabilityService(
+            $em ?? $this->createMock(EntityManagerInterface::class),
+            $repository ?? $this->createMock(ProviderAvailabilityRepository::class),
+            $credentialsResolver,
+            $credentialsAdminService ?? $this->createMock(ProviderCredentialsAdminService::class),
+            $registry,
+            $sysConfigRepo,
+            $notificationCenter ?? $this->createMock(NotificationCenterService::class),
+            $security ?? $this->createMock(Security::class),
+            new NullLogger(),
+        );
+    }
+
+    private function repositoryReturning(?ProviderAvailability $row): ProviderAvailabilityRepository&MockObject
+    {
+        $repository = $this->createMock(ProviderAvailabilityRepository::class);
+        $repository->method('findOneByProviderAndType')->willReturn($row);
+
+        return $repository;
+    }
+
+    // ---- canDispatchTo: tabla de verdad ----
+
+    public function testCanDispatchToFalseWhenGlobalDisabled(): void
+    {
+        $service = $this->makeService([
+            'communications.dispatch.enabled' => '0',
+            'provider.csq.test.token' => 'x',
+            'provider.csq.test.active' => '1',
+        ]);
+
+        $this->assertFalse($service->canDispatchTo('CSQ', 'TEST'));
+    }
+
+    public function testCanDispatchToFalseWhenNotConfigured(): void
+    {
+        $service = $this->makeService([
+            'communications.dispatch.enabled' => '1',
+            'provider.csq.test.active' => '1',
+            // sin provider.csq.test.token: no configurado
+        ]);
+
+        $this->assertFalse($service->canDispatchTo('CSQ', 'TEST'));
+    }
+
+    public function testCanDispatchToFalseWhenManualInactive(): void
+    {
+        $service = $this->makeService([
+            'communications.dispatch.enabled' => '1',
+            'provider.csq.test.token' => 'x',
+            'provider.csq.test.active' => '0',
+        ]);
+
+        $this->assertFalse($service->canDispatchTo('CSQ', 'TEST'));
+    }
+
+    public function testCanDispatchToDefaultsAutoEnabledWhenNoRowExistsYet(): void
+    {
+        $service = $this->makeService([
+            'communications.dispatch.enabled' => '1',
+            'provider.csq.test.token' => 'x',
+            'provider.csq.test.active' => '1',
+        ], repository: $this->repositoryReturning(null));
+
+        $this->assertTrue($service->canDispatchTo('CSQ', 'TEST'));
+    }
+
+    public function testCanDispatchToFalseWhenAutoDisabledByPing(): void
+    {
+        $row = (new ProviderAvailability())->setProvider('CSQ')->setEnvironmentType('TEST')->setAutoEnabled(false);
+
+        $service = $this->makeService([
+            'communications.dispatch.enabled' => '1',
+            'provider.csq.test.token' => 'x',
+            'provider.csq.test.active' => '1',
+        ], repository: $this->repositoryReturning($row));
+
+        $this->assertFalse($service->canDispatchTo('CSQ', 'TEST'));
+    }
+
+    // ---- recordPing ----
+
+    public function testRecordPingDisablesAutoOnFirstFailureAndNotifies(): void
+    {
+        $row = (new ProviderAvailability())->setProvider('CSQ')->setEnvironmentType('TEST')->setAutoEnabled(true);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->never())->method('persist');
+        $em->expects($this->once())->method('flush');
+
+        $notificationCenter = $this->createMock(NotificationCenterService::class);
+        $notificationCenter->expects($this->once())->method('bumpGroup');
+
+        $service = $this->makeService(
+            [],
+            repository: $this->repositoryReturning($row),
+            em: $em,
+            notificationCenter: $notificationCenter,
+        );
+
+        $result = $service->recordPing(CommunicationProviderEnum::CSQ, 'TEST', ProviderPingResult::unavailable('timeout'));
+
+        $this->assertFalse($result);
+        $this->assertFalse($row->isAutoEnabled());
+        $this->assertSame(ProviderActionTypeEnum::AUTO, $row->getLastActionType());
+        $this->assertSame('timeout', $row->getLastPingError());
+    }
+
+    public function testRecordPingReturnsTrueWhenRecoveryMakesItDispatchableAgain(): void
+    {
+        $row = (new ProviderAvailability())->setProvider('CSQ')->setEnvironmentType('TEST')->setAutoEnabled(false);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $notificationCenter = $this->createMock(NotificationCenterService::class);
+        $notificationCenter->expects($this->once())->method('bumpGroup');
+
+        $service = $this->makeService([
+            'communications.dispatch.enabled' => '1',
+            'provider.csq.test.token' => 'x',
+            'provider.csq.test.active' => '1',
+        ], repository: $this->repositoryReturning($row), em: $em, notificationCenter: $notificationCenter);
+
+        $result = $service->recordPing(CommunicationProviderEnum::CSQ, 'TEST', ProviderPingResult::available(120));
+
+        $this->assertTrue($result);
+        $this->assertTrue($row->isAutoEnabled());
+    }
+
+    public function testRecordPingRecoversAutoButStaysNonDispatchableWhenManualIsOff(): void
+    {
+        // Requisito 4, caso simétrico: el ping SÍ puede volver a poner AUTO en
+        // true (no queda bloqueado por un apagado manual previo), pero no
+        // reencola nada porque el interruptor MANUAL sigue mandando.
+        $row = (new ProviderAvailability())->setProvider('CSQ')->setEnvironmentType('TEST')->setAutoEnabled(false);
+
+        $service = $this->makeService([
+            'communications.dispatch.enabled' => '1',
+            'provider.csq.test.token' => 'x',
+            'provider.csq.test.active' => '0',
+        ], repository: $this->repositoryReturning($row));
+
+        $result = $service->recordPing(CommunicationProviderEnum::CSQ, 'TEST', ProviderPingResult::available(50));
+
+        $this->assertFalse($result);
+        $this->assertTrue($row->isAutoEnabled());
+    }
+
+    public function testRecordPingInconclusiveDoesNotChangeAuto(): void
+    {
+        $row = (new ProviderAvailability())->setProvider('CSQ')->setEnvironmentType('TEST')->setAutoEnabled(true);
+
+        $notificationCenter = $this->createMock(NotificationCenterService::class);
+        $notificationCenter->expects($this->once())->method('bumpGroup');
+
+        $service = $this->makeService(
+            [],
+            repository: $this->repositoryReturning($row),
+            notificationCenter: $notificationCenter,
+        );
+
+        $result = $service->recordPing(CommunicationProviderEnum::CSQ, 'TEST', ProviderPingResult::inconclusive('401'));
+
+        $this->assertFalse($result);
+        $this->assertTrue($row->isAutoEnabled());
+        $this->assertNull($row->getLastActionType());
+    }
+
+    // ---- setManual ----
+
+    public function testSetManualThrowsWhenActivatingUnconfiguredProvider(): void
+    {
+        $credentialsAdminService = $this->createMock(ProviderCredentialsAdminService::class);
+        $credentialsAdminService->expects($this->never())->method('setActive');
+
+        $service = $this->makeService([], credentialsAdminService: $credentialsAdminService);
+
+        $this->expectException(MyCurrentException::class);
+
+        $service->setManual(CommunicationProviderEnum::CSQ, 'TEST', true);
+    }
+
+    public function testSetManualEnableDelegatesResetsAutoAndAudits(): void
+    {
+        $row = (new ProviderAvailability())->setProvider('CSQ')->setEnvironmentType('TEST')->setAutoEnabled(false);
+
+        $credentialsAdminService = $this->createMock(ProviderCredentialsAdminService::class);
+        $credentialsAdminService->expects($this->once())
+            ->method('setActive')
+            ->with(CommunicationProviderEnum::CSQ, 'TEST', true);
+
+        $user = $this->createMock(User::class);
+        $security = $this->createMock(Security::class);
+        $security->method('getUser')->willReturn($user);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->once())->method('flush');
+
+        $service = $this->makeService(
+            ['provider.csq.test.token' => 'x'],
+            repository: $this->repositoryReturning($row),
+            em: $em,
+            credentialsAdminService: $credentialsAdminService,
+            security: $security,
+        );
+
+        $service->setManual(CommunicationProviderEnum::CSQ, 'TEST', true, 'reactivación manual');
+
+        $this->assertTrue($row->isAutoEnabled());
+        $this->assertSame(ProviderActionTypeEnum::MANUAL, $row->getLastActionType());
+        $this->assertSame($user, $row->getLastActionBy());
+        $this->assertSame('reactivación manual', $row->getLastActionReason());
+    }
+
+    public function testSetManualDisableDoesNotTouchAuto(): void
+    {
+        $row = (new ProviderAvailability())->setProvider('CSQ')->setEnvironmentType('TEST')->setAutoEnabled(false);
+
+        $service = $this->makeService(
+            [],
+            repository: $this->repositoryReturning($row),
+            credentialsAdminService: $this->createMock(ProviderCredentialsAdminService::class),
+        );
+
+        $service->setManual(CommunicationProviderEnum::CSQ, 'TEST', false);
+
+        $this->assertFalse($row->isAutoEnabled());
+        $this->assertSame(ProviderActionTypeEnum::MANUAL, $row->getLastActionType());
+    }
+
+    // ---- statusMatrix ----
+
+    public function testStatusMatrixReflectsEffectiveFlagPerEnvironment(): void
+    {
+        $service = $this->makeService([
+            'communications.dispatch.enabled' => '1',
+            'provider.csq.test.token' => 'x',
+            'provider.csq.test.active' => '1',
+            // provider.csq.prod.token ausente: PROD no configurado
+        ], repository: $this->repositoryReturning(null));
+
+        $matrix = $service->statusMatrix();
+        $byEnv = [];
+        foreach ($matrix as $row) {
+            $byEnv[$row['environmentType']] = $row;
+        }
+
+        $this->assertTrue($byEnv['TEST']['configured']);
+        $this->assertTrue($byEnv['TEST']['effective']);
+        $this->assertFalse($byEnv['PROD']['configured']);
+        $this->assertFalse($byEnv['PROD']['effective']);
+    }
+}

--- a/tests/Service/Provider/ProviderConnectionTestServiceTest.php
+++ b/tests/Service/Provider/ProviderConnectionTestServiceTest.php
@@ -9,11 +9,13 @@ use App\Provider\Contract\ProviderBalanceInterface;
 use App\Provider\Contract\ProviderBalanceResult;
 use App\Provider\Contract\ProviderContext;
 use App\Provider\ProviderContextFactory;
+use App\Provider\ProviderCredentialsResolver;
 use App\Provider\ProviderRegistry;
 use App\Provider\ProviderResolver;
 use App\Repository\ClientProviderRoutingRepository;
 use App\Repository\SysConfigRepository;
 use App\Service\Provider\ProviderConnectionTestService;
+use App\Service\Provider\ProviderPingService;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
@@ -34,6 +36,18 @@ class ProviderConnectionTestServiceTest extends TestCase
         );
 
         return new ProviderContextFactory($resolver);
+    }
+
+    private function service(ProviderRegistry $registry): ProviderConnectionTestService
+    {
+        // getConfigSchema() de los adaptadores de este test siempre es []:
+        // ProviderCredentialsResolver::isFullyConfigured() no itera ningún
+        // campo requerido y por tanto no llega a tocar SysConfigRepository.
+        $credentialsResolver = new ProviderCredentialsResolver($this->createMock(SysConfigRepository::class), $registry);
+
+        return new ProviderConnectionTestService(
+            new ProviderPingService($registry, $credentialsResolver, $this->contextFactory()),
+        );
     }
 
     public function testReturnsSuccessWithAmountsOnHappyPath(): void
@@ -61,7 +75,7 @@ class ProviderConnectionTestServiceTest extends TestCase
             }
         };
 
-        $service = new ProviderConnectionTestService(new ProviderRegistry([$adapter]), $this->contextFactory());
+        $service = $this->service(new ProviderRegistry([$adapter]));
 
         $result = $service->test(CommunicationProviderEnum::DTONE, 'TEST');
 
@@ -95,7 +109,7 @@ class ProviderConnectionTestServiceTest extends TestCase
             }
         };
 
-        $service = new ProviderConnectionTestService(new ProviderRegistry([$adapter]), $this->contextFactory());
+        $service = $this->service(new ProviderRegistry([$adapter]));
 
         $result = $service->test(CommunicationProviderEnum::DTONE, 'TEST');
 
@@ -105,7 +119,7 @@ class ProviderConnectionTestServiceTest extends TestCase
 
     public function testReturnsFailureWhenProviderNotRegistered(): void
     {
-        $service = new ProviderConnectionTestService(new ProviderRegistry([]), $this->contextFactory());
+        $service = $this->service(new ProviderRegistry([]));
 
         $result = $service->test(CommunicationProviderEnum::ETECSA, 'PROD');
 

--- a/tests/Service/Provider/ProviderPingServiceTest.php
+++ b/tests/Service/Provider/ProviderPingServiceTest.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace App\Tests\Service\Provider;
+
+use App\Enums\CommunicationProviderEnum;
+use App\Exception\MyCurrentException;
+use App\Provider\Contract\CommunicationProviderInterface;
+use App\Provider\Contract\ProviderBalanceInterface;
+use App\Provider\Contract\ProviderBalanceResult;
+use App\Provider\Contract\ProviderConfigField;
+use App\Provider\Contract\ProviderContext;
+use App\Provider\Contract\ProviderHealthCheckInterface;
+use App\Provider\Contract\ProviderPingResult;
+use App\Provider\ProviderContextFactory;
+use App\Provider\ProviderCredentialsResolver;
+use App\Provider\ProviderRegistry;
+use App\Provider\ProviderResolver;
+use App\Repository\ClientProviderRoutingRepository;
+use App\Repository\SysConfigRepository;
+use App\Service\Provider\ProviderPingService;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @covers \App\Service\Provider\ProviderPingService
+ */
+class ProviderPingServiceTest extends TestCase
+{
+    private function contextFactory(): ProviderContextFactory
+    {
+        // ProviderResolver y ProviderContextFactory son `final`: se
+        // instancian reales con dependencias mockeadas — forEnvironmentType()
+        // no usa el resolver en absoluto.
+        $resolver = new ProviderResolver(
+            $this->createMock(SysConfigRepository::class),
+            $this->createMock(ClientProviderRoutingRepository::class),
+            $this->createMock(LoggerInterface::class),
+        );
+
+        return new ProviderContextFactory($resolver);
+    }
+
+    private function credentialsResolver(ProviderRegistry $registry, ?string $tokenValue): ProviderCredentialsResolver
+    {
+        $sysConfigRepo = $this->createMock(SysConfigRepository::class);
+        $sysConfigRepo->method('findCachedValue')->willReturnMap([
+            ['provider.dtone.test.token', true, $tokenValue],
+        ]);
+
+        return new ProviderCredentialsResolver($sysConfigRepo, $registry);
+    }
+
+    public function testPingIsInconclusiveWhenNotFullyConfigured(): void
+    {
+        $adapter = new class implements CommunicationProviderInterface {
+            public function getCode(): CommunicationProviderEnum
+            {
+                return CommunicationProviderEnum::DTONE;
+            }
+
+            public function getCapabilities(): array
+            {
+                return [];
+            }
+
+            public function getConfigSchema(): array
+            {
+                return [new ProviderConfigField('token', 'Token', required: true, secret: false)];
+            }
+        };
+        $registry = new ProviderRegistry([$adapter]);
+
+        $service = new ProviderPingService($registry, $this->credentialsResolver($registry, null), $this->contextFactory());
+
+        $result = $service->ping(CommunicationProviderEnum::DTONE, 'TEST');
+
+        $this->assertTrue($result->inconclusive);
+        $this->assertFalse($result->available);
+    }
+
+    public function testPingDelegatesToHealthCheckWhenAvailable(): void
+    {
+        $adapter = new class implements ProviderHealthCheckInterface {
+            public function getCode(): CommunicationProviderEnum
+            {
+                return CommunicationProviderEnum::DTONE;
+            }
+
+            public function getCapabilities(): array
+            {
+                return [];
+            }
+
+            public function getConfigSchema(): array
+            {
+                return [];
+            }
+
+            public function checkHealth(ProviderContext $context): ProviderPingResult
+            {
+                return ProviderPingResult::available(42);
+            }
+        };
+        $registry = new ProviderRegistry([$adapter]);
+
+        $service = new ProviderPingService($registry, $this->credentialsResolver($registry, 'x'), $this->contextFactory());
+
+        $result = $service->ping(CommunicationProviderEnum::DTONE, 'TEST');
+
+        $this->assertTrue($result->available);
+        $this->assertSame(42, $result->latencyMs);
+    }
+
+    public function testPingFallsBackToBalanceWhenNoHealthCheck(): void
+    {
+        $adapter = new class implements ProviderBalanceInterface {
+            public function getCode(): CommunicationProviderEnum
+            {
+                return CommunicationProviderEnum::DTONE;
+            }
+
+            public function getCapabilities(): array
+            {
+                return [];
+            }
+
+            public function getConfigSchema(): array
+            {
+                return [];
+            }
+
+            public function getPlatformBalance(ProviderContext $context): ProviderBalanceResult
+            {
+                return new ProviderBalanceResult(['USD' => 10.0], new \DateTimeImmutable('2026-08-01T00:00:00+00:00'));
+            }
+        };
+        $registry = new ProviderRegistry([$adapter]);
+
+        $service = new ProviderPingService($registry, $this->credentialsResolver($registry, 'x'), $this->contextFactory());
+
+        $result = $service->ping(CommunicationProviderEnum::DTONE, 'TEST');
+
+        $this->assertTrue($result->available);
+        $this->assertSame(['USD' => 10.0], $result->details['amounts']);
+    }
+
+    public function testPingIsInconclusiveWhenAdapterHasNoProbe(): void
+    {
+        $adapter = new class implements CommunicationProviderInterface {
+            public function getCode(): CommunicationProviderEnum
+            {
+                return CommunicationProviderEnum::DTONE;
+            }
+
+            public function getCapabilities(): array
+            {
+                return [];
+            }
+
+            public function getConfigSchema(): array
+            {
+                return [];
+            }
+        };
+        $registry = new ProviderRegistry([$adapter]);
+
+        $service = new ProviderPingService($registry, $this->credentialsResolver($registry, 'x'), $this->contextFactory());
+
+        $result = $service->ping(CommunicationProviderEnum::DTONE, 'TEST');
+
+        $this->assertTrue($result->inconclusive);
+    }
+
+    public function testPingReturnsUnavailableWhenHealthCheckThrows(): void
+    {
+        $adapter = new class implements ProviderHealthCheckInterface {
+            public function getCode(): CommunicationProviderEnum
+            {
+                return CommunicationProviderEnum::DTONE;
+            }
+
+            public function getCapabilities(): array
+            {
+                return [];
+            }
+
+            public function getConfigSchema(): array
+            {
+                return [];
+            }
+
+            public function checkHealth(ProviderContext $context): ProviderPingResult
+            {
+                throw new MyCurrentException('DTONE_TIMEOUT', 'timeout', 503);
+            }
+        };
+        $registry = new ProviderRegistry([$adapter]);
+
+        $service = new ProviderPingService($registry, $this->credentialsResolver($registry, 'x'), $this->contextFactory());
+
+        $result = $service->ping(CommunicationProviderEnum::DTONE, 'TEST');
+
+        $this->assertFalse($result->available);
+        $this->assertFalse($result->inconclusive);
+        $this->assertSame('timeout', $result->error);
+    }
+
+    public function testPingReturnsUnavailableWhenProviderNotRegistered(): void
+    {
+        $registry = new ProviderRegistry([]);
+        $credentialsResolver = new ProviderCredentialsResolver($this->createMock(SysConfigRepository::class), $registry);
+
+        $service = new ProviderPingService($registry, $credentialsResolver, $this->contextFactory());
+
+        $result = $service->ping(CommunicationProviderEnum::ETECSA, 'PROD');
+
+        $this->assertFalse($result->available);
+        $this->assertStringContainsString('no está registrado', $result->error);
+    }
+}


### PR DESCRIPTION
## Resumen

- Ping cada 15 minutos a cada proveedor (ETECSA vía `GET /ping` nuevo, CSQ vía su ping existente, DTOne cae al fallback de `getPlatformBalance()`) que habilita/deshabilita automáticamente el despacho de transacciones por proveedor y entorno.
- Modelo de tres condiciones en AND: switch global (`communications.dispatch.enabled`) ∧ credenciales completas + interruptor manual (`ProviderCredentialsResolver::isEnabled()`) ∧ estado AUTO del ping (`ProviderAvailability.autoEnabled`). Lo automático nunca pisa una decisión manual, salvo para cortar el envío hacia un proveedor comprobadamente caído.
- `ProviderPingResult` con un tercer estado `inconclusive` (401/403/409/sin configurar) para que una credencial nuestra mal configurada nunca apague un proveedor sano.
- El corte es en el **despacho**, no en la admisión: la venta se crea igual y queda pendiente hasta que el proveedor se recupera, momento en el que se reencola sola (`CommunicationsDispatchService::redispatchPendingFor()`).
- Toda acción manual queda auditada (usuario, motivo, fecha) vía `ProviderAvailabilityService::setManual()`.
- Endpoints nuevos: `GET/PATCH/POST /admin/providers/availability/...`. Notificaciones al admin en los flancos (deshabilitado/recuperado/inconcluso).

## ⚠️ Antes de mezclar a master

El nuevo gate exige `provider.etecsa.{type}.base_url` y `api_key` en el esquema nuevo de `sys_config`. Si producción todavía depende solo de las claves legacy (`api.prod.communications.key` + `Environment::basePath`), este cambio **bloquearía todo el despacho de ETECSA** al desplegar. Verificar (o sembrar por migración) que esas filas ya existen en prod antes de liberar a master.

## Test plan

- [x] `php bin/phpunit --no-coverage` — 574 tests, 1257 assertions, en verde
- [x] `vendor/bin/phpstan analyse` — sin errores
- [ ] Verificar en prod que `provider.etecsa.prod.base_url`/`api_key` existen antes de mezclar a master

🤖 Generated with [Claude Code](https://claude.com/claude-code)