### PR TITLE
fix(staging-sync): re-cifra credenciales de proveedor con la clave de staging

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -288,17 +288,30 @@ staging vacía el schema, restaura, migra y **sanea** los `environment` que
 eran PROD (pasan a TEST, credenciales anuladas) para que staging con datos
 reales nunca pueda pegarle a las APIs de pago/comunicaciones reales.
 
+Las credenciales de proveedor (`sys_config` bajo `provider.%`) no viven en
+`environment`, así que el saneo de arriba no las toca: llegan cifradas con
+la `SYS_CONFIG_ENCRYPTION_KEY` de prod, que staging no puede descifrar con
+la suya. Decisión explícita (2026-08-04, no la de borrarlas): la clave de
+prod se envía por **stdin** de la misma conexión SSH restringida (nunca
+como argumento ni a disco), staging la usa una sola vez para descifrar y
+re-cifrar con su propia clave (`bin/console
+app:staging-sync:reencrypt-provider-secrets`) y la descarta — quedan
+funcionales en staging por ahora. Pendiente pensar un mecanismo mejor.
+
 Corre por dos vías, ninguna versionada en git (crontab de `deploy@` en el
-host de prod, igual que cualquier otro cron de sistema):
+host de prod, igual que cualquier otro cron de sistema). El log debe
+apuntar a una ruta que `deploy` pueda escribir — `/var/log` es de
+`root:syslog`, no de `deploy`, así que un cron que loguee ahí falla en seco
+(el redirect no se puede abrir y el comando ni siquiera llega a correr):
 
 ```cron
-# Mensual, el día 1 a las 03:00
-0 3 1 * * cd /opt/api-transferencias && ./scripts/sync-prod-to-staging.sh >> /var/log/sync-prod-to-staging.log 2>&1
+# Mensual, el día 2 a las 03:30
+30 3 2 * * cd /opt/api-transferencias && ./scripts/sync-prod-to-staging.sh >> /home/deploy/logs/sync-prod-to-staging.log 2>&1
 
 # Cada 2 minutos: recoge el disparo bajo demanda desde el dashboard
 # (App\Service\StagingSyncService::trigger()) — no hace nada si no hay
 # ninguna solicitud pendiente.
-*/2 * * * * cd /opt/api-transferencias && ./scripts/staging-sync-watcher.sh >> /var/log/staging-sync-watcher.log 2>&1
+*/2 * * * * cd /opt/api-transferencias && ./scripts/staging-sync-watcher.sh >> /home/deploy/logs/staging-sync-watcher.log 2>&1
 ```
 
 El script reporta su propio estado (`RUNNING`/`SUCCESS`/`FAILED`) a la app

--- a/scripts/staging-sync-dispatch.sh
+++ b/scripts/staging-sync-dispatch.sh
@@ -5,9 +5,12 @@ set -euo pipefail
 # de deploy@staging): esa clave vive en el host de prod para el sync mensual y
 # NUNCA debe poder ejecutar un comando arbitrario. Solo permite dos cosas:
 #   1. Recibir el dump vía rsync hacia backups/incoming/
-#   2. Disparar RESTORE_AND_SANITIZE, que restaura el dump más reciente y
+#   2. Disparar RESTORE_AND_SANITIZE, que restaura el dump más reciente,
 #      neutraliza los environment que eran PROD (type, client_secret,
-#      client_id, base_path) para que staging no pueda golpear APIs reales.
+#      client_id, base_path) y re-cifra las credenciales de proveedor
+#      (sys_config bajo provider.%) con la clave local — la clave de prod
+#      necesaria para descifrarlas llega por stdin de esta misma conexión,
+#      nunca como argumento ni a disco (ver sync-prod-to-staging.sh).
 
 cd /opt/api-transferencias
 
@@ -16,6 +19,11 @@ case "${SSH_ORIGINAL_COMMAND:-}" in
         exec $SSH_ORIGINAL_COMMAND
         ;;
     RESTORE_AND_SANITIZE)
+        # Primero que nada: la clave de cifrado de prod viaja por stdin de
+        # esta misma conexion (nunca en SSH_ORIGINAL_COMMAND, nunca a disco).
+        # Se lee ya, antes de que cualquier otro paso pueda tocar stdin.
+        PROD_SYS_CONFIG_KEY=$(cat)
+
         # || true: con set -e + pipefail, el glob sin coincidencias hace que
         # "ls" falle y aborte el script ANTES de llegar al mensaje de abajo.
         LATEST=$(ls -t backups/incoming/*.sql.gz 2>/dev/null | head -1) || true
@@ -59,6 +67,10 @@ case "${SSH_ORIGINAL_COMMAND:-}" in
                     base_path = 'https://staging-sync-disabled.invalid'
                 WHERE type = 'PROD';
             "
+
+        echo "Re-encriptando credenciales de proveedor con la clave local..."
+        "${COMPOSE[@]}" exec -T -e PROD_SYS_CONFIG_KEY="$PROD_SYS_CONFIG_KEY" php-fpm php bin/console app:staging-sync:reencrypt-provider-secrets
+        unset PROD_SYS_CONFIG_KEY
 
         "${COMPOSE[@]}" exec -T php-fpm php bin/console cache:clear
 

--- a/scripts/sync-prod-to-staging.sh
+++ b/scripts/sync-prod-to-staging.sh
@@ -18,6 +18,13 @@ set -euo pipefail
 #    environment que eran PROD (type, client_secret, client_id, base_path):
 #    sin esto, staging con datos reales podria terminar llamando a las APIs
 #    reales de pago/comunicaciones con las credenciales reales.
+# 4. Las credenciales de proveedor (sys_config bajo provider.%) llegan en el
+#    dump cifradas con la SYS_CONFIG_ENCRYPTION_KEY de prod, que staging no
+#    puede descifrar con la suya. Decision explicita (2026-08-04, no la de
+#    borrarlas): se envia la clave de prod SOLO por stdin de esta misma
+#    conexion SSH restringida, staging la usa una vez para descifrar y
+#    re-cifrar con su propia clave, y la descarta — quedan funcionales en
+#    staging por ahora. Pendiente un mecanismo mejor mas adelante.
 #
 # Reporta su propio estado (RUNNING/SUCCESS/FAILED) hacia la app en cada
 # checkpoint via `bin/console app:staging-sync:report` — es lo unico que le
@@ -80,8 +87,12 @@ log "Transfiriendo a staging ($STAGING_HOST)..."
 rsync -az -e "ssh ${SSH_OPTS[*]}" \
   "$DUMP_FILE" "$STAGING_USER@$STAGING_HOST:backups/incoming/$(basename "$DUMP_FILE")"
 
+PROD_SYS_CONFIG_KEY=$(grep '^SYS_CONFIG_ENCRYPTION_KEY=' .env.vps | cut -d= -f2-)
+[ -z "$PROD_SYS_CONFIG_KEY" ] && error "SYS_CONFIG_ENCRYPTION_KEY no esta definida en .env.vps"
+
 log "Disparando restore + saneo de environment en staging..."
-ssh "${SSH_OPTS[@]}" "$STAGING_USER@$STAGING_HOST" RESTORE_AND_SANITIZE
+echo "$PROD_SYS_CONFIG_KEY" | ssh "${SSH_OPTS[@]}" "$STAGING_USER@$STAGING_HOST" RESTORE_AND_SANITIZE
+unset PROD_SYS_CONFIG_KEY
 
 log "Sincronizacion completa."
 report SUCCESS

--- a/src/Command/StagingSync/ReencryptProviderSecretsCommand.php
+++ b/src/Command/StagingSync/ReencryptProviderSecretsCommand.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Command\StagingSync;
+
+use App\Repository\SysConfigRepository;
+use App\Service\SysConfigCipher;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * Paso de scripts/staging-sync-dispatch.sh: las credenciales de proveedor
+ * (sys_config bajo provider.%) llegan en el dump cifradas con la
+ * SYS_CONFIG_ENCRYPTION_KEY de prod, que esta instancia no puede descifrar
+ * con la suya. Decision explicita (2026-08-04, no la de borrarlas): se
+ * descifran con la clave de prod y se re-cifran con la clave local para que
+ * queden funcionales en staging por ahora — pendiente un mecanismo mejor.
+ *
+ * La clave de prod llega SOLO por la variable de entorno PROD_SYS_CONFIG_KEY
+ * de esta invocacion puntual (ver staging-sync-dispatch.sh, que la recibe
+ * por stdin de la conexion SSH restringida, nunca a disco) y no se persiste
+ * en ningun sitio mas alla de este proceso.
+ */
+#[AsCommand(
+    name: 'app:staging-sync:reencrypt-provider-secrets',
+    description: 'Re-cifra sys_config provider.% (copiadas del dump de prod) con la SYS_CONFIG_ENCRYPTION_KEY local',
+)]
+class ReencryptProviderSecretsCommand extends Command
+{
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly SysConfigRepository $sysConfigRepo,
+        #[Autowire('%env(string:default::SYS_CONFIG_ENCRYPTION_KEY)%')]
+        private readonly string $localKey = '',
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $prodKey = (string) getenv('PROD_SYS_CONFIG_KEY');
+        if ($prodKey === '') {
+            $io->error('PROD_SYS_CONFIG_KEY no esta definida en el entorno de esta invocacion.');
+
+            return Command::INVALID;
+        }
+
+        if ($this->localKey === '') {
+            $io->error('SYS_CONFIG_ENCRYPTION_KEY no esta configurada en esta instancia.');
+
+            return Command::INVALID;
+        }
+
+        $count = 0;
+        foreach ($this->sysConfigRepo->findBy(['isEncrypted' => true]) as $row) {
+            if (!str_starts_with((string) $row->getPropertyName(), 'provider.')) {
+                continue;
+            }
+
+            $plain = SysConfigCipher::decrypt((string) $row->getPropertyValue(), $prodKey);
+            $row->setPropertyValue(SysConfigCipher::encrypt($plain, $this->localKey));
+            $count++;
+        }
+
+        $this->em->flush();
+        $this->sysConfigRepo->invalidateCache();
+
+        $io->success("Re-encriptadas {$count} credenciales de proveedor con la clave local.");
+
+        return Command::SUCCESS;
+    }
+}

--- a/tests/Command/StagingSync/ReencryptProviderSecretsCommandTest.php
+++ b/tests/Command/StagingSync/ReencryptProviderSecretsCommandTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Tests\Command\StagingSync;
+
+use App\Command\StagingSync\ReencryptProviderSecretsCommand;
+use App\Entity\SysConfig;
+use App\Repository\SysConfigRepository;
+use App\Service\SysConfigCipher;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @covers \App\Command\StagingSync\ReencryptProviderSecretsCommand
+ */
+class ReencryptProviderSecretsCommandTest extends TestCase
+{
+    private function prodKey(): string
+    {
+        return str_repeat('1', 64);
+    }
+
+    private function localKey(): string
+    {
+        return str_repeat('2', 64);
+    }
+
+    private function configRow(string $propertyName, string $plainValue, bool $encrypted, string $withKey = ''): SysConfig
+    {
+        $row = new SysConfig();
+        $row->setPropertyName($propertyName);
+        $row->setIsEncrypted($encrypted);
+        $row->setPropertyValue($encrypted ? SysConfigCipher::encrypt($plainValue, $withKey) : $plainValue);
+
+        return $row;
+    }
+
+    private function tester(SysConfigRepository $repo, ?string $localKey = null): CommandTester
+    {
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('flush');
+
+        $application = new Application();
+        $application->addCommand(new ReencryptProviderSecretsCommand($em, $repo, $localKey ?? $this->localKey()));
+
+        return new CommandTester($application->find('app:staging-sync:reencrypt-provider-secrets'));
+    }
+
+    public function testReencryptsOnlyEncryptedProviderRowsWithTheLocalKey(): void
+    {
+        $providerSecret = $this->configRow('provider.etecsa.prod.api_key', 'secreto-real', encrypted: true, withKey: $this->prodKey());
+        $providerPlain = $this->configRow('provider.etecsa.prod.base_url', 'https://etecsa.example', encrypted: false);
+        $unrelated = $this->configRow('communications.dispatch.enabled', '1', encrypted: false);
+
+        $repo = $this->createMock(SysConfigRepository::class);
+        $repo->method('findBy')->with(['isEncrypted' => true])->willReturn([$providerSecret]);
+        $repo->expects($this->once())->method('invalidateCache');
+
+        putenv('PROD_SYS_CONFIG_KEY=' . $this->prodKey());
+        try {
+            $exitCode = $this->tester($repo)->execute([]);
+        } finally {
+            putenv('PROD_SYS_CONFIG_KEY');
+        }
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $this->assertSame(
+            'secreto-real',
+            SysConfigCipher::decrypt((string) $providerSecret->getPropertyValue(), $this->localKey()),
+        );
+        // Los no-cifrados y los que no son de provider.% no se tocan.
+        $this->assertSame('https://etecsa.example', $providerPlain->getPropertyValue());
+        $this->assertSame('1', $unrelated->getPropertyValue());
+    }
+
+    public function testFailsWithoutTheProdKeyInTheEnvironment(): void
+    {
+        $repo = $this->createMock(SysConfigRepository::class);
+        $repo->expects($this->never())->method('findBy');
+
+        putenv('PROD_SYS_CONFIG_KEY');
+        $exitCode = $this->tester($repo)->execute([]);
+
+        $this->assertSame(Command::INVALID, $exitCode);
+    }
+
+    public function testFailsWithoutALocalEncryptionKeyConfigured(): void
+    {
+        $repo = $this->createMock(SysConfigRepository::class);
+        $repo->expects($this->never())->method('findBy');
+
+        putenv('PROD_SYS_CONFIG_KEY=' . $this->prodKey());
+        try {
+            $exitCode = $this->tester($repo, localKey: '')->execute([]);
+        } finally {
+            putenv('PROD_SYS_CONFIG_KEY');
+        }
+
+        $this->assertSame(Command::INVALID, $exitCode);
+    }
+}


### PR DESCRIPTION
## Resumen
- `sys_config` bajo `provider.%` no pasaba por el saneo de `environment`: llegaba a staging cifrado con la `SYS_CONFIG_ENCRYPTION_KEY` de prod, imposible de descifrar con la clave local — el dashboard reventaba en 500 al pedir el estado de cualquier proveedor.
- Nuevo comando `app:staging-sync:reencrypt-provider-secrets`: descifra con la clave de prod y re-cifra con la clave local. La clave de prod viaja por **stdin** de la misma conexión SSH restringida (nunca como argumento ni a disco) y se descarta tras usarse una vez.
- Decisión explícita del negocio: por ahora las credenciales quedan **funcionales** en staging (no se borran) — pendiente un mecanismo mejor más adelante.
- Corrige además: el path de log del watcher/sync (`/var/log` es `root:syslog`, `deploy` no puede escribir ahí — el cron nunca llegaba a ejecutar) y el horario documentado del cron mensual para que coincida con el real del servidor (`30 3 2 * *`).

## Test plan
- [x] `php bin/phpunit --no-coverage` — 597 tests, 0 fallos (corrido en Docker)
- [x] `vendor/bin/phpstan analyse` — sin errores
- [x] `bash -n` sobre ambos scripts modificados
- [x] Verificado en el servidor real de producción: el bug original (500 al listar proveedores en staging por fallo de descifrado) fue diagnosticado en vivo vía el correo de alerta y los logs de la app

🤖 Generated with [Claude Code](https://claude.com/claude-code)