### PR TITLE
fix(sale): oculta el proveedor interno de la respuesta pública de venta

### DIFF
--- a/src/Entity/CommunicationSaleInfo.php
+++ b/src/Entity/CommunicationSaleInfo.php
@@ -170,8 +170,16 @@ class CommunicationSaleInfo
     #[ApiProperty]
     protected ?float $totalPrice = 0;
 
+    /**
+     * Sobre v2 crudo del proveedor (TransactionStatus::envelope()) — incluye
+     * qué proveedor (CSQ/DTOne/ETECSA) procesó la venta y su respuesta cruda.
+     * Deliberadamente FUERA de 'comSales:read': ese grupo alimenta la API
+     * pública consumida por clientes externos (app móvil), que no debe ver
+     * el proveedor interno usado para el enrutado. Sigue disponible para el
+     * dashboard vía 'sale:detail'/'balance:reading'.
+     */
     #[ORM\Column]
-    #[Groups(['comSales:read', 'balance:reading', 'sale:detail'])]
+    #[Groups(['balance:reading', 'sale:detail'])]
     #[ApiProperty]
     protected array $transactionStatus = [];
 
@@ -266,7 +274,7 @@ class CommunicationSaleInfo
      * proveedor correcto aunque cambie el routing del cliente.
      */
     #[ORM\Column(length: 20)]
-    #[Groups(['comSales:read', 'sale:list', 'sale:detail'])]
+    #[Groups(['sale:list', 'sale:detail'])]
     private ?string $provider = null;
 
     public function __construct() {

--- a/tests/Entity/CommunicationSaleInfoSerializationTest.php
+++ b/tests/Entity/CommunicationSaleInfoSerializationTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Tests\Entity;
+
+use App\Entity\CommunicationSaleInfo;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Attribute\Groups;
+
+/**
+ * Regresión: el grupo 'comSales:read' alimenta la respuesta pública de
+ * /api/communication/sale/* (API Platform, consumida por la app móvil).
+ * $provider y $transactionStatus revelan qué proveedor interno (CSQ/DTOne/
+ * ETECSA) procesó la venta y no deben ser visibles al cliente externo.
+ *
+ * @covers \App\Entity\CommunicationSaleInfo
+ */
+class CommunicationSaleInfoSerializationTest extends TestCase
+{
+    /**
+     * @dataProvider providerLeakingProperties
+     */
+    public function testProviderSensitivePropertiesAreNotInPublicApiGroup(string $property): void
+    {
+        $reflection = new \ReflectionProperty(CommunicationSaleInfo::class, $property);
+        $attributes = $reflection->getAttributes(Groups::class);
+
+        self::assertNotEmpty($attributes, "La propiedad {$property} debería tener un atributo #[Groups].");
+
+        /** @var Groups $groups */
+        $groups = $attributes[0]->newInstance();
+
+        self::assertNotContains(
+            'comSales:read',
+            $groups->groups,
+            "La propiedad {$property} expone el proveedor interno y no debe pertenecer al grupo 'comSales:read' (API pública)."
+        );
+    }
+
+    public static function providerLeakingProperties(): array
+    {
+        return [
+            'provider' => ['provider'],
+            'transactionStatus' => ['transactionStatus'],
+        ];
+    }
+
+    public function testStateStaysVisibleToClientsForOutcomeTracking(): void
+    {
+        $reflection = new \ReflectionProperty(CommunicationSaleInfo::class, 'state');
+        $attributes = $reflection->getAttributes(Groups::class);
+
+        self::assertNotEmpty($attributes);
+
+        /** @var Groups $groups */
+        $groups = $attributes[0]->newInstance();
+
+        self::assertContains(
+            'comSales:read',
+            $groups->groups,
+            "El cliente externo debe poder seguir viendo 'state' para saber si la venta se completó, aunque no vea el proveedor."
+        );
+    }
+}


### PR DESCRIPTION
## Resumen
- `CommunicationSaleInfo` exponía `$provider` y `$transactionStatus` (sobre v2 completo, incluyendo la respuesta cruda del proveedor) bajo el grupo `comSales:read`, que alimenta `/api/communication/sale/*` consumido por la app móvil.
- Se quita `comSales:read` de ambas propiedades — siguen visibles para el dashboard vía `sale:list`/`sale:detail`/`balance:reading`.
- `state` se mantiene expuesto al cliente externo, así sigue sabiendo si la venta se completó, sin filtrar qué proveedor (CSQ/DTOne/ETECSA) la procesó.

## Test plan
- [x] `tests/Entity/CommunicationSaleInfoSerializationTest.php` (nuevo) — verifica por reflexión que `provider`/`transactionStatus` no estén en `comSales:read`; falla sin el fix, pasa con él.
- [x] `php bin/phpunit --no-coverage` → 905 tests en verde
- [x] `vendor/bin/phpstan analyse` → sin errores

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHeH98E2osimuNWWmCvPqF