### PR TITLE
feat(promotions): promociones V2 con catálogo compartido y despacho estricto por proveedor

### DIFF
--- a/migrations/Version20260818090000.php
+++ b/migrations/Version20260818090000.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Marca el origen de un CommunicationPackage: nullable = catálogo regular
+ * (sincronizado o creado a mano), no nulo = generado por rango para una
+ * promoción V2 (ver App\Entity\CommunicationPromotions). Necesario porque
+ * CommunicationPackageRepository::findByDestination() (usado por el
+ * catálogo normal y por CommunicationContractService::createByRange()) no
+ * debe confundir una copia promocional con el paquete regular del mismo
+ * monto — dos paquetes pueden compartir tupla destino a propósito (ver
+ * docblock de CommunicationPackage).
+ */
+final class Version20260818090000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Agrega communication_package.promotion_id (origen: catálogo regular vs. generado por promoción V2)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE communication_package ADD COLUMN IF NOT EXISTS promotion_id INT DEFAULT NULL');
+
+        $this->addSql(<<<'SQL'
+            ALTER TABLE communication_package
+                ADD CONSTRAINT FK_CP_PROMOTION FOREIGN KEY (promotion_id) REFERENCES communication_promotions (id) ON DELETE CASCADE
+                NOT DEFERRABLE INITIALLY IMMEDIATE
+        SQL);
+
+        $this->addSql(<<<'SQL'
+            CREATE INDEX IF NOT EXISTS idx_com_package_promotion
+                ON communication_package (promotion_id)
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IF EXISTS idx_com_package_promotion');
+        $this->addSql('ALTER TABLE communication_package DROP CONSTRAINT IF EXISTS FK_CP_PROMOTION');
+        $this->addSql('ALTER TABLE communication_package DROP COLUMN IF EXISTS promotion_id');
+    }
+}

--- a/migrations/Version20260818093000.php
+++ b/migrations/Version20260818093000.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Afloja communication_promotions.product_id a nullable. Era el "producto
+ * de origen" legacy (V1, un único producto de un único proveedor) — las
+ * promociones V2 (Fase 5) no tienen ese concepto: cada proveedor resuelve
+ * su propia equivalencia por tramo vía CommunicationPackageProviderProduct.
+ * Aditivo: las promociones legacy existentes conservan su product_id.
+ */
+final class Version20260818093000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Afloja communication_promotions.product_id a nullable (promociones V2 sin producto de origen)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE communication_promotions ALTER COLUMN product_id DROP NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE communication_promotions ALTER COLUMN product_id SET NOT NULL');
+    }
+}

--- a/migrations/Version20260818140000.php
+++ b/migrations/Version20260818140000.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Fase 6A del rediseño de promociones V2: CommunicationContract pasa de
+ * "un contrato → un CommunicationPackage" (FK communication_package_id,
+ * NOT NULL) a "un contrato → N CommunicationPackage" (tabla puente
+ * communication_contract_package). Un contrato deja de ser "el precio de
+ * ESTE paquete" y pasa a ser "el precio para (tenant, destinationAmount,
+ * destinationCurrency)" — dos paquetes que comparten esa tupla (ej. un
+ * paquete del catálogo normal y uno generado por una promoción V2 al mismo
+ * monto) terminan en el MISMO contrato, sin duplicar filas.
+ *
+ * Migra los datos existentes (cada contrato conserva su único paquete de
+ * hoy, ahora vía la tabla puente) antes de tocar la columna vieja.
+ *
+ * down() es reversible pero con pérdida de información si algún contrato
+ * terminó con más de un paquete tras up() + operación normal: solo puede
+ * recuperar UN paquete por contrato (el de menor id), porque
+ * communication_package_id vuelve a ser una columna singular NOT NULL.
+ */
+final class Version20260818140000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'CommunicationContract: de FK singular a ManyToMany con CommunicationPackage (Fase 6A)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE IF NOT EXISTS communication_contract_package (
+                communication_contract_id INT NOT NULL,
+                communication_package_id  INT NOT NULL,
+                PRIMARY KEY (communication_contract_id, communication_package_id)
+            )
+        SQL);
+
+        $this->addSql(<<<'SQL'
+            ALTER TABLE communication_contract_package
+                ADD CONSTRAINT FK_CCP_CONTRACT FOREIGN KEY (communication_contract_id) REFERENCES communication_contract (id) ON DELETE CASCADE
+                NOT DEFERRABLE INITIALLY IMMEDIATE
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE communication_contract_package
+                ADD CONSTRAINT FK_CCP_PACKAGE FOREIGN KEY (communication_package_id) REFERENCES communication_package (id) ON DELETE CASCADE
+                NOT DEFERRABLE INITIALLY IMMEDIATE
+        SQL);
+        $this->addSql(<<<'SQL'
+            CREATE INDEX IF NOT EXISTS idx_com_contract_package_package
+                ON communication_contract_package (communication_package_id)
+        SQL);
+
+        // Migrar los datos existentes ANTES de tocar communication_package_id.
+        $this->addSql(<<<'SQL'
+            INSERT INTO communication_contract_package (communication_contract_id, communication_package_id)
+                SELECT id, communication_package_id FROM communication_contract
+                ON CONFLICT DO NOTHING
+        SQL);
+
+        $this->addSql('DROP INDEX IF EXISTS uniq_com_contract_open_per_tenant_package');
+        $this->addSql('DROP INDEX IF EXISTS idx_com_contract_tenant_package');
+        $this->addSql('DROP INDEX IF EXISTS idx_com_contract_default_package');
+        $this->addSql('ALTER TABLE communication_contract DROP CONSTRAINT IF EXISTS fk_cc_package');
+        $this->addSql('ALTER TABLE communication_contract DROP COLUMN IF EXISTS communication_package_id');
+
+        $this->addSql(<<<'SQL'
+            CREATE INDEX IF NOT EXISTS idx_com_contract_tenant_amount
+                ON communication_contract (tenant_id, destination_amount, destination_currency, start_at DESC, end_at)
+        SQL);
+        $this->addSql(<<<'SQL'
+            CREATE INDEX IF NOT EXISTS idx_com_contract_default_amount
+                ON communication_contract (destination_amount, destination_currency, start_at DESC, end_at)
+                WHERE tenant_id IS NULL
+        SQL);
+        // PostgreSQL 18: NULLS NOT DISTINCT — como tenant_id puede ser NULL
+        // (contrato "por defecto"), sin esto podría haber dos contratos
+        // por-defecto abiertos simultáneos de la misma tupla.
+        $this->addSql(<<<'SQL'
+            CREATE UNIQUE INDEX IF NOT EXISTS uniq_com_contract_open_per_tenant_amount
+                ON communication_contract (tenant_id, destination_amount, destination_currency)
+                NULLS NOT DISTINCT
+                WHERE end_at IS NULL
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IF EXISTS uniq_com_contract_open_per_tenant_amount');
+        $this->addSql('DROP INDEX IF EXISTS idx_com_contract_default_amount');
+        $this->addSql('DROP INDEX IF EXISTS idx_com_contract_tenant_amount');
+
+        $this->addSql('ALTER TABLE communication_contract ADD COLUMN IF NOT EXISTS communication_package_id INT');
+
+        // Solo puede recuperar UN paquete por contrato (el de menor id) —
+        // ver docblock de clase sobre pérdida de información.
+        $this->addSql(<<<'SQL'
+            UPDATE communication_contract c
+                SET communication_package_id = sub.communication_package_id
+                FROM (
+                    SELECT DISTINCT ON (communication_contract_id) communication_contract_id, communication_package_id
+                    FROM communication_contract_package
+                    ORDER BY communication_contract_id, communication_package_id ASC
+                ) sub
+                WHERE c.id = sub.communication_contract_id
+        SQL);
+
+        $this->addSql('ALTER TABLE communication_contract ALTER COLUMN communication_package_id SET NOT NULL');
+        $this->addSql(<<<'SQL'
+            ALTER TABLE communication_contract
+                ADD CONSTRAINT FK_CC_PACKAGE FOREIGN KEY (communication_package_id) REFERENCES communication_package (id)
+                NOT DEFERRABLE INITIALLY IMMEDIATE
+        SQL);
+
+        $this->addSql(<<<'SQL'
+            CREATE INDEX IF NOT EXISTS idx_com_contract_tenant_package
+                ON communication_contract (tenant_id, communication_package_id, start_at DESC, end_at)
+        SQL);
+        $this->addSql(<<<'SQL'
+            CREATE INDEX IF NOT EXISTS idx_com_contract_default_package
+                ON communication_contract (communication_package_id, start_at DESC, end_at)
+                WHERE tenant_id IS NULL
+        SQL);
+        $this->addSql(<<<'SQL'
+            CREATE UNIQUE INDEX IF NOT EXISTS uniq_com_contract_open_per_tenant_package
+                ON communication_contract (tenant_id, communication_package_id)
+                NULLS NOT DISTINCT
+                WHERE end_at IS NULL
+        SQL);
+
+        $this->addSql('DROP TABLE IF EXISTS communication_contract_package');
+    }
+}

--- a/src/Controller/DashboardCommunicationContractsController.php
+++ b/src/Controller/DashboardCommunicationContractsController.php
@@ -55,12 +55,17 @@ class DashboardCommunicationContractsController extends AbstractController
         $limit = min(100, max(1, (int) $request->query->get('limit', 20)));
         $orderBy = $request->query->get('orderBy', 'id DESC');
 
+        // Sin fetch-join de `packages` aquí a propósito: es una colección
+        // ManyToMany (to-many) y Doctrine no puede aplicar setMaxResults()
+        // de forma fiable sobre una fetch-join de colección — cada paquete
+        // extra de un contrato agrega una fila SQL, corriendo la paginación
+        // (un contrato con 2 paquetes consume 2 cupos de $limit+1 en vez de
+        // 1). `p` se usa solo para el filtro communicationPackageId; las
+        // colecciones de la página se recargan aparte más abajo.
         $qb = $this->em->getRepository(CommunicationContract::class)
             ->createQueryBuilder('c')
-            ->leftJoin('c.communicationPackage', 'p')
             ->leftJoin('c.tenant', 't')
             ->leftJoin('t.client', 'cl')
-            ->addSelect('p')
             ->addSelect('t')
             ->addSelect('cl');
 
@@ -78,6 +83,8 @@ class DashboardCommunicationContractsController extends AbstractController
         if ($hasNext) {
             array_pop($results);
         }
+
+        $this->eagerLoadPackages($results);
 
         return $this->json([
             'limit' => $limit,
@@ -218,10 +225,34 @@ class DashboardCommunicationContractsController extends AbstractController
         return $this->json(['deleted' => $deleted]);
     }
 
+    /**
+     * Recarga en lote las colecciones `packages` de los contratos de la
+     * página actual — a salvo del fan-out de la paginación (ver comentario
+     * en list()) porque acá no hay setMaxResults(): el IN (:ids) ya acota
+     * el resultado a exactamente los contratos de esta página.
+     *
+     * @param list<CommunicationContract> $contracts
+     */
+    private function eagerLoadPackages(array $contracts): void
+    {
+        $ids = array_map(static fn (CommunicationContract $c) => $c->getId(), $contracts);
+        if ($ids === []) {
+            return;
+        }
+
+        $this->em->getRepository(CommunicationContract::class)
+            ->createQueryBuilder('c')
+            ->leftJoin('c.packages', 'p')
+            ->addSelect('p')
+            ->where('c.id IN (:ids)')
+            ->setParameter('ids', $ids)
+            ->getQuery()->getResult();
+    }
+
     private function applyFilters(QueryBuilder $qb, Request $request): void
     {
         if ($packageId = $request->query->get('communicationPackageId')) {
-            $qb->andWhere('p.id = :packageId')->setParameter('packageId', $packageId);
+            $qb->andWhere(':packageId MEMBER OF c.packages')->setParameter('packageId', $packageId);
         }
         if ($tenantId = $request->query->get('tenantId')) {
             // tenantId es Client.id (mismo espacio que en los DTOs de alta,
@@ -243,8 +274,10 @@ class DashboardCommunicationContractsController extends AbstractController
 
         return [
             'id' => $contract->getId(),
-            'communicationPackageId' => $contract->getCommunicationPackage()?->getId(),
-            'communicationPackageName' => $contract->getCommunicationPackage()?->getName(),
+            'packages' => array_map(
+                static fn ($p) => ['id' => $p->getId(), 'name' => $p->getName()],
+                $contract->getPackages()->toArray(),
+            ),
             'tenant' => [
                 'id' => $contract->getTenant()?->getId(),
                 'clientName' => $contract->getTenant()?->getClient()?->getCompanyName(),

--- a/src/Controller/DashboardPromotionController.php
+++ b/src/Controller/DashboardPromotionController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller;
 
+use App\DTO\CreatePromotionV2Dto;
 use App\DTO\Out\DeletedOutDto;
 use App\DTO\Out\PaginatedListOutDto;
 use App\DTO\SetPromotionProviderProductDto;
@@ -114,6 +115,33 @@ class DashboardPromotionController extends AbstractController
         }
 
         return $this->json($result, Response::HTTP_CREATED);
+    }
+
+    #[Route('/v2', name: 'dashboard_promotions_create_v2', methods: ['POST'])]
+    #[IsGranted('ROLE_ADMIN')]
+    #[DashboardEndpoint(summary: 'Crear promoción V2 (catálogo compartido)', tag: 'Promotions', requestDto: CreatePromotionV2Dto::class, responseStatusCode: 201)]
+    public function createV2(CreatePromotionV2Dto $dto): JsonResponse
+    {
+        try {
+            $result = $this->promotionService->createV2($dto);
+        } catch (MyCurrentException $e) {
+            return $this->json(['error' => ['message' => $e->getMessage()]], $e->getCode());
+        }
+
+        return $this->json([
+            'promotion' => $this->normalizeDetail($result->promotion),
+            'packagesCreated' => count($result->packages),
+            'packages' => array_map(fn ($p) => [
+                'id' => $p->getId(),
+                'name' => $p->getName(),
+                'destinationAmount' => $p->getDestinationAmount(),
+                'destinationCurrency' => $p->getDestinationCurrency(),
+            ], $result->packages),
+            'contracts' => [
+                'created' => $result->contracts->created,
+                'updated' => $result->contracts->updated,
+            ],
+        ], Response::HTTP_CREATED);
     }
 
     #[Route('/{id}', name: 'dashboard_promotions_update', methods: ['PATCH', 'PUT'])]

--- a/src/Controller/DashboardPromotionController.php
+++ b/src/Controller/DashboardPromotionController.php
@@ -16,6 +16,8 @@ use App\OpenApi\Attribute\DashboardEndpoint;
 use App\Repository\CommunicationPromotionsRepository;
 use App\Service\CommunicationPromotionService;
 use App\Service\Pricing\CommunicationPromotionBindingService;
+use App\Service\Pricing\CommunicationPromotionEquivalenceService;
+use App\Service\Pricing\PromotionEquivalenceResult;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -34,6 +36,7 @@ class DashboardPromotionController extends AbstractController
         private readonly NormalizerInterface $serializer,
         private readonly CommunicationPromotionService $promotionService,
         private readonly CommunicationPromotionBindingService $bindingService,
+        private readonly CommunicationPromotionEquivalenceService $equivalenceService,
     ) {
     }
 
@@ -141,7 +144,33 @@ class DashboardPromotionController extends AbstractController
                 'created' => $result->contracts->created,
                 'updated' => $result->contracts->updated,
             ],
+            'equivalences' => $this->serializeEquivalenceResult($result->equivalences),
         ], Response::HTTP_CREATED);
+    }
+
+    #[Route('/{id}/v2/equivalences', name: 'dashboard_promotions_v2_equivalences', methods: ['GET'])]
+    #[DashboardEndpoint(summary: 'Cobertura de equivalencias por proveedor de una promoción V2', tag: 'Promotions')]
+    public function equivalences(int $id): JsonResponse
+    {
+        $promotion = $this->repository->find($id);
+        if ($promotion === null) {
+            return $this->json(['error' => ['message' => 'Promotion not found']], Response::HTTP_NOT_FOUND);
+        }
+
+        return $this->json($this->serializeEquivalenceResult($this->equivalenceService->coverage($promotion)));
+    }
+
+    #[Route('/{id}/v2/equivalences/refresh', name: 'dashboard_promotions_v2_equivalences_refresh', methods: ['POST'])]
+    #[IsGranted('ROLE_ADMIN')]
+    #[DashboardEndpoint(summary: 'Vuelve a poblar las equivalencias por proveedor de una promoción V2', tag: 'Promotions')]
+    public function refreshEquivalences(int $id): JsonResponse
+    {
+        $promotion = $this->repository->find($id);
+        if ($promotion === null) {
+            return $this->json(['error' => ['message' => 'Promotion not found']], Response::HTTP_NOT_FOUND);
+        }
+
+        return $this->json($this->serializeEquivalenceResult($this->equivalenceService->refreshForPromotion($promotion)));
     }
 
     #[Route('/{id}', name: 'dashboard_promotions_update', methods: ['PATCH', 'PUT'])]
@@ -236,6 +265,14 @@ class DashboardPromotionController extends AbstractController
         }
 
         return $this->json(['deleted' => true]);
+    }
+
+    private function serializeEquivalenceResult(PromotionEquivalenceResult $result): array
+    {
+        return [
+            'providers' => $result->providers,
+            'gaps' => $result->gaps,
+        ];
     }
 
     private function serializeProduct(?CommunicationProduct $product): ?array

--- a/src/DTO/CreatePromotionV2Dto.php
+++ b/src/DTO/CreatePromotionV2Dto.php
@@ -1,0 +1,246 @@
+<?php
+
+namespace App\DTO;
+
+use App\OpenApi\Attribute\OAProperty;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+
+/**
+ * Alta de promoción V2 (catálogo compartido, Fase 5B) — a diferencia de
+ * UpsertPromotionDto (legacy, un producto de origen + paquetes por
+ * cliente), esta genera un CommunicationPackage por cada monto del rango
+ * [amountFrom, amountTo] saltando de amountStep en amountStep (ambos
+ * extremos incluidos, así que amountFrom == amountTo es válido para una
+ * promoción de un solo producto), marcado con esta promoción — catálogo
+ * compartido, vigente solo durante [startAt, endAt] — más un
+ * CommunicationContract "por defecto" por cada uno, con el precio
+ * interpolado linealmente entre priceFrom/priceTo. NO tiene productId: las
+ * equivalencias por proveedor se resuelven aparte (Fase 5C/5D) — sin
+ * equivalencia explícita, ningún proveedor despacha ese tramo.
+ */
+class CreatePromotionV2Dto implements IInput
+{
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 255)]
+    protected ?string $name;
+
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 255)]
+    protected ?string $description;
+
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 255)]
+    protected ?string $packageNameTemplate;
+
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 255)]
+    protected ?string $packageDescriptionTemplate;
+
+    #[Assert\Length(max: 500)]
+    protected ?string $knowMore;
+
+    #[Assert\NotBlank]
+    protected ?string $startAt;
+
+    #[Assert\NotBlank]
+    protected ?string $endAt;
+
+    #[Assert\NotNull]
+    #[Assert\Positive]
+    protected ?int $environmentId;
+
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 10)]
+    protected ?string $destinationCurrency;
+
+    #[Assert\NotNull]
+    #[Assert\Positive]
+    protected ?float $amountFrom;
+
+    #[Assert\NotNull]
+    #[Assert\Positive]
+    protected ?float $amountTo;
+
+    #[Assert\NotNull]
+    #[Assert\Positive]
+    protected ?float $amountStep;
+
+    #[Assert\NotNull]
+    #[Assert\PositiveOrZero]
+    protected ?float $priceFrom;
+
+    #[Assert\NotNull]
+    #[Assert\PositiveOrZero]
+    protected ?float $priceTo;
+
+    #[Assert\NotBlank]
+    #[Assert\Length(exactly: 3)]
+    protected ?string $priceCurrency;
+
+    #[Assert\PositiveOrZero]
+    protected ?int $displayOrder;
+
+    #[OAProperty(schema: [
+        'type' => 'array',
+        'nullable' => true,
+        'items' => [
+            'type' => 'object',
+            'properties' => [
+                'type' => ['type' => 'string', 'enum' => ['CREDITS', 'TALKTIME', 'DATA', 'SMS']],
+                'unit' => ['type' => 'string', 'enum' => ['CUP', 'USD', 'UNITS', 'MINUTES', 'GB', 'ILIM']],
+                'unit_type' => ['type' => 'string', 'enum' => ['CURRENCY', 'QUANTITY', 'DATA', 'TIME']],
+                'additional_information' => ['type' => 'string'],
+                'amount' => ['type' => 'object', 'properties' => [
+                    'base' => ['type' => 'integer'],
+                    'promotion_bonus' => ['type' => 'integer'],
+                ]],
+            ],
+        ],
+    ])]
+    protected ?array $benefits;
+
+    #[OAProperty(schema: [
+        'type' => 'array',
+        'nullable' => true,
+        'items' => ['type' => 'string', 'enum' => ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET']],
+    ])]
+    protected ?array $tags;
+
+    #[OAProperty(schema: [
+        'type' => 'object',
+        'nullable' => true,
+        'properties' => [
+            'name' => ['type' => 'string', 'enum' => ['Mobile', 'uSIM', 'Devices']],
+            'subservice' => ['type' => 'object', 'properties' => [
+                'name' => ['type' => 'string', 'enum' => ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET', 'uSIM']],
+            ]],
+        ],
+    ])]
+    protected ?array $service;
+
+    #[OAProperty(schema: [
+        'type' => 'object',
+        'nullable' => true,
+        'default' => null,
+        'properties' => [
+            'quantity' => ['type' => 'integer'],
+            'unit' => ['type' => 'string', 'enum' => ['DAYS', 'MONTH', 'YEAR']],
+        ],
+    ])]
+    protected ?array $validity;
+
+    public function __construct(
+        ?string $name = null,
+        ?string $description = null,
+        ?string $packageNameTemplate = null,
+        ?string $packageDescriptionTemplate = null,
+        ?string $knowMore = null,
+        ?string $startAt = null,
+        ?string $endAt = null,
+        ?int $environmentId = null,
+        ?string $destinationCurrency = null,
+        ?float $amountFrom = null,
+        ?float $amountTo = null,
+        ?float $amountStep = null,
+        ?float $priceFrom = null,
+        ?float $priceTo = null,
+        ?string $priceCurrency = null,
+        ?int $displayOrder = null,
+        ?array $benefits = null,
+        ?array $tags = null,
+        ?array $service = null,
+        ?array $validity = null,
+    ) {
+        $this->name = $name;
+        $this->description = $description;
+        $this->packageNameTemplate = $packageNameTemplate;
+        $this->packageDescriptionTemplate = $packageDescriptionTemplate;
+        $this->knowMore = $knowMore;
+        $this->startAt = $startAt;
+        $this->endAt = $endAt;
+        $this->environmentId = $environmentId;
+        $this->destinationCurrency = $destinationCurrency;
+        $this->amountFrom = $amountFrom;
+        $this->amountTo = $amountTo;
+        $this->amountStep = $amountStep;
+        $this->priceFrom = $priceFrom;
+        $this->priceTo = $priceTo;
+        $this->priceCurrency = $priceCurrency;
+        $this->displayOrder = $displayOrder;
+        $this->benefits = $benefits;
+        $this->tags = $tags;
+        $this->service = $service;
+        $this->validity = $validity;
+    }
+
+    #[Assert\Callback]
+    public function validateRange(ExecutionContextInterface $context): void
+    {
+        if ($this->amountFrom !== null && $this->amountTo !== null && $this->amountTo < $this->amountFrom) {
+            $context->buildViolation('El monto final debe ser mayor o igual al monto inicial')
+                ->atPath('amountTo')
+                ->addViolation();
+        }
+    }
+
+    public function getName(): ?string { return $this->name; }
+    public function setName(?string $v): void { $this->name = $v; }
+
+    public function getDescription(): ?string { return $this->description; }
+    public function setDescription(?string $v): void { $this->description = $v; }
+
+    public function getPackageNameTemplate(): ?string { return $this->packageNameTemplate; }
+    public function setPackageNameTemplate(?string $v): void { $this->packageNameTemplate = $v; }
+
+    public function getPackageDescriptionTemplate(): ?string { return $this->packageDescriptionTemplate; }
+    public function setPackageDescriptionTemplate(?string $v): void { $this->packageDescriptionTemplate = $v; }
+
+    public function getKnowMore(): ?string { return $this->knowMore; }
+    public function setKnowMore(?string $v): void { $this->knowMore = $v; }
+
+    public function getStartAt(): ?string { return $this->startAt; }
+    public function setStartAt(?string $v): void { $this->startAt = $v; }
+
+    public function getEndAt(): ?string { return $this->endAt; }
+    public function setEndAt(?string $v): void { $this->endAt = $v; }
+
+    public function getEnvironmentId(): ?int { return $this->environmentId; }
+    public function setEnvironmentId(?int $v): void { $this->environmentId = $v; }
+
+    public function getDestinationCurrency(): ?string { return $this->destinationCurrency; }
+    public function setDestinationCurrency(?string $v): void { $this->destinationCurrency = $v; }
+
+    public function getAmountFrom(): ?float { return $this->amountFrom; }
+    public function setAmountFrom(?float $v): void { $this->amountFrom = $v; }
+
+    public function getAmountTo(): ?float { return $this->amountTo; }
+    public function setAmountTo(?float $v): void { $this->amountTo = $v; }
+
+    public function getAmountStep(): ?float { return $this->amountStep; }
+    public function setAmountStep(?float $v): void { $this->amountStep = $v; }
+
+    public function getPriceFrom(): ?float { return $this->priceFrom; }
+    public function setPriceFrom(?float $v): void { $this->priceFrom = $v; }
+
+    public function getPriceTo(): ?float { return $this->priceTo; }
+    public function setPriceTo(?float $v): void { $this->priceTo = $v; }
+
+    public function getPriceCurrency(): ?string { return $this->priceCurrency; }
+    public function setPriceCurrency(?string $v): void { $this->priceCurrency = $v; }
+
+    public function getDisplayOrder(): ?int { return $this->displayOrder; }
+    public function setDisplayOrder(?int $v): void { $this->displayOrder = $v; }
+
+    public function getBenefits(): ?array { return $this->benefits; }
+    public function setBenefits(?array $v): void { $this->benefits = $v; }
+
+    public function getTags(): ?array { return $this->tags; }
+    public function setTags(?array $v): void { $this->tags = $v; }
+
+    public function getService(): ?array { return $this->service; }
+    public function setService(?array $v): void { $this->service = $v; }
+
+    public function getValidity(): ?array { return $this->validity; }
+    public function setValidity(?array $v): void { $this->validity = $v; }
+}

--- a/src/DTO/Out/CommunicationContractOutDto.php
+++ b/src/DTO/Out/CommunicationContractOutDto.php
@@ -5,8 +5,12 @@ namespace App\DTO\Out;
 final class CommunicationContractOutDto
 {
     public int $id;
-    public int $communicationPackageId;
-    public ?string $communicationPackageName = null;
+
+    /**
+     * @var list<CommunicationPackageRefOutDto>
+     */
+    public array $packages = [];
+
     public ?TenantRefOutDto $tenant = null;
     public float $destinationAmount;
     public string $destinationCurrency;

--- a/src/DTO/Out/CommunicationPackageRefOutDto.php
+++ b/src/DTO/Out/CommunicationPackageRefOutDto.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\DTO\Out;
+
+final class CommunicationPackageRefOutDto
+{
+    public int $id;
+    public string $name;
+}

--- a/src/Entity/CommunicationContract.php
+++ b/src/Entity/CommunicationContract.php
@@ -3,18 +3,24 @@
 namespace App\Entity;
 
 use App\Repository\CommunicationContractRepository;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * Contrato de precio/visibilidad para un CommunicationPackage concreto
- * (rediseño V2). El match con el paquete es SIEMPRE por el FK
- * `communicationPackage` — nunca por la tupla (destinationAmount/
- * destinationCurrency), que aquí solo es un snapshot congelado en el
- * momento de crear el contrato (si el paquete cambia después, los
- * contratos ya emitidos no se alteran).
+ * Contrato de precio/visibilidad para un `(tenant, destinationAmount,
+ * destinationCurrency)` (rediseño V2, ManyToMany desde 2026-08-18 — ver
+ * docs de la Fase 6). `destinationAmount`/`destinationCurrency` son la
+ * IDENTIDAD del contrato (con `tenant`, definen su tupla única mientras
+ * esté abierto) — YA NO son solo snapshot: `CommunicationContractService::
+ * upsertContract()` deduplica por esta tupla, así que dos
+ * `CommunicationPackage` distintos que compartan monto y tenant terminan en
+ * el MISMO contrato (`$packages`), a propósito — es lo que permite que un
+ * paquete promocional a un monto ya cubierto por el catálogo normal
+ * aparezca junto a él sin tocar la precedencia de `PackageCatalogResolver`.
  *
  * `tenant === null` = contrato "por defecto": aplica a cualquier cuenta sin
- * contrato propio para este paquete, con el mismo efecto de
+ * contrato propio para esta tupla, con el mismo efecto de
  * visibilidad/precio que uno específico (ver PackageCatalogResolver, Fase
  * 2). Sin `isActive`: la vigencia es solo `startAt`/`endAt` — "pausar" es
  * cerrar (`endAt = now()`) y crear uno nuevo si se reactiva.
@@ -28,21 +34,29 @@ class CommunicationContract
     #[ORM\Column]
     private ?int $id = null;
 
-    #[ORM\ManyToOne(targetEntity: CommunicationPackage::class)]
-    #[ORM\JoinColumn(nullable: false)]
-    private ?CommunicationPackage $communicationPackage = null;
+    /**
+     * Todos los CommunicationPackage que este contrato cubre — cualquiera
+     * que comparta `(destinationAmount, destinationCurrency)` con el
+     * contrato en el momento en que se le asoció (ver upsertContract()).
+     * Lado propietario de la relación (la tabla puente es
+     * communication_contract_package).
+     *
+     * @var Collection<int, CommunicationPackage>
+     */
+    #[ORM\ManyToMany(targetEntity: CommunicationPackage::class)]
+    #[ORM\JoinTable(name: 'communication_contract_package')]
+    private Collection $packages;
 
     /**
      * null = contrato "por defecto" (aplica a cualquier cuenta sin contrato
-     * propio para este paquete).
+     * propio para esta tupla).
      */
     #[ORM\ManyToOne(targetEntity: Account::class)]
     #[ORM\JoinColumn(nullable: true, onDelete: 'CASCADE')]
     private ?Account $tenant = null;
 
     /**
-     * Snapshot de CommunicationPackage::$destinationAmount al crear el
-     * contrato — no se usa para buscar (eso es el FK), solo auditoría.
+     * Identidad del contrato junto con `tenant` — ver docblock de clase.
      */
     #[ORM\Column]
     private ?float $destinationAmount = null;
@@ -83,6 +97,7 @@ class CommunicationContract
     public function __construct()
     {
         $this->startAt = new \DateTimeImmutable();
+        $this->packages = new ArrayCollection();
     }
 
     public function getId(): ?int
@@ -90,14 +105,26 @@ class CommunicationContract
         return $this->id;
     }
 
-    public function getCommunicationPackage(): ?CommunicationPackage
+    /**
+     * @return Collection<int, CommunicationPackage>
+     */
+    public function getPackages(): Collection
     {
-        return $this->communicationPackage;
+        return $this->packages;
     }
 
-    public function setCommunicationPackage(CommunicationPackage $communicationPackage): static
+    public function addPackage(CommunicationPackage $package): static
     {
-        $this->communicationPackage = $communicationPackage;
+        if (!$this->packages->contains($package)) {
+            $this->packages->add($package);
+        }
+
+        return $this;
+    }
+
+    public function removePackage(CommunicationPackage $package): static
+    {
+        $this->packages->removeElement($package);
 
         return $this;
     }

--- a/src/Entity/CommunicationPackage.php
+++ b/src/Entity/CommunicationPackage.php
@@ -10,6 +10,8 @@ use App\Repository\CommunicationPackageRepository;
 use App\Service\Pricing\ResolvedPackageOffer;
 use App\State\CommunicationPackageCatalogItemProvider;
 use App\State\CommunicationPackageCatalogProvider;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Attribute\Groups;
 
@@ -266,17 +268,38 @@ class CommunicationPackage
     #[ORM\JoinColumn(name: 'promotion_id', nullable: true, onDelete: 'CASCADE')]
     private ?CommunicationPromotions $promotion = null;
 
+    /**
+     * Lado inverso de CommunicationContract::$packages — solo para el guard
+     * de borrado (CommunicationPackageAdminService::delete()): un paquete
+     * con al menos un contrato no se puede borrar (FK RESTRICT en la tabla
+     * puente). No se usa para resolver catálogo/precio (eso sigue siendo
+     * responsabilidad de PackageCatalogResolver desde el lado contrato).
+     *
+     * @var Collection<int, CommunicationContract>
+     */
+    #[ORM\ManyToMany(targetEntity: CommunicationContract::class, mappedBy: 'packages')]
+    private Collection $contracts;
+
     public function __construct()
     {
         $this->benefits = [];
         $this->tags = [];
         $this->service = [];
         $this->activeStartAt = new \DateTimeImmutable();
+        $this->contracts = new ArrayCollection();
     }
 
     public function getId(): ?int
     {
         return $this->id;
+    }
+
+    /**
+     * @return Collection<int, CommunicationContract>
+     */
+    public function getContracts(): Collection
+    {
+        return $this->contracts;
     }
 
     public function getName(): ?string

--- a/src/Entity/CommunicationPackage.php
+++ b/src/Entity/CommunicationPackage.php
@@ -253,6 +253,19 @@ class CommunicationPackage
      */
     private ?ResolvedPackageOffer $resolvedOffer = null;
 
+    /**
+     * Null = catálogo regular (sincronizado o creado a mano). No nulo =
+     * este paquete fue generado por rango para una promoción V2 (ver
+     * CommunicationPromotionService/Fase 5) — activo solo durante su
+     * ventana (activeStartAt/activeEndAt heredados de la promoción) y
+     * SIN fallback a auto-match en ProviderDispatchResolver: un
+     * proveedor sin CommunicationPackageProviderProduct explícito para
+     * este paquete simplemente no lo despacha.
+     */
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(name: 'promotion_id', nullable: true, onDelete: 'CASCADE')]
+    private ?CommunicationPromotions $promotion = null;
+
     public function __construct()
     {
         $this->benefits = [];
@@ -512,5 +525,17 @@ class CommunicationPackage
     public function getCurrency(): ?string
     {
         return $this->resolvedOffer?->currency;
+    }
+
+    public function getPromotion(): ?CommunicationPromotions
+    {
+        return $this->promotion;
+    }
+
+    public function setPromotion(?CommunicationPromotions $promotion): static
+    {
+        $this->promotion = $promotion;
+
+        return $this;
     }
 }

--- a/src/Entity/CommunicationPromotions.php
+++ b/src/Entity/CommunicationPromotions.php
@@ -238,6 +238,18 @@ class CommunicationPromotions
         return $this->product;
     }
 
+    /**
+     * true = promoción V2 (catálogo compartido, sin producto de origen —
+     * ver createV2()). false = legacy (V1). Expuesto en el listado para
+     * que el dashboard sepa qué acciones mostrar (bindings legacy vs.
+     * equivalencias V2).
+     */
+    #[Groups(['comProm:read', 'promotion:list', 'promotion:detail'])]
+    public function isV2(): bool
+    {
+        return $this->product === null;
+    }
+
     public function setProduct(?CommunicationProduct $product): static
     {
         $this->product = $product;

--- a/src/Entity/CommunicationPromotions.php
+++ b/src/Entity/CommunicationPromotions.php
@@ -84,8 +84,16 @@ class CommunicationPromotions
     #[Groups(['comProm:read', 'comPackage:read', 'promotion:list', 'promotion:detail'])]
     private ?\DateTimeImmutable $endAt = null;
 
+    /**
+     * "Producto de origen" legacy (V1) — un único producto de un único
+     * proveedor. Nullable desde el rediseño V2 (Fase 5): una promoción V2
+     * no tiene un producto de origen global, cada proveedor resuelve su
+     * propia equivalencia por tramo (ver CommunicationPackageProviderProduct
+     * + ProviderDispatchResolver en modo estricto). Las promociones legacy
+     * existentes siguen con este campo lleno.
+     */
     #[ORM\ManyToOne]
-    #[ORM\JoinColumn(nullable: false)]
+    #[ORM\JoinColumn(nullable: true)]
     private ?CommunicationProduct $product = null;
 
     #[ORM\ManyToMany(targetEntity: CommunicationClientPackage::class, inversedBy: 'promotionItems')]

--- a/src/Provider/Contract/PromotionCatalogQuery.php
+++ b/src/Provider/Contract/PromotionCatalogQuery.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Provider\Contract;
+
+/**
+ * Parámetros para ProviderPromotionCatalogInterface::fetchPromotionProducts()
+ * — qué tramos cubre la promoción y en qué ventana está vigente. Cada
+ * adaptador decide con esto qué fuente consultar: DTOne filtra su propio
+ * `GET /v1/promotions` por solapamiento de fecha; ETECSA/CSQ, sin concepto
+ * de "promoción" del lado del proveedor, ignoran la ventana y devuelven su
+ * catálogo normal (la vigencia la impone nuestro CommunicationPackage, no
+ * el proveedor).
+ */
+final readonly class PromotionCatalogQuery
+{
+    /**
+     * @param list<float> $destinationAmounts montos exactos de los tramos generados
+     */
+    public function __construct(
+        public string $destinationCurrency,
+        public array $destinationAmounts,
+        public \DateTimeImmutable $activeFrom,
+        public \DateTimeImmutable $activeTo,
+    ) {
+    }
+}

--- a/src/Provider/Contract/ProviderPromotionCatalogInterface.php
+++ b/src/Provider/Contract/ProviderPromotionCatalogInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Provider\Contract;
+
+/**
+ * Capacidad opcional (ProviderRegistry::allImplementing()): "dame los
+ * productos candidatos para poblar las equivalencias de una promoción V2"
+ * (Fase 5C/5D del rediseño de promociones). Cada proveedor decide su propia
+ * fuente — no hay un criterio único:
+ *  - DTOne: GET /v1/promotions (campañas reales del proveedor, filtradas
+ *    por solapamiento de ventana) — solo devuelve productos que de verdad
+ *    pertenecen a una promoción vigente de DTOne, evitando el problema de
+ *    productos-bono indistinguibles por tupla (ver
+ *    docs/promotion-provider-routing-por-tramo.md §4).
+ *  - ETECSA/CSQ: no tienen concepto de "promoción" propio — delegan en
+ *    fetchProducts() (su catálogo normal); la vigencia la impone nuestro
+ *    CommunicationPackage, no el proveedor.
+ *
+ * Un proveedor que no la implemente simplemente no participa en el
+ * poblado automático (Fase 5D) — sigue pudiendo recibir un vínculo manual.
+ */
+interface ProviderPromotionCatalogInterface extends CommunicationProviderInterface
+{
+    /**
+     * @return iterable<ProviderProductDto>
+     */
+    public function fetchPromotionProducts(ProviderContext $context, PromotionCatalogQuery $query): iterable;
+}

--- a/src/Provider/Csq/CsqCommunicationProvider.php
+++ b/src/Provider/Csq/CsqCommunicationProvider.php
@@ -16,8 +16,10 @@ use App\Provider\Contract\ProviderDispatchResult;
 use App\Provider\Contract\ProviderHealthCheckInterface;
 use App\Provider\Contract\ProviderPingResult;
 use App\Provider\Contract\ProviderProductDto;
+use App\Provider\Contract\ProviderPromotionCatalogInterface;
 use App\Provider\Contract\ProviderStatusQuery;
 use App\Provider\Contract\ProviderStatusResult;
+use App\Provider\Contract\PromotionCatalogQuery;
 use App\Provider\Contract\RechargeProviderInterface;
 use App\Provider\Contract\RechargeRequest;
 use Psr\Log\LoggerInterface;
@@ -96,7 +98,8 @@ final class CsqCommunicationProvider implements
     ProviderHealthCheckInterface,
     ProviderCatalogInterface,
     RechargeProviderInterface,
-    ProviderBalanceInterface
+    ProviderBalanceInterface,
+    ProviderPromotionCatalogInterface
 {
     /** countryId de Cuba en el portfolio de CSQ (confirmado contra el payload real). */
     private const CUBA_COUNTRY_ID = 192;
@@ -291,6 +294,21 @@ final class CsqCommunicationProvider implements
                 );
             }
         }
+    }
+
+    /**
+     * CSQ no expone un endpoint de "promociones" propio — al igual que
+     * ETECSA, delega en fetchProducts() (su catálogo normal). A diferencia
+     * de ETECSA, sus productos SÍ tienen destinationAmount por tramo (un
+     * mismo articleId se expande a N filas, una por monto — ver
+     * fetchProducts()), pero cuál de esos montos corresponde a cada tramo
+     * de la promoción lo decide el orquestador (Fase 5D) por tupla, igual
+     * que con el resto del catálogo — este método no filtra, solo expone
+     * los candidatos.
+     */
+    public function fetchPromotionProducts(ProviderContext $context, PromotionCatalogQuery $query): iterable
+    {
+        return $this->fetchProducts($context);
     }
 
     /**

--- a/src/Provider/DTOne/DTOneCommunicationProvider.php
+++ b/src/Provider/DTOne/DTOneCommunicationProvider.php
@@ -15,8 +15,10 @@ use App\Provider\Contract\ProviderConfigField;
 use App\Provider\Contract\ProviderContext;
 use App\Provider\Contract\ProviderDispatchResult;
 use App\Provider\Contract\ProviderProductDto;
+use App\Provider\Contract\ProviderPromotionCatalogInterface;
 use App\Provider\Contract\ProviderStatusQuery;
 use App\Provider\Contract\ProviderStatusResult;
+use App\Provider\Contract\PromotionCatalogQuery;
 use App\Provider\Contract\RechargeProviderInterface;
 use App\Provider\Contract\RechargeRequest;
 use Psr\Log\LoggerInterface;
@@ -53,7 +55,8 @@ final class DTOneCommunicationProvider implements
     RechargeProviderInterface,
     PackageSaleProviderInterface,
     ProviderBalanceInterface,
-    ProviderCatalogInterface
+    ProviderCatalogInterface,
+    ProviderPromotionCatalogInterface
 {
     /**
      * Valores de `type` (clasificación de producto de DTOne) soportados hoy
@@ -293,6 +296,82 @@ final class DTOneCommunicationProvider implements
                 ], static fn ($v) => $v !== null),
             );
         }
+    }
+
+    /**
+     * GET /v1/promotions filtrado por solapamiento de ventana con la
+     * promoción nuestra — a diferencia de fetchProducts() (catálogo
+     * completo), esto SOLO devuelve productos que de verdad pertenecen a
+     * una campaña vigente de DTOne. `products[]` de cada promoción trae
+     * únicamente {id, name, description, type} (sin destinationAmount ni
+     * benefits — esquema verificado, ver DTOneHttpClient::iteratePromotions()),
+     * así que se cruza contra fetchProducts() para obtener el
+     * ProviderProductDto completo de cada match, y se filtra el resultado
+     * final por los montos de los tramos de la promoción — nunca se
+     * devuelve un producto de una campaña vigente que no cubre ningún
+     * tramo pedido.
+     */
+    public function fetchPromotionProducts(ProviderContext $context, PromotionCatalogQuery $query): iterable
+    {
+        $matchedProductIds = [];
+        foreach ($this->client->iteratePromotions($context, ['country_iso_code' => self::COUNTRY_ISO_CODE]) as $promotion) {
+            if (!$this->promotionOverlapsWindow($promotion, $query)) {
+                continue;
+            }
+
+            foreach ((array) ($promotion['products'] ?? []) as $product) {
+                if (isset($product['id'])) {
+                    $matchedProductIds[(string) $product['id']] = true;
+                }
+            }
+        }
+
+        if ($matchedProductIds === []) {
+            return;
+        }
+
+        foreach ($this->fetchProducts($context) as $product) {
+            if (!isset($matchedProductIds[$product->externalId])) {
+                continue;
+            }
+            if ($this->matchesAnyTramo($product, $query)) {
+                yield $product;
+            }
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $promotion
+     */
+    private function promotionOverlapsWindow(array $promotion, PromotionCatalogQuery $query): bool
+    {
+        try {
+            $start = isset($promotion['start_date']) ? new \DateTimeImmutable((string) $promotion['start_date']) : null;
+            $end = isset($promotion['end_date']) ? new \DateTimeImmutable((string) $promotion['end_date']) : null;
+        } catch (\Exception) {
+            return false;
+        }
+
+        if ($start !== null && $start > $query->activeTo) {
+            return false;
+        }
+
+        return $end === null || $end >= $query->activeFrom;
+    }
+
+    private function matchesAnyTramo(ProviderProductDto $product, PromotionCatalogQuery $query): bool
+    {
+        if ($product->destinationAmount === null || strtoupper((string) $product->destinationUnit) !== strtoupper($query->destinationCurrency)) {
+            return false;
+        }
+
+        foreach ($query->destinationAmounts as $amount) {
+            if (abs($product->destinationAmount - $amount) < 0.005) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Provider/DTOne/DTOneHttpClient.php
+++ b/src/Provider/DTOne/DTOneHttpClient.php
@@ -119,6 +119,41 @@ class DTOneHttpClient
     }
 
     /**
+     * GET /v1/promotions — campañas de DTOne (esquema verificado contra
+     * https://developers.dtone.com/reference/getpromotions el 2026-08-18):
+     * array plano (NO envuelto en "data"), paginado con los MISMOS headers
+     * que /v1/products (X-Total-Pages). Cada promoción trae
+     * `{id, title, description, terms, start_date, end_date, operator,
+     * products: [{id, name, description, type}]}` — OJO: `products[]` NO
+     * trae destinationAmount/benefits, solo id/name/description/type; para
+     * esos datos hay que cruzar contra fetchProducts() (ver
+     * DTOneCommunicationProvider::fetchPromotionProducts()).
+     *
+     * @param array<string, mixed> $query
+     * @return iterable<array<string, mixed>>
+     */
+    public function iteratePromotions(ProviderContext $context, array $query = []): iterable
+    {
+        $page = 1;
+        $query['per_page'] ??= 100;
+
+        do {
+            $response = $this->requestRaw($context, 'GET', '/v1/promotions', null, $query + ['page' => $page]);
+            $body = json_decode($response->getContent(), true);
+
+            foreach ((array) ($body['data'] ?? $body) as $item) {
+                if (is_array($item)) {
+                    yield $item;
+                }
+            }
+
+            $headers = $response->getHeaders();
+            $totalPages = isset($headers['x-total-pages'][0]) ? (int) $headers['x-total-pages'][0] : 1;
+            $page++;
+        } while ($page <= $totalPages);
+    }
+
+    /**
      * GET /v1/balances — nuestro saldo con DTOne, multi-moneda.
      *
      * @return array<string, mixed>

--- a/src/Provider/Etecsa/EtecsaCommunicationProvider.php
+++ b/src/Provider/Etecsa/EtecsaCommunicationProvider.php
@@ -19,8 +19,10 @@ use App\Provider\Contract\ProviderDispatchResult;
 use App\Provider\Contract\ProviderHealthCheckInterface;
 use App\Provider\Contract\ProviderPingResult;
 use App\Provider\Contract\ProviderProductDto;
+use App\Provider\Contract\ProviderPromotionCatalogInterface;
 use App\Provider\Contract\ProviderStatusQuery;
 use App\Provider\Contract\ProviderStatusResult;
+use App\Provider\Contract\PromotionCatalogQuery;
 use App\Provider\Contract\RechargeProviderInterface;
 use App\Provider\Contract\RechargeRequest;
 use App\Provider\Contract\TouristSimProviderInterface;
@@ -60,7 +62,8 @@ final class EtecsaCommunicationProvider implements
     ProviderCatalogInterface,
     TouristSimProviderInterface,
     GeoCatalogProviderInterface,
-    ProviderHealthCheckInterface
+    ProviderHealthCheckInterface,
+    ProviderPromotionCatalogInterface
 {
     public function __construct(
         private readonly EtecsaGatewayClient $client,
@@ -246,6 +249,17 @@ final class EtecsaCommunicationProvider implements
                 service: ['name' => 'MOBILE', 'subservice' => ['name' => 'AIRTIME']],
             );
         }
+    }
+
+    /**
+     * ETECSA no tiene concepto de "promoción" propio — su único producto es
+     * de monto flexible (destinationAmount siempre null en fetchProducts(),
+     * ver arriba), así que cubre cualquier tramo por igual. La vigencia de
+     * la promoción la impone nuestro CommunicationPackage, no ETECSA.
+     */
+    public function fetchPromotionProducts(ProviderContext $context, PromotionCatalogQuery $query): iterable
+    {
+        return $this->fetchProducts($context);
     }
 
     public function checkPhone(ProviderContext $context, string $phoneNumber): ProviderStatusResult

--- a/src/Provider/ProviderDispatchResolver.php
+++ b/src/Provider/ProviderDispatchResolver.php
@@ -29,9 +29,13 @@ use Symfony\Component\HttpFoundation\Response;
  * cliente, o con el switch apagado, se prueba solo el proveedor por
  * defecto.
  *
- * El camino "con promoción" (mapeo explícito CommunicationPromotionProviderProduct,
- * en vez de búsqueda automática por tupla) es Fase 5 — todavía no existe esa
- * entidad, así que select() solo cubre venta regular.
+ * Excepción al fallback: un paquete generado por una promoción
+ * (CommunicationPackage::$promotion !== null, ver Fase 5) exige SIEMPRE
+ * vínculo explícito — nunca cae a findMatchingDestination(). Es la garantía
+ * de "nunca despachar en silencio con el producto equivocado": si el admin
+ * (o el poblado automático por proveedor) no dejó una equivalencia para
+ * este tramo, ese proveedor simplemente no participa, se prueba el
+ * siguiente candidato de prioridad.
  */
 class ProviderDispatchResolver
 {
@@ -97,15 +101,23 @@ class ProviderDispatchResolver
      * El vínculo explícito (CommunicationPackageProviderProduct) gana
      * siempre que exista y siga siendo válido (habilitado + del entorno de
      * la cuenta) — el admin lo fijó a propósito, así que no se re-valida
-     * contra saleType ni tupla. Sin vínculo (o si el vinculado ya no sirve),
-     * cae al matching automático de siempre — ningún paquete deja de
-     * despachar solo porque todavía no fue vinculado a mano.
+     * contra saleType ni tupla.
+     *
+     * Sin vínculo (o si el vinculado ya no sirve): un paquete de catálogo
+     * regular cae al matching automático de siempre — ningún paquete deja
+     * de despachar solo porque todavía no fue vinculado a mano. Un paquete
+     * de PROMOCIÓN (getPromotion() !== null) NUNCA cae al automático — sin
+     * equivalencia explícita para este proveedor, no hay nada que devolver.
      */
     private function findDispatchableProduct(Account $account, CommunicationPackage $package, string $provider, ?string $saleType): ?CommunicationProduct
     {
         $bound = $this->packageBindingRepo->findForPackageAndProvider($package, $provider)?->getProduct();
         if ($bound !== null && $bound->isEnabled() && ($bound->getEnvironment() === null || $bound->getEnvironment() === $account->getEnvironment())) {
             return $bound;
+        }
+
+        if ($package->getPromotion() !== null) {
+            return null;
         }
 
         $candidates = $this->productRepository->findMatchingDestination(

--- a/src/Repository/CommunicationContractRepository.php
+++ b/src/Repository/CommunicationContractRepository.php
@@ -4,6 +4,7 @@ namespace App\Repository;
 
 use App\Entity\Account;
 use App\Entity\CommunicationContract;
+use App\Service\Pricing\DestinationKey;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
@@ -24,10 +25,12 @@ class CommunicationContractRepository extends ServiceEntityRepository
     }
 
     /**
-     * Contratos propios vigentes de un tenant, con su CommunicationPackage
-     * ya cargado (un solo JOIN — el match es por FK, no por tupla). Usado
-     * por PackageCatalogResolver::catalogFor() (Fase 2): si esto no está
-     * vacío, el catálogo visible del cliente es EXACTAMENTE estos paquetes.
+     * Contratos propios vigentes de un tenant, con sus CommunicationPackage
+     * ya cargados (fetch join sobre la colección — Doctrine hidrata UN
+     * CommunicationContract por fila lógica, con su colección poblada, no
+     * uno por paquete). Usado por PackageCatalogResolver::catalogFor()
+     * (Fase 2): si esto no está vacío, el catálogo visible del cliente es
+     * EXACTAMENTE los paquetes de estos contratos.
      *
      * @return list<CommunicationContract>
      */
@@ -63,11 +66,38 @@ class CommunicationContractRepository extends ServiceEntityRepository
     {
         return $this->createQueryBuilder('c')
             ->addSelect('p')
-            ->innerJoin('c.communicationPackage', 'p')
+            ->leftJoin('c.packages', 'p')
             ->andWhere('c.startAt <= :now')
             ->andWhere('c.endAt IS NULL OR c.endAt > :now')
             ->setParameter('now', $now)
             ->orderBy('c.startAt', 'DESC')
             ->addOrderBy('c.id', 'DESC');
+    }
+
+    /**
+     * El contrato ABIERTO (endAt IS NULL) para esta tupla — tolerancia de
+     * coma flotante igual que CommunicationPackageRepository::findByDestination()
+     * (DestinationKey::EPSILON). Es la clave de deduplicación de
+     * CommunicationContractService::upsertContract(): dos paquetes con la
+     * misma tupla y tenant terminan en el contrato que esto devuelve.
+     */
+    public function findOpenContract(?Account $tenant, float $amount, string $currency): ?CommunicationContract
+    {
+        $qb = $this->createQueryBuilder('c')
+            ->andWhere('c.destinationAmount BETWEEN :min AND :max')
+            ->andWhere('c.destinationCurrency = :currency')
+            ->andWhere('c.endAt IS NULL')
+            ->setParameter('min', $amount - DestinationKey::EPSILON)
+            ->setParameter('max', $amount + DestinationKey::EPSILON)
+            ->setParameter('currency', strtoupper($currency))
+            ->setMaxResults(1);
+
+        if ($tenant === null) {
+            $qb->andWhere('c.tenant IS NULL');
+        } else {
+            $qb->andWhere('c.tenant = :tenant')->setParameter('tenant', $tenant);
+        }
+
+        return $qb->getQuery()->getOneOrNullResult();
     }
 }

--- a/src/Repository/CommunicationPackageRepository.php
+++ b/src/Repository/CommunicationPackageRepository.php
@@ -74,6 +74,25 @@ class CommunicationPackageRepository extends ServiceEntityRepository
     }
 
     /**
+     * Todos los tramos generados por una promoción V2, ordenados por monto
+     * — usado por CommunicationPromotionEquivalenceService (Fase 5D) para
+     * poblar/refrescar las equivalencias por proveedor sin depender de
+     * tener la lista en memoria (ej. acción manual "refrescar" sobre una
+     * promoción ya creada en una petición anterior).
+     *
+     * @return list<CommunicationPackage>
+     */
+    public function findByPromotion(CommunicationPromotions $promotion): array
+    {
+        return $this->createQueryBuilder('p')
+            ->andWhere('p.promotion = :promotion')
+            ->setParameter('promotion', $promotion)
+            ->orderBy('p.destinationAmount', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
      * Variante de findByDestination() acotada a los paquetes generados por
      * UNA promoción concreta (Fase 5B) — misma tolerancia de coma flotante,
      * pero nunca puede devolver un paquete del catálogo regular ni de otra

--- a/src/Repository/CommunicationPackageRepository.php
+++ b/src/Repository/CommunicationPackageRepository.php
@@ -3,6 +3,7 @@
 namespace App\Repository;
 
 use App\Entity\CommunicationPackage;
+use App\Entity\CommunicationPromotions;
 use App\Service\Pricing\DestinationKey;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
@@ -50,15 +51,44 @@ class CommunicationPackageRepository extends ServiceEntityRepository
      * coma flotante (DestinationKey::EPSILON) — usado por
      * CommunicationContractService::createByRange() para resolver, monto a
      * monto, a qué CommunicationPackage corresponde cada paso del rango.
+     *
+     * Excluye SIEMPRE los paquetes generados por una promoción
+     * (promotion IS NOT NULL, ver CommunicationPackage::$promotion) — son
+     * copias con vigencia acotada, no catálogo regular; el admin de
+     * contratos no debe poder engancharse a uno por coincidencia de monto.
+     * Para resolver dentro del lote de una promoción concreta, ver
+     * findByDestinationForPromotion().
      */
     public function findByDestination(float $amount, string $currency): ?CommunicationPackage
     {
         return $this->createQueryBuilder('p')
             ->andWhere('p.destinationAmount BETWEEN :min AND :max')
             ->andWhere('p.destinationCurrency = :currency')
+            ->andWhere('p.promotion IS NULL')
             ->setParameter('min', $amount - DestinationKey::EPSILON)
             ->setParameter('max', $amount + DestinationKey::EPSILON)
             ->setParameter('currency', strtoupper($currency))
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
+    /**
+     * Variante de findByDestination() acotada a los paquetes generados por
+     * UNA promoción concreta (Fase 5B) — misma tolerancia de coma flotante,
+     * pero nunca puede devolver un paquete del catálogo regular ni de otra
+     * promoción, aunque compartan tupla destino.
+     */
+    public function findByDestinationForPromotion(float $amount, string $currency, CommunicationPromotions $promotion): ?CommunicationPackage
+    {
+        return $this->createQueryBuilder('p')
+            ->andWhere('p.destinationAmount BETWEEN :min AND :max')
+            ->andWhere('p.destinationCurrency = :currency')
+            ->andWhere('p.promotion = :promotion')
+            ->setParameter('min', $amount - DestinationKey::EPSILON)
+            ->setParameter('max', $amount + DestinationKey::EPSILON)
+            ->setParameter('currency', strtoupper($currency))
+            ->setParameter('promotion', $promotion)
             ->setMaxResults(1)
             ->getQuery()
             ->getOneOrNullResult();

--- a/src/Service/CommunicationPromotionService.php
+++ b/src/Service/CommunicationPromotionService.php
@@ -20,6 +20,7 @@ use App\Repository\EnvironmentRepository;
 use App\Repository\SysConfigRepository;
 use App\Service\Pricing\CommunicationContractService;
 use App\Service\Pricing\CommunicationPackageAdminService;
+use App\Service\Pricing\CommunicationPromotionEquivalenceService;
 use App\Service\Pricing\TargetAccountResolver;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
@@ -46,6 +47,7 @@ class CommunicationPromotionService extends CommonService
         private readonly TargetAccountResolver $targetAccountResolver,
         private readonly CommunicationPackageAdminService $packageAdminService,
         private readonly CommunicationContractService $contractService,
+        private readonly CommunicationPromotionEquivalenceService $equivalenceService,
     ) {
         parent::__construct($em, $security, $parameters, $mailer, $logger, $passwordHasher, $environmentRepository, $sysConfigRepo, $serializer);
     }
@@ -413,10 +415,14 @@ class CommunicationPromotionService extends CommonService
      * un producto de origen ni genera nada por cliente — la visibilidad la
      * decide PackageCatalogResolver como a cualquier paquete V2.
      *
-     * Las equivalencias por proveedor (quién despacha cada tramo) NO se
-     * resuelven aquí — ver Fase 5C/5D. Sin equivalencia explícita, ningún
-     * proveedor despacha ese tramo (ProviderDispatchResolver en modo
-     * estricto para paquetes de promoción).
+     * Las equivalencias por proveedor (quién despacha cada tramo) se
+     * auto-pueblan al final vía CommunicationPromotionEquivalenceService
+     * (Fase 5D) — cada proveedor con capacidad de auto-poblado
+     * (ProviderPromotionCatalogInterface) cubre los tramos que pueda; los
+     * huecos quedan reportados en el resultado para curar a mano. Sin
+     * equivalencia (ni automática ni manual), ese proveedor no despacha el
+     * tramo (ProviderDispatchResolver en modo estricto para paquetes de
+     * promoción).
      *
      * @throws MyCurrentException
      */
@@ -481,6 +487,8 @@ class CommunicationPromotionService extends CommonService
             $dto->getEndAt(),
         );
 
-        return new CreatePromotionV2Result($promotion, $packages, $contractResult);
+        $equivalences = $this->equivalenceService->populateEquivalences($promotion, $packages);
+
+        return new CreatePromotionV2Result($promotion, $packages, $contractResult, $equivalences);
     }
 }

--- a/src/Service/CommunicationPromotionService.php
+++ b/src/Service/CommunicationPromotionService.php
@@ -3,6 +3,8 @@
 namespace App\Service;
 
 use App\DTO\CreateAdminPromotionDto;
+use App\DTO\CreateCommunicationPackageBatchDto;
+use App\DTO\CreatePromotionV2Dto;
 use App\DTO\UpdatePromotionDto;
 use App\Entity\CommunicationClientPackage;
 use App\Entity\CommunicationPrice;
@@ -16,6 +18,8 @@ use App\Exception\MyCurrentException;
 use App\Message\PromotionCreatedMessage;
 use App\Repository\EnvironmentRepository;
 use App\Repository\SysConfigRepository;
+use App\Service\Pricing\CommunicationContractService;
+use App\Service\Pricing\CommunicationPackageAdminService;
 use App\Service\Pricing\TargetAccountResolver;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
@@ -40,6 +44,8 @@ class CommunicationPromotionService extends CommonService
         SerializerInterface $serializer,
         private readonly MessageBusInterface $messageBus,
         private readonly TargetAccountResolver $targetAccountResolver,
+        private readonly CommunicationPackageAdminService $packageAdminService,
+        private readonly CommunicationContractService $contractService,
     ) {
         parent::__construct($em, $security, $parameters, $mailer, $logger, $passwordHasher, $environmentRepository, $sysConfigRepo, $serializer);
     }
@@ -395,5 +401,86 @@ class CommunicationPromotionService extends CommonService
         $this->em->flush();
 
         return $promotion;
+    }
+
+    /**
+     * Alta de promoción V2 (Fase 5B, catálogo compartido) — genera un
+     * CommunicationPackage por cada monto de [amountFrom, amountTo] (paso
+     * amountStep), marcado con esta promoción y vigente SOLO durante
+     * [startAt, endAt], más un CommunicationContract "por defecto" por
+     * cada uno con el precio interpolado entre priceFrom/priceTo. A
+     * diferencia de createPackagesForPromotion() (legacy), no depende de
+     * un producto de origen ni genera nada por cliente — la visibilidad la
+     * decide PackageCatalogResolver como a cualquier paquete V2.
+     *
+     * Las equivalencias por proveedor (quién despacha cada tramo) NO se
+     * resuelven aquí — ver Fase 5C/5D. Sin equivalencia explícita, ningún
+     * proveedor despacha ese tramo (ProviderDispatchResolver en modo
+     * estricto para paquetes de promoción).
+     *
+     * @throws MyCurrentException
+     */
+    public function createV2(CreatePromotionV2Dto $dto): CreatePromotionV2Result
+    {
+        $environment = $this->em->getRepository(Environment::class)->find($dto->getEnvironmentId());
+        if ($environment === null) {
+            throw new MyCurrentException('ENVIRONMENT_NOT_FOUND', 'Environment not found', 404);
+        }
+
+        try {
+            $startAt = new \DateTimeImmutable((string) $dto->getStartAt());
+            $endAt = new \DateTimeImmutable((string) $dto->getEndAt());
+        } catch (\Exception) {
+            throw new MyCurrentException('INVALID_DATE', 'Invalid date format', 400);
+        }
+
+        $promotion = new CommunicationPromotions();
+        $promotion->setName((string) $dto->getName());
+        $promotion->setDescription((string) $dto->getDescription());
+        $promotion->setEnvironment($environment);
+        $promotion->setStartAt($startAt);
+        $promotion->setEndAt($endAt);
+        if ($dto->getKnowMore() !== null) {
+            $promotion->setKnowMore($dto->getKnowMore());
+        }
+
+        $this->em->persist($promotion);
+        $this->em->flush();
+
+        $batchDto = new CreateCommunicationPackageBatchDto(
+            nameTemplate: (string) $dto->getPackageNameTemplate(),
+            descriptionTemplate: (string) $dto->getPackageDescriptionTemplate(),
+            knowMore: $dto->getKnowMore(),
+            fromAmount: $dto->getAmountFrom(),
+            toAmount: $dto->getAmountTo(),
+            step: $dto->getAmountStep(),
+            destinationCurrency: $dto->getDestinationCurrency(),
+            isActive: true,
+            activeStartAt: $dto->getStartAt(),
+            activeEndAt: $dto->getEndAt(),
+            displayOrder: $dto->getDisplayOrder(),
+            benefits: $dto->getBenefits(),
+            tags: $dto->getTags(),
+            service: $dto->getService(),
+            validity: $dto->getValidity(),
+        );
+
+        $packages = $this->packageAdminService->createBatch($batchDto);
+
+        foreach ($packages as $package) {
+            $package->setPromotion($promotion);
+        }
+        $this->em->flush();
+
+        $contractResult = $this->contractService->createForPromotionPackages(
+            $packages,
+            (float) $dto->getPriceFrom(),
+            (float) $dto->getPriceTo(),
+            (string) $dto->getPriceCurrency(),
+            $dto->getStartAt(),
+            $dto->getEndAt(),
+        );
+
+        return new CreatePromotionV2Result($promotion, $packages, $contractResult);
     }
 }

--- a/src/Service/CreatePromotionV2Result.php
+++ b/src/Service/CreatePromotionV2Result.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\CommunicationPackage;
+use App\Entity\CommunicationPromotions;
+use App\Service\Pricing\ContractRangeResult;
+
+/**
+ * Resultado de CommunicationPromotionService::createV2() — la promoción,
+ * los CommunicationPackage generados por rango (todos marcados con esta
+ * promoción) y el resultado de los CommunicationContract "por defecto"
+ * creados para ellos. NO incluye equivalencias por proveedor — eso es
+ * Fase 5C/5D, todavía sin implementar.
+ */
+final readonly class CreatePromotionV2Result
+{
+    /**
+     * @param list<CommunicationPackage> $packages
+     */
+    public function __construct(
+        public CommunicationPromotions $promotion,
+        public array $packages,
+        public ContractRangeResult $contracts,
+    ) {
+    }
+}

--- a/src/Service/CreatePromotionV2Result.php
+++ b/src/Service/CreatePromotionV2Result.php
@@ -5,13 +5,16 @@ namespace App\Service;
 use App\Entity\CommunicationPackage;
 use App\Entity\CommunicationPromotions;
 use App\Service\Pricing\ContractRangeResult;
+use App\Service\Pricing\PromotionEquivalenceResult;
 
 /**
  * Resultado de CommunicationPromotionService::createV2() — la promoción,
  * los CommunicationPackage generados por rango (todos marcados con esta
- * promoción) y el resultado de los CommunicationContract "por defecto"
- * creados para ellos. NO incluye equivalencias por proveedor — eso es
- * Fase 5C/5D, todavía sin implementar.
+ * promoción), el resultado de los CommunicationContract "por defecto"
+ * creados para ellos, y el reporte del auto-poblado de equivalencias por
+ * proveedor (Fase 5D) — qué proveedores cubrieron cuántos tramos, y qué
+ * huecos quedaron (ver PromotionEquivalenceResult::$gaps) para que el
+ * admin los cure a mano.
  */
 final readonly class CreatePromotionV2Result
 {
@@ -22,6 +25,7 @@ final readonly class CreatePromotionV2Result
         public CommunicationPromotions $promotion,
         public array $packages,
         public ContractRangeResult $contracts,
+        public PromotionEquivalenceResult $equivalences,
     ) {
     }
 }

--- a/src/Service/Pricing/CommunicationContractService.php
+++ b/src/Service/Pricing/CommunicationContractService.php
@@ -12,6 +12,7 @@ use App\Entity\CommunicationPackage;
 use App\Entity\Environment;
 use App\Entity\User;
 use App\Exception\MyCurrentException;
+use App\Repository\CommunicationContractRepository;
 use App\Repository\CommunicationPackageRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -19,11 +20,16 @@ use Symfony\Bundle\SecurityBundle\Security;
 /**
  * Administración de CommunicationContract (V2) — calcado de
  * PackageContractService en estructura: alta única + alta en lote (misma
- * TargetAccountResolver), ambas idempotentes por (tenant, paquete): una
- * segunda llamada sobre el mismo par ACTUALIZA el contrato ABIERTO existente
- * (endAt IS NULL) en vez de duplicarlo — el índice único
- * uniq_com_contract_open_per_tenant_package lo garantiza a nivel de esquema.
- * "Pausar" (close()) es la única forma de dejar hueco a uno nuevo distinto.
+ * TargetAccountResolver), ambas idempotentes por (tenant, destinationAmount,
+ * destinationCurrency): una segunda llamada sobre la misma tupla ACTUALIZA
+ * el contrato ABIERTO existente (endAt IS NULL) en vez de duplicarlo — el
+ * índice único uniq_com_contract_open_per_tenant_amount lo garantiza a nivel
+ * de esquema. "Pausar" (close()) es la única forma de dejar hueco a uno
+ * nuevo distinto.
+ *
+ * Desde la Fase 6 (ManyToMany), un contrato puede cubrir VARIOS
+ * CommunicationPackage que compartan tupla — ver upsertContract() y el
+ * docblock de CommunicationContract.
  */
 class CommunicationContractService
 {
@@ -39,6 +45,7 @@ class CommunicationContractService
         private readonly TargetAccountResolver $targetAccountResolver,
         private readonly Security $security,
         private readonly CommunicationPackageRepository $packageRepository,
+        private readonly CommunicationContractRepository $contractRepository,
     ) {
     }
 
@@ -50,7 +57,7 @@ class CommunicationContractService
         $package = $this->findPackageOrFail((int) $dto->getCommunicationPackageId());
         $tenant = $this->resolveTenantOrFail($dto->getTenantId(), $dto->getEnvironmentId());
 
-        $contract = $this->upsertContract($package, $tenant);
+        $contract = $this->upsertContract($package, $tenant)->contract;
         $this->applyPricing($contract, (float) $dto->getPrice(), (string) $dto->getCurrency(), $dto->getStartAt(), $dto->getEndAt());
         $this->stampCreatedBy($contract);
 
@@ -81,17 +88,11 @@ class CommunicationContractService
         $accountIds = [];
 
         foreach ($accounts as $account) {
-            $isNew = $this->em->getRepository(CommunicationContract::class)->findOneBy([
-                'communicationPackage' => $package,
-                'tenant' => $account,
-                'endAt' => null,
-            ]) === null;
+            $result = $this->upsertContract($package, $account);
+            $this->applyPricing($result->contract, (float) $dto->getPrice(), (string) $dto->getCurrency(), $dto->getStartAt(), $dto->getEndAt());
+            $this->stampCreatedBy($result->contract);
 
-            $contract = $this->upsertContract($package, $account);
-            $this->applyPricing($contract, (float) $dto->getPrice(), (string) $dto->getCurrency(), $dto->getStartAt(), $dto->getEndAt());
-            $this->stampCreatedBy($contract);
-
-            $isNew ? $created++ : $updated++;
+            $result->isNew ? $created++ : $updated++;
             $accountIds[] = $account->getId();
         }
 
@@ -151,18 +152,12 @@ class CommunicationContractService
                 ? round($priceFrom + ($priceTo - $priceFrom) * ($amount - $from) / $span, 2)
                 : round($priceFrom, 2);
 
-            $isNew = $this->em->getRepository(CommunicationContract::class)->findOneBy([
-                'communicationPackage' => $package,
-                'tenant' => $tenant,
-                'endAt' => null,
-            ]) === null;
+            $result = $this->upsertContract($package, $tenant);
+            $this->applyPricing($result->contract, $price, $priceCurrency, $dto->getStartAt(), $dto->getEndAt());
+            $this->stampCreatedBy($result->contract);
 
-            $contract = $this->upsertContract($package, $tenant);
-            $this->applyPricing($contract, $price, $priceCurrency, $dto->getStartAt(), $dto->getEndAt());
-            $this->stampCreatedBy($contract);
-
-            $isNew ? $created++ : $updated++;
-            $contracts[] = $contract;
+            $result->isNew ? $created++ : $updated++;
+            $contracts[] = $result->contract;
         }
 
         $this->em->flush();
@@ -212,18 +207,12 @@ class CommunicationContractService
                 ? round($priceFrom + ($priceTo - $priceFrom) * ($amount - $from) / $span, 2)
                 : round($priceFrom, 2);
 
-            $isNew = $this->em->getRepository(CommunicationContract::class)->findOneBy([
-                'communicationPackage' => $package,
-                'tenant' => null,
-                'endAt' => null,
-            ]) === null;
+            $result = $this->upsertContract($package, null);
+            $this->applyPricing($result->contract, $price, $priceCurrency, $startAt, $endAt);
+            $this->stampCreatedBy($result->contract);
 
-            $contract = $this->upsertContract($package, null);
-            $this->applyPricing($contract, $price, $priceCurrency, $startAt, $endAt);
-            $this->stampCreatedBy($contract);
-
-            $isNew ? $created++ : $updated++;
-            $contracts[] = $contract;
+            $result->isNew ? $created++ : $updated++;
+            $contracts[] = $result->contract;
         }
 
         $this->em->flush();
@@ -235,53 +224,43 @@ class CommunicationContractService
 
     /**
      * Edita un contrato existente — siempre uno a uno (a diferencia de
-     * createBatch()/createByRange()). El paquete al que apunta el contrato
-     * puede reasignarse, pero nunca por id: se referencia por
-     * destinationAmount (+ destinationCurrency opcional si además cambia de
-     * moneda/unidad), resuelto contra el catálogo vigente — mismo criterio
-     * que createByRange().
+     * createBatch()/createByRange()).
      *
-     * @throws MyCurrentException si se pide un destinationAmount sin ningún
-     *   CommunicationPackage correspondiente
+     * Desde la Fase 6 (ManyToMany), `destinationAmount`/`destinationCurrency`
+     * son la IDENTIDAD del contrato, no la de un paquete puntual — editarlos
+     * "relabela" la tupla que este contrato representa, pero NO recalcula ni
+     * mueve su colección de `CommunicationPackage` (los paquetes que ya
+     * cubría siguen ahí, aunque ahora el contrato diga otro monto). Para
+     * "mover" paquetes de un contrato a otro, usar los flujos de creación
+     * (createSingle/createBatch/createByRange/createForPromotionPackages) —
+     * convergen solos al contrato correcto vía upsertContract().
+     *
+     * @throws MyCurrentException si ya existe OTRO contrato abierto para la
+     *   tupla (tenant, nuevo monto, nueva moneda)
      */
     public function update(CommunicationContract $contract, UpdateCommunicationContractDto $dto): CommunicationContract
     {
-        if ($dto->getDestinationAmount() !== null) {
+        if ($dto->getDestinationAmount() !== null || $dto->getDestinationCurrency() !== null) {
+            $amount = $dto->getDestinationAmount() ?? (float) $contract->getDestinationAmount();
             $currency = $dto->getDestinationCurrency() !== null
                 ? strtoupper($dto->getDestinationCurrency())
                 : (string) $contract->getDestinationCurrency();
 
-            $package = $this->packageRepository->findByDestination((float) $dto->getDestinationAmount(), $currency);
-            if ($package === null) {
+            // El índice único (tenant, amount, currency) WHERE endAt IS NULL
+            // solo permite un contrato abierto por tupla — si ya hay uno
+            // para la tupla destino, avisar en vez de dejar que el flush()
+            // reviente con una violación de integridad.
+            $conflict = $this->contractRepository->findOpenContract($contract->getTenant(), $amount, $currency);
+            if ($conflict !== null && $conflict !== $contract) {
                 throw new MyCurrentException(
-                    'COMMUNICATION_PACKAGE_NOT_FOUND',
-                    'No existe ningún paquete con ese monto de destino',
-                    404,
+                    'COMMUNICATION_CONTRACT_ALREADY_EXISTS',
+                    'Ya existe un contrato abierto para esa tupla y cliente',
+                    409,
                 );
             }
 
-            if ($package !== $contract->getCommunicationPackage()) {
-                // El índice único (tenant, communicationPackage) WHERE endAt
-                // IS NULL solo permite un contrato abierto por par — si ya
-                // hay uno para el paquete destino, avisar en vez de dejar
-                // que el flush() reviente con una violación de integridad.
-                $conflict = $this->em->getRepository(CommunicationContract::class)->findOneBy([
-                    'communicationPackage' => $package,
-                    'tenant' => $contract->getTenant(),
-                    'endAt' => null,
-                ]);
-                if ($conflict !== null && $conflict !== $contract) {
-                    throw new MyCurrentException(
-                        'COMMUNICATION_CONTRACT_ALREADY_EXISTS',
-                        'Ya existe un contrato abierto para ese paquete y cliente',
-                        409,
-                    );
-                }
-            }
-
-            $contract->setCommunicationPackage($package);
-            $contract->setDestinationAmount((float) $package->getDestinationAmount());
-            $contract->setDestinationCurrency((string) $package->getDestinationCurrency());
+            $contract->setDestinationAmount($amount);
+            $contract->setDestinationCurrency($currency);
         }
         if ($dto->getPrice() !== null) {
             $contract->setPrice($dto->getPrice());
@@ -392,31 +371,42 @@ class CommunicationContractService
     }
 
     /**
-     * Idempotente por (communicationPackage, tenant): reutiliza el contrato
-     * ABIERTO existente (endAt IS NULL) en vez de duplicar — el único que
-     * puede existir a la vez por el índice único de esquema.
+     * Idempotente por (tenant, destinationAmount, destinationCurrency): el
+     * contrato ABIERTO (endAt IS NULL) para esa tupla es único por
+     * esquema (uniq_com_contract_open_per_tenant_amount). Si $package NO
+     * está todavía en su colección, se agrega — es lo que hace que dos
+     * CommunicationPackage distintos (ej. uno del catálogo normal y uno
+     * generado por una promoción V2) que comparten tupla terminen en el
+     * MISMO contrato en vez de crear una fila nueva.
+     *
+     * `isNew` en el resultado distingue "este paquete acaba de sumarse"
+     * (contrato nuevo, o existente sin este paquete todavía) de "este
+     * paquete ya estaba" (re-afirmación de precio) — los contadores
+     * created/updated de cada flujo de alta lo usan directamente.
      */
-    private function upsertContract(CommunicationPackage $package, ?Account $tenant): CommunicationContract
+    private function upsertContract(CommunicationPackage $package, ?Account $tenant): UpsertContractResult
     {
-        $existing = $this->em->getRepository(CommunicationContract::class)->findOneBy([
-            'communicationPackage' => $package,
-            'tenant' => $tenant,
-            'endAt' => null,
-        ], ['id' => 'DESC']);
+        $amount = (float) $package->getDestinationAmount();
+        $currency = (string) $package->getDestinationCurrency();
 
-        if ($existing !== null) {
-            return $existing;
+        $contract = $this->contractRepository->findOpenContract($tenant, $amount, $currency);
+        if ($contract === null) {
+            $contract = (new CommunicationContract())
+                ->setTenant($tenant)
+                ->setDestinationAmount($amount)
+                ->setDestinationCurrency($currency);
+            $this->em->persist($contract);
+            $contract->addPackage($package);
+
+            return new UpsertContractResult($contract, true);
         }
 
-        $contract = (new CommunicationContract())
-            ->setCommunicationPackage($package)
-            ->setTenant($tenant)
-            ->setDestinationAmount((float) $package->getDestinationAmount())
-            ->setDestinationCurrency((string) $package->getDestinationCurrency());
+        $isNew = !$contract->getPackages()->contains($package);
+        if ($isNew) {
+            $contract->addPackage($package);
+        }
 
-        $this->em->persist($contract);
-
-        return $contract;
+        return new UpsertContractResult($contract, $isNew);
     }
 
     private function applyPricing(CommunicationContract $contract, float $price, string $currency, ?string $startAt, ?string $endAt): void

--- a/src/Service/Pricing/CommunicationContractService.php
+++ b/src/Service/Pricing/CommunicationContractService.php
@@ -173,6 +173,67 @@ class CommunicationContractService
     }
 
     /**
+     * Variante de createByRange() para promociones V2 (Fase 5B): en vez de
+     * resolver cada paquete por (monto, moneda) contra el catálogo regular
+     * (findByDestination() excluye a propósito los paquetes promocionales,
+     * ver su docblock), recibe DIRECTAMENTE la lista ya generada por
+     * CommunicationPackageAdminService::createBatch() — un contrato "por
+     * defecto" (tenant=null, catálogo compartido) por cada paquete, con el
+     * precio interpolado linealmente entre priceFrom (el de menor
+     * destinationAmount) y priceTo (el de mayor).
+     *
+     * @param list<CommunicationPackage> $packages
+     */
+    public function createForPromotionPackages(
+        array $packages,
+        float $priceFrom,
+        float $priceTo,
+        string $currency,
+        ?string $startAt,
+        ?string $endAt,
+    ): ContractRangeResult {
+        if ($packages === []) {
+            return new ContractRangeResult(0, 0, 0, [], []);
+        }
+
+        $amounts = array_map(static fn (CommunicationPackage $p) => (float) $p->getDestinationAmount(), $packages);
+        $from = min($amounts);
+        $to = max($amounts);
+        $span = $to - $from;
+        $priceCurrency = strtoupper($currency);
+
+        $created = 0;
+        $updated = 0;
+        $contracts = [];
+
+        foreach ($packages as $package) {
+            $amount = (float) $package->getDestinationAmount();
+            $price = $span > 0
+                ? round($priceFrom + ($priceTo - $priceFrom) * ($amount - $from) / $span, 2)
+                : round($priceFrom, 2);
+
+            $isNew = $this->em->getRepository(CommunicationContract::class)->findOneBy([
+                'communicationPackage' => $package,
+                'tenant' => null,
+                'endAt' => null,
+            ]) === null;
+
+            $contract = $this->upsertContract($package, null);
+            $this->applyPricing($contract, $price, $priceCurrency, $startAt, $endAt);
+            $this->stampCreatedBy($contract);
+
+            $isNew ? $created++ : $updated++;
+            $contracts[] = $contract;
+        }
+
+        $this->em->flush();
+
+        $contractIds = array_map(static fn (CommunicationContract $c) => $c->getId(), $contracts);
+
+        return new ContractRangeResult($created, $updated, 0, $contractIds, []);
+    }
+
+    /**
      * Edita un contrato existente — siempre uno a uno (a diferencia de
      * createBatch()/createByRange()). El paquete al que apunta el contrato
      * puede reasignarse, pero nunca por id: se referencia por

--- a/src/Service/Pricing/CommunicationContractService.php
+++ b/src/Service/Pricing/CommunicationContractService.php
@@ -57,13 +57,13 @@ class CommunicationContractService
         $package = $this->findPackageOrFail((int) $dto->getCommunicationPackageId());
         $tenant = $this->resolveTenantOrFail($dto->getTenantId(), $dto->getEnvironmentId());
 
-        $contract = $this->upsertContract($package, $tenant)->contract;
-        $this->applyPricing($contract, (float) $dto->getPrice(), (string) $dto->getCurrency(), $dto->getStartAt(), $dto->getEndAt());
-        $this->stampCreatedBy($contract);
+        $result = $this->upsertContract($package, $tenant);
+        $this->applyPricing($result->contract, (float) $dto->getPrice(), (string) $dto->getCurrency(), $dto->getStartAt(), $dto->getEndAt(), $result->contractIsNew);
+        $this->stampCreatedBy($result->contract);
 
         $this->em->flush();
 
-        return $contract;
+        return $result->contract;
     }
 
     /**
@@ -89,7 +89,7 @@ class CommunicationContractService
 
         foreach ($accounts as $account) {
             $result = $this->upsertContract($package, $account);
-            $this->applyPricing($result->contract, (float) $dto->getPrice(), (string) $dto->getCurrency(), $dto->getStartAt(), $dto->getEndAt());
+            $this->applyPricing($result->contract, (float) $dto->getPrice(), (string) $dto->getCurrency(), $dto->getStartAt(), $dto->getEndAt(), $result->contractIsNew);
             $this->stampCreatedBy($result->contract);
 
             $result->isNew ? $created++ : $updated++;
@@ -153,7 +153,7 @@ class CommunicationContractService
                 : round($priceFrom, 2);
 
             $result = $this->upsertContract($package, $tenant);
-            $this->applyPricing($result->contract, $price, $priceCurrency, $dto->getStartAt(), $dto->getEndAt());
+            $this->applyPricing($result->contract, $price, $priceCurrency, $dto->getStartAt(), $dto->getEndAt(), $result->contractIsNew);
             $this->stampCreatedBy($result->contract);
 
             $result->isNew ? $created++ : $updated++;
@@ -208,7 +208,7 @@ class CommunicationContractService
                 : round($priceFrom, 2);
 
             $result = $this->upsertContract($package, null);
-            $this->applyPricing($result->contract, $price, $priceCurrency, $startAt, $endAt);
+            $this->applyPricing($result->contract, $price, $priceCurrency, $startAt, $endAt, $result->contractIsNew);
             $this->stampCreatedBy($result->contract);
 
             $result->isNew ? $created++ : $updated++;
@@ -398,7 +398,7 @@ class CommunicationContractService
             $this->em->persist($contract);
             $contract->addPackage($package);
 
-            return new UpsertContractResult($contract, true);
+            return new UpsertContractResult($contract, true, true);
         }
 
         $isNew = !$contract->getPackages()->contains($package);
@@ -406,19 +406,52 @@ class CommunicationContractService
             $contract->addPackage($package);
         }
 
-        return new UpsertContractResult($contract, $isNew);
+        return new UpsertContractResult($contract, $isNew, false);
     }
 
-    private function applyPricing(CommunicationContract $contract, float $price, string $currency, ?string $startAt, ?string $endAt): void
+    /**
+     * Contrato NUEVO ($contractIsNew): fija startAt/endAt tal cual los pida
+     * el caller — está estableciendo la ventana desde cero.
+     *
+     * Contrato REUTILIZADO (se le suma un paquete, o se reafirma uno que ya
+     * tenía): NUNCA lo estrecha — solo ensancha. Sin este resguardo, fusionar
+     * un paquete promocional (con endAt corto) en un contrato "por defecto"
+     * indefinido le heredaría ese endAt corto a TODO el contrato, incluido
+     * el paquete no-promocional que ya cubría — justo el efecto que este
+     * ManyToMany existe para evitar (ver docblock de CommunicationContract).
+     * Simétrico para startAt: un merge no debe retrasar el inicio de algo
+     * que ya era visible.
+     */
+    private function applyPricing(CommunicationContract $contract, float $price, string $currency, ?string $startAt, ?string $endAt, bool $contractIsNew): void
     {
         $contract->setPrice($price);
         $contract->setCurrency(strtoupper($currency));
+
+        if ($contractIsNew) {
+            if ($startAt !== null) {
+                $contract->setStartAt(self::parseUtc($startAt));
+            }
+            if ($endAt !== null) {
+                $contract->setEndAt(self::parseUtc($endAt));
+            }
+
+            return;
+        }
+
         if ($startAt !== null) {
-            $contract->setStartAt(self::parseUtc($startAt));
+            $newStart = self::parseUtc($startAt);
+            if ($contract->getStartAt() === null || $newStart < $contract->getStartAt()) {
+                $contract->setStartAt($newStart);
+            }
         }
-        if ($endAt !== null) {
-            $contract->setEndAt(self::parseUtc($endAt));
+        if ($endAt !== null && $contract->getEndAt() !== null) {
+            $newEnd = self::parseUtc($endAt);
+            if ($newEnd > $contract->getEndAt()) {
+                $contract->setEndAt($newEnd);
+            }
         }
+        // $contract->getEndAt() === null (indefinido) nunca se estrecha,
+        // pase lo que pase en $endAt.
     }
 
     /**

--- a/src/Service/Pricing/CommunicationPackageAdminService.php
+++ b/src/Service/Pricing/CommunicationPackageAdminService.php
@@ -5,7 +5,6 @@ namespace App\Service\Pricing;
 use App\DTO\CreateCommunicationPackageBatchDto;
 use App\DTO\CreateCommunicationPackageDto;
 use App\DTO\UpdateCommunicationPackageDto;
-use App\Entity\CommunicationContract;
 use App\Entity\CommunicationPackage;
 use App\Entity\CommunicationProduct;
 use App\Entity\Environment;
@@ -274,15 +273,15 @@ class CommunicationPackageAdminService
     }
 
     /**
-     * @throws MyCurrentException si tiene contratos asociados (la FK de
-     *   communication_contract.communication_package_id es RESTRICT — sin
-     *   esta guardia, el borrado fallaría con un error de integridad crudo).
+     * @throws MyCurrentException si tiene contratos asociados (la tabla
+     *   puente communication_contract_package tiene FK ON DELETE CASCADE
+     *   desde el lado paquete, así que SIN esta guardia el borrado
+     *   desasociaría al paquete de sus contratos en silencio en vez de
+     *   avisar — un contrato con 0 paquetes queda huérfano).
      */
     public function delete(CommunicationPackage $package): void
     {
-        $existingContract = $this->em->getRepository(CommunicationContract::class)
-            ->findOneBy(['communicationPackage' => $package]);
-        if ($existingContract !== null) {
+        if (!$package->getContracts()->isEmpty()) {
             throw new MyCurrentException(
                 'COMMUNICATION_PACKAGE_HAS_CONTRACTS',
                 'No se puede eliminar: tiene contratos asociados',

--- a/src/Service/Pricing/CommunicationPromotionEquivalenceService.php
+++ b/src/Service/Pricing/CommunicationPromotionEquivalenceService.php
@@ -40,6 +40,14 @@ use Doctrine\ORM\EntityManagerInterface;
  */
 class CommunicationPromotionEquivalenceService
 {
+    /**
+     * Caché en memoria por (package, provider) — vigente solo durante UNA
+     * llamada a populateEquivalences(), ver upsertBinding().
+     *
+     * @var array<string, CommunicationPackageProviderProduct>
+     */
+    private array $bindingCache = [];
+
     public function __construct(
         private readonly EntityManagerInterface $em,
         private readonly ProviderRegistry $providerRegistry,
@@ -55,6 +63,8 @@ class CommunicationPromotionEquivalenceService
      */
     public function populateEquivalences(CommunicationPromotions $promotion, array $packages): PromotionEquivalenceResult
     {
+        $this->bindingCache = [];
+
         if ($packages === []) {
             return new PromotionEquivalenceResult([], []);
         }
@@ -213,11 +223,32 @@ class CommunicationPromotionEquivalenceService
         );
     }
 
+    /**
+     * Necesaria porque, dentro del mismo run, dos candidatos distintos del
+     * MISMO proveedor pueden cubrir el MISMO tramo (ej. CSQ con más de un
+     * producto al mismo monto nominal, ver §4 del doc de diseño) — sin la
+     * caché, la segunda llamada no vería la fila recién persist()eada por
+     * la primera (findForPackageAndProvider() consulta BD, no el unit of
+     * work) e intentaría crear OTRA fila nueva para la misma clave,
+     * violando uniq_com_package_provider al hacer flush(). Con la caché, la
+     * segunda llamada reutiliza la MISMA entidad y solo actualiza su
+     * producto — el primer candidato que cubre el tramo "gana" el binding,
+     * el resto solo lo re-apunta sin crear filas de más.
+     */
     private function upsertBinding(CommunicationPackage $package, string $provider, CommunicationProduct $product): void
     {
+        $key = $package->getId() . ':' . $provider;
+
+        if (isset($this->bindingCache[$key])) {
+            $this->bindingCache[$key]->setProduct($product);
+
+            return;
+        }
+
         $existing = $this->bindingRepo->findForPackageAndProvider($package, $provider);
         if ($existing !== null) {
             $existing->setProduct($product);
+            $this->bindingCache[$key] = $existing;
 
             return;
         }
@@ -227,5 +258,6 @@ class CommunicationPromotionEquivalenceService
             ->setProvider($provider)
             ->setProduct($product);
         $this->em->persist($binding);
+        $this->bindingCache[$key] = $binding;
     }
 }

--- a/src/Service/Pricing/CommunicationPromotionEquivalenceService.php
+++ b/src/Service/Pricing/CommunicationPromotionEquivalenceService.php
@@ -1,0 +1,231 @@
+<?php
+
+namespace App\Service\Pricing;
+
+use App\Entity\CommunicationPackage;
+use App\Entity\CommunicationPackageProviderProduct;
+use App\Entity\CommunicationProduct;
+use App\Entity\CommunicationPromotions;
+use App\Provider\Contract\ProviderPromotionCatalogInterface;
+use App\Provider\Contract\PromotionCatalogQuery;
+use App\Provider\ProviderContextFactory;
+use App\Provider\ProviderRegistry;
+use App\Repository\CommunicationPackageProviderProductRepository;
+use App\Repository\CommunicationPackageRepository;
+use App\Repository\CommunicationProductRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Orquestador Fase 5D: puebla automáticamente las equivalencias
+ * tramo→producto por proveedor (CommunicationPackageProviderProduct) de una
+ * promoción V2, usando el método común de la Fase 5C
+ * (ProviderPromotionCatalogInterface::fetchPromotionProducts()).
+ *
+ * Por cada proveedor registrado que implemente esa interfaz:
+ *  1. Pide sus productos candidatos para la ventana/tramos de la promoción.
+ *  2. Cruza cada candidato contra NUESTRO catálogo ya sincronizado
+ *     (CommunicationProductRepository, por provider+externalRef) — lo que
+ *     devuelve fetchPromotionProducts() es la respuesta EN VIVO del
+ *     proveedor, no necesariamente ya sincronizada como CommunicationProduct.
+ *  3. Matchea por tupla contra cada tramo (monto flexible = null aplica a
+ *     todos, como ETECSA) y hace upsert del vínculo.
+ *
+ * Nunca borra un vínculo existente que ya no aparezca en el resultado —
+ * podría ser un vínculo manual del admin que el auto-poblado no reproduce
+ * (ej. un producto-bono elegido a propósito). Solo agrega/actualiza.
+ *
+ * Se ejecuta automáticamente al crear la promoción (createV2()) y queda
+ * disponible como acción manual "refrescar equivalencias" — cubre el caso
+ * de que un proveedor publique su campaña después de creada la promoción.
+ */
+class CommunicationPromotionEquivalenceService
+{
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly ProviderRegistry $providerRegistry,
+        private readonly ProviderContextFactory $contextFactory,
+        private readonly CommunicationPackageProviderProductRepository $bindingRepo,
+        private readonly CommunicationProductRepository $productRepository,
+        private readonly CommunicationPackageRepository $packageRepository,
+    ) {
+    }
+
+    /**
+     * @param list<CommunicationPackage> $packages
+     */
+    public function populateEquivalences(CommunicationPromotions $promotion, array $packages): PromotionEquivalenceResult
+    {
+        if ($packages === []) {
+            return new PromotionEquivalenceResult([], []);
+        }
+
+        $environment = $promotion->getEnvironment();
+        $environmentType = $environment?->getType() ?? 'PROD';
+        $currency = (string) $packages[0]->getDestinationCurrency();
+        $amounts = array_map(static fn (CommunicationPackage $p) => (float) $p->getDestinationAmount(), $packages);
+
+        $query = new PromotionCatalogQuery(
+            destinationCurrency: $currency,
+            destinationAmounts: $amounts,
+            activeFrom: $promotion->getStartAt() ?? new \DateTimeImmutable(),
+            activeTo: $promotion->getEndAt() ?? new \DateTimeImmutable(),
+        );
+
+        $providerReports = [];
+        /** @var array<string, true> $coveredKeys "{packageId}:{provider}" ya cubiertos por este run o antes */
+        $coveredKeys = $this->indexExistingBindings($packages);
+        $capableProviders = [];
+
+        foreach ($this->providerRegistry->allImplementing(ProviderPromotionCatalogInterface::class) as $provider) {
+            $capableProviders[] = $provider->getCode()->value;
+            $matched = 0;
+            $error = null;
+
+            try {
+                $context = $this->contextFactory->forEnvironmentType($provider->getCode(), $environmentType, $environment?->getId());
+
+                foreach ($provider->fetchPromotionProducts($context, $query) as $candidate) {
+                    $product = $this->productRepository->findOneBy([
+                        'provider' => $provider->getCode()->value,
+                        'externalRef' => $candidate->externalId,
+                    ]);
+                    if ($product === null) {
+                        // Candidato reportado por el proveedor pero todavía
+                        // no sincronizado en nuestro catálogo — se salta, no
+                        // se puede vincular a un CommunicationProduct que no
+                        // existe. Queda como hueco (candidateAmount no cubre
+                        // el tramo en $coveredKeys).
+                        continue;
+                    }
+
+                    foreach ($packages as $package) {
+                        if (!$this->coversTramo($candidate->destinationAmount, $candidate->destinationUnit, $package)) {
+                            continue;
+                        }
+
+                        $key = $package->getId() . ':' . $provider->getCode()->value;
+                        $this->upsertBinding($package, $provider->getCode()->value, $product);
+                        if (!isset($coveredKeys[$key])) {
+                            $coveredKeys[$key] = true;
+                            $matched++;
+                        }
+                    }
+                }
+            } catch (\Throwable $e) {
+                $error = $e->getMessage();
+            }
+
+            $providerReports[] = ['provider' => $provider->getCode()->value, 'matched' => $matched, 'error' => $error];
+        }
+
+        $this->em->flush();
+
+        return new PromotionEquivalenceResult($providerReports, $this->computeGaps($packages, $capableProviders, $coveredKeys));
+    }
+
+    /**
+     * Acción manual "refrescar equivalencias" sobre una promoción V2 ya
+     * creada — recarga sus tramos desde BD (no depende de tener la lista
+     * en memoria) y vuelve a correr populateEquivalences(). Cubre el caso
+     * de que un proveedor publique su campaña después de creada la
+     * promoción (ver docs/promotion-provider-routing-por-tramo.md §6).
+     */
+    public function refreshForPromotion(CommunicationPromotions $promotion): PromotionEquivalenceResult
+    {
+        return $this->populateEquivalences($promotion, $this->packageRepository->findByPromotion($promotion));
+    }
+
+    /**
+     * Vista de solo lectura de la cobertura actual — no llama a ningún
+     * proveedor ni escribe nada, solo lee los vínculos ya persistidos.
+     */
+    public function coverage(CommunicationPromotions $promotion): PromotionEquivalenceResult
+    {
+        $packages = $this->packageRepository->findByPromotion($promotion);
+        if ($packages === []) {
+            return new PromotionEquivalenceResult([], []);
+        }
+
+        $capableProviders = array_map(
+            static fn ($p) => $p->getCode()->value,
+            $this->providerRegistry->allImplementing(ProviderPromotionCatalogInterface::class),
+        );
+
+        return new PromotionEquivalenceResult([], $this->computeGaps($packages, $capableProviders, $this->indexExistingBindings($packages)));
+    }
+
+    /**
+     * @param list<CommunicationPackage> $packages
+     * @return array<string, true>
+     */
+    private function indexExistingBindings(array $packages): array
+    {
+        $covered = [];
+        foreach ($packages as $package) {
+            foreach ($this->bindingRepo->findAllForPackage($package) as $binding) {
+                $covered[$package->getId() . ':' . $binding->getProvider()] = true;
+            }
+        }
+
+        return $covered;
+    }
+
+    /**
+     * @param list<CommunicationPackage> $packages
+     * @param list<string> $capableProviders
+     * @param array<string, true> $coveredKeys
+     * @return list<array{packageId: int, destinationAmount: float, missingProviders: list<string>}>
+     */
+    private function computeGaps(array $packages, array $capableProviders, array $coveredKeys): array
+    {
+        $gaps = [];
+        foreach ($packages as $package) {
+            $missing = [];
+            foreach ($capableProviders as $provider) {
+                if (!isset($coveredKeys[$package->getId() . ':' . $provider])) {
+                    $missing[] = $provider;
+                }
+            }
+            if ($missing !== []) {
+                $gaps[] = [
+                    'packageId' => (int) $package->getId(),
+                    'destinationAmount' => (float) $package->getDestinationAmount(),
+                    'missingProviders' => $missing,
+                ];
+            }
+        }
+
+        return $gaps;
+    }
+
+    private function coversTramo(?float $candidateAmount, ?string $candidateUnit, CommunicationPackage $package): bool
+    {
+        if ($candidateAmount === null) {
+            // Monto flexible (ej. ETECSA) — cubre cualquier tramo.
+            return true;
+        }
+
+        return DestinationKey::matches(
+            $candidateAmount,
+            $candidateUnit ?? '',
+            (float) $package->getDestinationAmount(),
+            (string) $package->getDestinationCurrency(),
+        );
+    }
+
+    private function upsertBinding(CommunicationPackage $package, string $provider, CommunicationProduct $product): void
+    {
+        $existing = $this->bindingRepo->findForPackageAndProvider($package, $provider);
+        if ($existing !== null) {
+            $existing->setProduct($product);
+
+            return;
+        }
+
+        $binding = (new CommunicationPackageProviderProduct())
+            ->setCommunicationPackage($package)
+            ->setProvider($provider)
+            ->setProduct($product);
+        $this->em->persist($binding);
+    }
+}

--- a/src/Service/Pricing/PackageCatalogResolver.php
+++ b/src/Service/Pricing/PackageCatalogResolver.php
@@ -131,14 +131,28 @@ class PackageCatalogResolver
     }
 
     /**
+     * Aplana: por cada contrato, por cada CommunicationPackage de su
+     * colección (Fase 6 — un contrato puede cubrir varios), una oferta.
+     * Dedup defensivo por packageId — un paquete nunca debería aparecer dos
+     * veces (upsertContract() lo routea siempre al mismo contrato), pero se
+     * guarda como cinturón de seguridad ante contratos superpuestos creados
+     * a mano.
+     *
      * @param list<CommunicationContract> $contracts
      * @return list<ResolvedPackageOffer>
      */
     private function offersFromContracts(array $contracts, PackageOfferSourceEnum $source): array
     {
         $offers = [];
+        $seenPackageIds = [];
         foreach ($contracts as $contract) {
-            $offers[] = $this->offerFromContract($contract, $source);
+            foreach ($contract->getPackages() as $package) {
+                if (isset($seenPackageIds[$package->getId()])) {
+                    continue;
+                }
+                $seenPackageIds[$package->getId()] = true;
+                $offers[] = $this->offerFromContract($contract, $package, $source);
+            }
         }
 
         return $offers;
@@ -150,24 +164,16 @@ class PackageCatalogResolver
     private function offerFromContractsForPackage(array $contracts, CommunicationPackage $package, PackageOfferSourceEnum $source): ?ResolvedPackageOffer
     {
         foreach ($contracts as $contract) {
-            if ($contract->getCommunicationPackage()?->getId() === $package->getId()) {
-                return $this->offerFromContract($contract, $source);
+            if ($contract->getPackages()->contains($package)) {
+                return $this->offerFromContract($contract, $package, $source);
             }
         }
 
         return null;
     }
 
-    private function offerFromContract(CommunicationContract $contract, PackageOfferSourceEnum $source): ResolvedPackageOffer
+    private function offerFromContract(CommunicationContract $contract, CommunicationPackage $package, PackageOfferSourceEnum $source): ResolvedPackageOffer
     {
-        $package = $contract->getCommunicationPackage();
-        if ($package === null) {
-            // communication_package_id es NOT NULL a nivel de esquema — un
-            // contrato persistido siempre lo trae. Solo puede pasar con una
-            // entidad construida a mano sin setCommunicationPackage().
-            throw new \LogicException('CommunicationContract sin CommunicationPackage — violación de invariante de esquema.');
-        }
-
         $offer = new ResolvedPackageOffer(
             package: $package,
             price: $contract->getPrice() ?? 0.0,

--- a/src/Service/Pricing/PromotionEquivalenceResult.php
+++ b/src/Service/Pricing/PromotionEquivalenceResult.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Service\Pricing;
+
+/**
+ * Resultado de CommunicationPromotionEquivalenceService::populateEquivalences()/
+ * coverage() — nunca se omiten en silencio los huecos: `gaps` lista, para
+ * cada tramo, qué proveedores con capacidad de auto-poblado (
+ * ProviderPromotionCatalogInterface) todavía no tienen equivalencia — el
+ * admin los cura a mano desde la pantalla de bindings existente
+ * (CommunicationPackageBindingService).
+ */
+final readonly class PromotionEquivalenceResult
+{
+    /**
+     * @param list<array{provider: string, matched: int, error: ?string}> $providers
+     * @param list<array{packageId: int, destinationAmount: float, missingProviders: list<string>}> $gaps
+     */
+    public function __construct(
+        public array $providers,
+        public array $gaps,
+    ) {
+    }
+}

--- a/src/Service/Pricing/UpsertContractResult.php
+++ b/src/Service/Pricing/UpsertContractResult.php
@@ -10,12 +10,22 @@ use App\Entity\CommunicationContract;
  * existente)" de "este paquete ya estaba en el contrato" (re-afirmación de
  * precio), para que los contadores created/updated de cada flujo de alta no
  * dependan de una consulta aparte.
+ *
+ * `contractIsNew` distingue, aparte, "la FILA de contrato se acaba de crear"
+ * de "se reutilizó una fila existente" (aunque el paquete sea nuevo para
+ * ella) — CommunicationContractService::applyPricing() lo usa para decidir
+ * si puede fijar startAt/endAt libremente (contrato nuevo) o si debe
+ * ensanchar en vez de reemplazar (contrato reutilizado): un contrato "por
+ * defecto" indefinido no debe heredar el `endAt` corto de una promoción
+ * que se fusiona en él, o el paquete que ya cubría también dejaría de
+ * verse cuando la promoción termine.
  */
 final readonly class UpsertContractResult
 {
     public function __construct(
         public CommunicationContract $contract,
         public bool $isNew,
+        public bool $contractIsNew,
     ) {
     }
 }

--- a/src/Service/Pricing/UpsertContractResult.php
+++ b/src/Service/Pricing/UpsertContractResult.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Service\Pricing;
+
+use App\Entity\CommunicationContract;
+
+/**
+ * Resultado de CommunicationContractService::upsertContract() — `isNew`
+ * distingue "este paquete acaba de sumarse a un contrato (nuevo o
+ * existente)" de "este paquete ya estaba en el contrato" (re-afirmación de
+ * precio), para que los contadores created/updated de cada flujo de alta no
+ * dependan de una consulta aparte.
+ */
+final readonly class UpsertContractResult
+{
+    public function __construct(
+        public CommunicationContract $contract,
+        public bool $isNew,
+    ) {
+    }
+}

--- a/tests/Controller/DashboardCommunicationContractsControllerTest.php
+++ b/tests/Controller/DashboardCommunicationContractsControllerTest.php
@@ -57,7 +57,7 @@ class DashboardCommunicationContractsControllerTest extends TestCase
             ->setDestinationAmount(500.0)->setDestinationCurrency('CUP');
 
         return (new CommunicationContract())
-            ->setCommunicationPackage($package)
+            ->addPackage($package)
             ->setDestinationAmount(500.0)->setDestinationCurrency('CUP')
             ->setPrice(10.0)->setCurrency('USD');
     }
@@ -84,6 +84,8 @@ class DashboardCommunicationContractsControllerTest extends TestCase
         $this->assertEquals(10.0, $data['price']);
         $this->assertSame('USD', $data['currency']);
         $this->assertTrue($data['isActive']);
+        $this->assertCount(1, $data['packages']);
+        $this->assertSame('P', $data['packages'][0]['name']);
     }
 
     public function testCreateReturnsCreatedWithSerializedContract(): void

--- a/tests/Controller/DashboardPromotionControllerTest.php
+++ b/tests/Controller/DashboardPromotionControllerTest.php
@@ -14,7 +14,9 @@ use App\Repository\CommunicationPromotionsRepository;
 use App\Service\CommunicationPromotionService;
 use App\Service\CreatePromotionV2Result;
 use App\Service\Pricing\CommunicationPromotionBindingService;
+use App\Service\Pricing\CommunicationPromotionEquivalenceService;
 use App\Service\Pricing\ContractRangeResult;
+use App\Service\Pricing\PromotionEquivalenceResult;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -34,6 +36,7 @@ class DashboardPromotionControllerTest extends TestCase
     private CommunicationPromotionsRepository&MockObject $repository;
     private CommunicationPromotionBindingService&MockObject $bindingService;
     private CommunicationPromotionService&MockObject $promotionService;
+    private CommunicationPromotionEquivalenceService&MockObject $equivalenceService;
     private NormalizerInterface&MockObject $serializer;
     private DashboardPromotionController $controller;
 
@@ -42,6 +45,7 @@ class DashboardPromotionControllerTest extends TestCase
         $this->repository = $this->createMock(CommunicationPromotionsRepository::class);
         $this->bindingService = $this->createMock(CommunicationPromotionBindingService::class);
         $this->promotionService = $this->createMock(CommunicationPromotionService::class);
+        $this->equivalenceService = $this->createMock(CommunicationPromotionEquivalenceService::class);
         $this->serializer = $this->createMock(NormalizerInterface::class);
         $this->serializer->method('normalize')->willReturn([]);
 
@@ -51,6 +55,7 @@ class DashboardPromotionControllerTest extends TestCase
             $this->serializer,
             $this->promotionService,
             $this->bindingService,
+            $this->equivalenceService,
         );
 
         $container = $this->createMock(ContainerInterface::class);
@@ -183,7 +188,11 @@ class DashboardPromotionControllerTest extends TestCase
             (new CommunicationPackage())->setName('p1')->setDescription('p1')->setDestinationAmount(500.0)->setDestinationCurrency('CUP'),
             (new CommunicationPackage())->setName('p2')->setDescription('p2')->setDestinationAmount(525.0)->setDestinationCurrency('CUP'),
         ];
-        $result = new CreatePromotionV2Result($promotion, $packages, new ContractRangeResult(2, 0, 0, [1, 2], []));
+        $equivalences = new PromotionEquivalenceResult(
+            [['provider' => 'DTONE', 'matched' => 2, 'error' => null]],
+            [],
+        );
+        $result = new CreatePromotionV2Result($promotion, $packages, new ContractRangeResult(2, 0, 0, [1, 2], []), $equivalences);
         $this->promotionService->expects($this->once())->method('createV2')->willReturn($result);
 
         $response = $this->controller->createV2($this->v2Dto());
@@ -194,6 +203,8 @@ class DashboardPromotionControllerTest extends TestCase
         $this->assertCount(2, $data['packages']);
         $this->assertEquals(500.0, $data['packages'][0]['destinationAmount']);
         $this->assertSame(2, $data['contracts']['created']);
+        $this->assertSame('DTONE', $data['equivalences']['providers'][0]['provider']);
+        $this->assertSame([], $data['equivalences']['gaps']);
     }
 
     public function testCreateV2MapsDomainExceptionToItsHttpCode(): void
@@ -204,5 +215,51 @@ class DashboardPromotionControllerTest extends TestCase
         $response = $this->controller->createV2($this->v2Dto());
 
         $this->assertSame(404, $response->getStatusCode());
+    }
+
+    public function testEquivalencesReturnsNotFoundWhenPromotionDoesNotExist(): void
+    {
+        $this->repository->method('find')->willReturn(null);
+
+        $response = $this->controller->equivalences(999);
+
+        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+    }
+
+    public function testEquivalencesReturnsCoverageFromTheService(): void
+    {
+        $promotion = new CommunicationPromotions();
+        $this->repository->method('find')->willReturn($promotion);
+        $this->equivalenceService->expects($this->once())->method('coverage')->with($promotion)->willReturn(
+            new PromotionEquivalenceResult([], [['packageId' => 1, 'destinationAmount' => 500.0, 'missingProviders' => ['DTONE']]]),
+        );
+
+        $response = $this->controller->equivalences(1);
+
+        $data = json_decode($response->getContent(), true);
+        $this->assertSame('DTONE', $data['gaps'][0]['missingProviders'][0]);
+    }
+
+    public function testRefreshEquivalencesReturnsNotFoundWhenPromotionDoesNotExist(): void
+    {
+        $this->repository->method('find')->willReturn(null);
+
+        $response = $this->controller->refreshEquivalences(999);
+
+        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+    }
+
+    public function testRefreshEquivalencesDelegatesToTheService(): void
+    {
+        $promotion = new CommunicationPromotions();
+        $this->repository->method('find')->willReturn($promotion);
+        $this->equivalenceService->expects($this->once())->method('refreshForPromotion')->with($promotion)->willReturn(
+            new PromotionEquivalenceResult([['provider' => 'DTONE', 'matched' => 5, 'error' => null]], []),
+        );
+
+        $response = $this->controller->refreshEquivalences(1);
+
+        $data = json_decode($response->getContent(), true);
+        $this->assertSame(5, $data['providers'][0]['matched']);
     }
 }

--- a/tests/Controller/DashboardPromotionControllerTest.php
+++ b/tests/Controller/DashboardPromotionControllerTest.php
@@ -3,14 +3,18 @@
 namespace App\Tests\Controller;
 
 use App\Controller\DashboardPromotionController;
+use App\DTO\CreatePromotionV2Dto;
 use App\DTO\SetPromotionProviderProductDto;
+use App\Entity\CommunicationPackage;
 use App\Entity\CommunicationProduct;
 use App\Entity\CommunicationPromotionProviderProduct;
 use App\Entity\CommunicationPromotions;
 use App\Exception\MyCurrentException;
 use App\Repository\CommunicationPromotionsRepository;
 use App\Service\CommunicationPromotionService;
+use App\Service\CreatePromotionV2Result;
 use App\Service\Pricing\CommunicationPromotionBindingService;
+use App\Service\Pricing\ContractRangeResult;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -22,24 +26,30 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  * @covers \App\Controller\DashboardPromotionController
  *
  * Cubre solo los 3 endpoints nuevos de vínculo promoción→producto por
- * proveedor — el resto del controlador (CRUD de promociones) no cambió.
+ * proveedor y el alta V2 — el resto del controlador (CRUD legacy) no
+ * cambió.
  */
 class DashboardPromotionControllerTest extends TestCase
 {
     private CommunicationPromotionsRepository&MockObject $repository;
     private CommunicationPromotionBindingService&MockObject $bindingService;
+    private CommunicationPromotionService&MockObject $promotionService;
+    private NormalizerInterface&MockObject $serializer;
     private DashboardPromotionController $controller;
 
     protected function setUp(): void
     {
         $this->repository = $this->createMock(CommunicationPromotionsRepository::class);
         $this->bindingService = $this->createMock(CommunicationPromotionBindingService::class);
+        $this->promotionService = $this->createMock(CommunicationPromotionService::class);
+        $this->serializer = $this->createMock(NormalizerInterface::class);
+        $this->serializer->method('normalize')->willReturn([]);
 
         $this->controller = new DashboardPromotionController(
             $this->repository,
             $this->createMock(EntityManagerInterface::class),
-            $this->createMock(NormalizerInterface::class),
-            $this->createMock(CommunicationPromotionService::class),
+            $this->serializer,
+            $this->promotionService,
             $this->bindingService,
         );
 
@@ -144,5 +154,55 @@ class DashboardPromotionControllerTest extends TestCase
 
         $data = json_decode($response->getContent(), true);
         $this->assertTrue($data['deleted']);
+    }
+
+    private function v2Dto(): CreatePromotionV2Dto
+    {
+        return new CreatePromotionV2Dto(
+            name: 'Promo V2',
+            description: 'Promo V2',
+            packageNameTemplate: 'Cubacel {monto} CUP',
+            packageDescriptionTemplate: 'Cubacel {monto} CUP',
+            startAt: '2026-08-18T00:00:00+00:00',
+            endAt: '2026-08-25T23:59:00+00:00',
+            environmentId: 4,
+            destinationCurrency: 'CUP',
+            amountFrom: 500.0,
+            amountTo: 525.0,
+            amountStep: 25.0,
+            priceFrom: 19.7,
+            priceTo: 20.71,
+            priceCurrency: 'USD',
+        );
+    }
+
+    public function testCreateV2ReturnsThePromotionAndGeneratedPackages(): void
+    {
+        $promotion = new CommunicationPromotions();
+        $packages = [
+            (new CommunicationPackage())->setName('p1')->setDescription('p1')->setDestinationAmount(500.0)->setDestinationCurrency('CUP'),
+            (new CommunicationPackage())->setName('p2')->setDescription('p2')->setDestinationAmount(525.0)->setDestinationCurrency('CUP'),
+        ];
+        $result = new CreatePromotionV2Result($promotion, $packages, new ContractRangeResult(2, 0, 0, [1, 2], []));
+        $this->promotionService->expects($this->once())->method('createV2')->willReturn($result);
+
+        $response = $this->controller->createV2($this->v2Dto());
+
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $data = json_decode($response->getContent(), true);
+        $this->assertSame(2, $data['packagesCreated']);
+        $this->assertCount(2, $data['packages']);
+        $this->assertEquals(500.0, $data['packages'][0]['destinationAmount']);
+        $this->assertSame(2, $data['contracts']['created']);
+    }
+
+    public function testCreateV2MapsDomainExceptionToItsHttpCode(): void
+    {
+        $this->promotionService->method('createV2')
+            ->willThrowException(new MyCurrentException('ENVIRONMENT_NOT_FOUND', 'Environment not found', 404));
+
+        $response = $this->controller->createV2($this->v2Dto());
+
+        $this->assertSame(404, $response->getStatusCode());
     }
 }

--- a/tests/Entity/CommunicationContractTest.php
+++ b/tests/Entity/CommunicationContractTest.php
@@ -20,7 +20,7 @@ class CommunicationContractTest extends TestCase
             ->setDestinationCurrency('CUP');
 
         return (new CommunicationContract())
-            ->setCommunicationPackage($package)
+            ->addPackage($package)
             ->setDestinationAmount(500.0)
             ->setDestinationCurrency('CUP')
             ->setPrice(10.0)
@@ -85,5 +85,27 @@ class CommunicationContractTest extends TestCase
         $contract = $this->contract()->close($at);
 
         $this->assertSame($at, $contract->getEndAt());
+    }
+
+    public function testAddPackageIsIdempotent(): void
+    {
+        $contract = new CommunicationContract();
+        $package = (new CommunicationPackage())->setName('p')->setDescription('p')->setDestinationAmount(500.0)->setDestinationCurrency('CUP');
+
+        $contract->addPackage($package);
+        $contract->addPackage($package);
+
+        $this->assertCount(1, $contract->getPackages());
+        $this->assertTrue($contract->getPackages()->contains($package));
+    }
+
+    public function testRemovePackage(): void
+    {
+        $contract = $this->contract();
+        $package = $contract->getPackages()->first();
+
+        $contract->removePackage($package);
+
+        $this->assertCount(0, $contract->getPackages());
     }
 }

--- a/tests/Functional/Pricing/CommunicationContractRepositoryTest.php
+++ b/tests/Functional/Pricing/CommunicationContractRepositoryTest.php
@@ -46,7 +46,7 @@ class CommunicationContractRepositoryTest extends ProviderFunctionalTestCase
         float $price = 10.0,
     ): CommunicationContract {
         $contract = (new CommunicationContract())
-            ->setCommunicationPackage($package)
+            ->addPackage($package)
             ->setTenant($tenant)
             ->setDestinationAmount($package->getDestinationAmount())
             ->setDestinationCurrency($package->getDestinationCurrency())
@@ -170,5 +170,75 @@ class CommunicationContractRepositoryTest extends ProviderFunctionalTestCase
         $this->assertCount(2, $result);
         $this->assertSame($newer->getId(), $result[0]->getId());
         $this->assertSame($older->getId(), $result[1]->getId());
+    }
+
+    public function testFindActiveForTenantEagerLoadsAllPackagesOfAContractSharedByTwo(): void
+    {
+        $now = new \DateTimeImmutable();
+        $client = $this->createClient();
+        $environment = $this->createEnvironment();
+        $account = $this->createAccount($client, $environment);
+
+        // Dos CommunicationPackage al mismo monto, un solo contrato (ver
+        // upsertContract() — Fase 6B): el fetch join no debe perder ninguno.
+        $packageA = $this->communicationPackage();
+        $packageB = $this->communicationPackage();
+        $contract = (new CommunicationContract())
+            ->addPackage($packageA)
+            ->addPackage($packageB)
+            ->setTenant($account)
+            ->setDestinationAmount(500.0)
+            ->setDestinationCurrency('CUP')
+            ->setPrice(10.0)
+            ->setCurrency('USD')
+            ->setStartAt($now->modify('-1 day'));
+        $this->em->persist($contract);
+        $this->em->flush();
+        $this->em->clear();
+
+        $result = $this->repository()->findActiveForTenant($account, $now);
+
+        $this->assertCount(1, $result);
+        $this->assertCount(2, $result[0]->getPackages());
+    }
+
+    public function testFindOpenContractMatchesByTupleWithFloatingPointTolerance(): void
+    {
+        $now = new \DateTimeImmutable();
+        $client = $this->createClient();
+        $environment = $this->createEnvironment();
+        $account = $this->createAccount($client, $environment);
+
+        $package = $this->communicationPackage();
+        $open = $this->contract($package, $account, $now->modify('-1 day'));
+        $this->em->flush();
+
+        $found = $this->repository()->findOpenContract($account, 500.0 + 0.001, 'cup');
+
+        $this->assertSame($open->getId(), $found?->getId());
+    }
+
+    public function testFindOpenContractReturnsNullWhenNoOpenContractMatches(): void
+    {
+        $client = $this->createClient();
+        $environment = $this->createEnvironment();
+        $account = $this->createAccount($client, $environment);
+
+        $this->assertNull($this->repository()->findOpenContract($account, 999.0, 'CUP'));
+    }
+
+    public function testFindOpenContractDistinguishesTenantFromDefault(): void
+    {
+        $now = new \DateTimeImmutable();
+        $client = $this->createClient();
+        $environment = $this->createEnvironment();
+        $account = $this->createAccount($client, $environment);
+
+        $package = $this->communicationPackage();
+        $default = $this->contract($package, null, $now->modify('-1 day'));
+        $this->em->flush();
+
+        $this->assertSame($default->getId(), $this->repository()->findOpenContract(null, 500.0, 'CUP')?->getId());
+        $this->assertNull($this->repository()->findOpenContract($account, 500.0, 'CUP'));
     }
 }

--- a/tests/Functional/Pricing/DashboardCommunicationContractsControllerListTest.php
+++ b/tests/Functional/Pricing/DashboardCommunicationContractsControllerListTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Tests\Functional\Pricing;
+
+use App\Controller\DashboardCommunicationContractsController;
+use App\Entity\CommunicationContract;
+use App\Entity\CommunicationPackage;
+use App\Service\Pricing\CommunicationContractService;
+use App\Tests\Functional\Provider\ProviderFunctionalTestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @covers \App\Controller\DashboardCommunicationContractsController
+ *
+ * Contra Postgres real — a propósito: list() (Fase 6C) dejó de hacer
+ * fetch-join de `packages` en la consulta paginada porque Doctrine no puede
+ * aplicar setMaxResults() de forma fiable sobre una fetch-join de colección
+ * to-many (un contrato con 2 paquetes agrega 2 filas SQL y corre la
+ * paginación). Este test es el único que ejercita ese camino end-to-end
+ * contra SQL real — un mock de EntityManager no puede validar el fan-out.
+ */
+class DashboardCommunicationContractsControllerListTest extends ProviderFunctionalTestCase
+{
+    private static int $counter = 0;
+
+    private function controller(): DashboardCommunicationContractsController
+    {
+        $controller = new DashboardCommunicationContractsController(
+            $this->em,
+            self::getContainer()->get(CommunicationContractService::class),
+        );
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('has')->willReturn(false);
+        $controller->setContainer($container);
+
+        return $controller;
+    }
+
+    private function communicationPackage(string $name): CommunicationPackage
+    {
+        self::$counter++;
+
+        $package = (new CommunicationPackage())
+            ->setName($name)
+            ->setDescription($name)
+            ->setDestinationAmount(500.0)
+            ->setDestinationCurrency('CUP');
+
+        $this->em->persist($package);
+
+        return $package;
+    }
+
+    public function testListDoesNotSkipEntriesWhenAContractInThePageSharesTwoPackages(): void
+    {
+        $packageA = $this->communicationPackage('Catálogo normal');
+        $packageB = $this->communicationPackage('Promo verano');
+        $shared = (new CommunicationContract())
+            ->addPackage($packageA)
+            ->addPackage($packageB)
+            ->setDestinationAmount(500.0)
+            ->setDestinationCurrency('CUP')
+            ->setPrice(10.0)
+            ->setCurrency('USD');
+        $this->em->persist($shared);
+
+        // Un segundo contrato, sin paquetes compartidos, para confirmar que
+        // la paginación sigue trayendo AMBOS resultados (2, no 1) aunque el
+        // primero haya aportado 2 filas SQL.
+        $other = (new CommunicationContract())
+            ->addPackage($this->communicationPackage('Otro paquete'))
+            ->setDestinationAmount(700.0)
+            ->setDestinationCurrency('CUP')
+            ->setPrice(20.0)
+            ->setCurrency('USD');
+        $this->em->persist($other);
+        $this->em->flush();
+        $this->em->clear();
+
+        $response = $this->controller()->list(new Request(['limit' => '10']));
+        $data = json_decode($response->getContent(), true);
+
+        $this->assertCount(2, $data['results']);
+        $this->assertFalse($data['hasNext']);
+
+        $sharedResult = null;
+        foreach ($data['results'] as $result) {
+            if ($result['id'] === $shared->getId()) {
+                $sharedResult = $result;
+            }
+        }
+        $this->assertNotNull($sharedResult, 'El contrato compartido debe estar en la página.');
+        $this->assertCount(2, $sharedResult['packages']);
+        $this->assertSame(
+            ['Catálogo normal', 'Promo verano'],
+            array_map(static fn (array $p) => $p['name'], $sharedResult['packages']),
+        );
+    }
+
+    public function testListFiltersByEitherPackageOfASharedContract(): void
+    {
+        $packageA = $this->communicationPackage('Catálogo normal');
+        $packageB = $this->communicationPackage('Promo verano');
+        $shared = (new CommunicationContract())
+            ->addPackage($packageA)
+            ->addPackage($packageB)
+            ->setDestinationAmount(500.0)
+            ->setDestinationCurrency('CUP')
+            ->setPrice(10.0)
+            ->setCurrency('USD');
+        $this->em->persist($shared);
+        $this->em->flush();
+        $this->em->clear();
+
+        $response = $this->controller()->list(new Request(['communicationPackageId' => (string) $packageB->getId()]));
+        $data = json_decode($response->getContent(), true);
+
+        $this->assertCount(1, $data['results']);
+        $this->assertSame($shared->getId(), $data['results'][0]['id']);
+    }
+}

--- a/tests/Provider/Csq/CsqCommunicationProviderCatalogTest.php
+++ b/tests/Provider/Csq/CsqCommunicationProviderCatalogTest.php
@@ -287,4 +287,43 @@ class CsqCommunicationProviderCatalogTest extends TestCase
 
         $this->assertSame([], $products);
     }
+
+    /**
+     * CSQ no tiene endpoint de "promociones" propio — fetchPromotionProducts()
+     * (Fase 5C) delega en fetchProducts() sin filtrar por tupla; es el
+     * orquestador (Fase 5D) quien decide qué candidato corresponde a cada
+     * tramo.
+     */
+    public function testFetchPromotionProductsDelegatesToFetchProductsWithoutFiltering(): void
+    {
+        $this->client->method('getPortfolio')->willReturn($this->portfolio([
+            [
+                'articleId' => 7951,
+                'name' => 'Cubacel Pack Combos',
+                'countryId' => 192,
+                'topupType' => 'Bundles',
+                'amountType' => 'by_list',
+                'saleAmount' => ['from' => null, 'to' => null, 'step' => null, 'list' => [2200, 3300]],
+                'exchangeRate' => 22.0,
+                'saleCurrency' => 'USD',
+                'destinationCurrency' => 'CUP',
+                'productDescription' => 'Combos',
+            ],
+        ]));
+
+        $query = new \App\Provider\Contract\PromotionCatalogQuery(
+            destinationCurrency: 'CUP',
+            destinationAmounts: [2200.0],
+            activeFrom: new \DateTimeImmutable('2026-08-18T00:00:00+00:00'),
+            activeTo: new \DateTimeImmutable('2026-08-25T23:59:00+00:00'),
+        );
+
+        $products = iterator_to_array($this->provider->fetchPromotionProducts($this->context(), $query));
+
+        // Devuelve TODOS los candidatos del catálogo (incluido 3300, que no
+        // está entre destinationAmounts) — el filtrado por tramo no es
+        // responsabilidad de este método para CSQ.
+        $this->assertCount(2, $products);
+        $this->assertSame(['7951-2200', '7951-3300'], array_map(static fn ($p) => $p->externalId, $products));
+    }
 }

--- a/tests/Provider/DTOne/DTOneCommunicationProviderTest.php
+++ b/tests/Provider/DTOne/DTOneCommunicationProviderTest.php
@@ -8,6 +8,7 @@ use App\Enums\ProviderOutcomeEnum;
 use App\Exception\MyCurrentException;
 use App\Provider\Contract\ProviderContext;
 use App\Provider\Contract\ProviderStatusQuery;
+use App\Provider\Contract\PromotionCatalogQuery;
 use App\Provider\Contract\RechargeRequest;
 use App\Provider\DTOne\DTOneCommunicationProvider;
 use App\Provider\DTOne\DTOneHttpClient;
@@ -401,5 +402,89 @@ class DTOneCommunicationProviderTest extends TestCase
 
         $this->assertSame(25.0, $products[0]->destinationMinAmount);
         $this->assertSame(50.0, $products[0]->destinationMaxAmount);
+    }
+
+    private function query(array $amounts = [500.0, 625.0]): PromotionCatalogQuery
+    {
+        return new PromotionCatalogQuery(
+            destinationCurrency: 'CUP',
+            destinationAmounts: $amounts,
+            activeFrom: new \DateTimeImmutable('2026-08-18T00:00:00+00:00'),
+            activeTo: new \DateTimeImmutable('2026-08-25T23:59:00+00:00'),
+        );
+    }
+
+    private function catalogProduct(int $id, float $amount, string $name = 'Producto'): array
+    {
+        return [
+            'id' => $id,
+            'name' => $name,
+            'type' => 'FIXED_VALUE_RECHARGE',
+            'is_active' => true,
+            'destination' => ['amount' => $amount, 'unit' => 'CUP'],
+            'prices' => ['wholesale' => ['amount' => $amount / 25, 'unit' => 'USD']],
+        ];
+    }
+
+    public function testFetchPromotionProductsCrossReferencesLivePromotionsAgainstFullCatalog(): void
+    {
+        // La promoción vigente (35719) referencia productos por id/name/type
+        // únicamente — sin destinationAmount, así que hay que cruzar contra
+        // fetchProducts() (iterateProducts) para obtener la tupla completa.
+        $this->client->method('iteratePromotions')->willReturn((function () {
+            yield [
+                'id' => 6999,
+                'start_date' => '2026-08-15T00:00:00.000Z',
+                'end_date' => '2026-08-31T00:00:00.000Z',
+                'products' => [['id' => 35719, 'name' => '500 CUP', 'type' => 'FIXED_VALUE_RECHARGE']],
+            ];
+        })());
+        $this->client->method('iterateProducts')->willReturn((function () {
+            yield $this->catalogProduct(35719, 500.0);
+            // Mismo monto (625), pero NO referenciado por ninguna promoción vigente.
+            yield $this->catalogProduct(35733, 625.0);
+        })());
+
+        $products = iterator_to_array($this->provider->fetchPromotionProducts($this->context(), $this->query()));
+
+        $this->assertCount(1, $products);
+        $this->assertSame('35719', $products[0]->externalId);
+    }
+
+    public function testFetchPromotionProductsExcludesPromotionsOutsideTheRequestedWindow(): void
+    {
+        $this->client->method('iteratePromotions')->willReturn((function () {
+            yield [
+                'id' => 5000,
+                'start_date' => '2026-01-01T00:00:00.000Z',
+                'end_date' => '2026-01-31T00:00:00.000Z',
+                'products' => [['id' => 35719, 'name' => '500 CUP', 'type' => 'FIXED_VALUE_RECHARGE']],
+            ];
+        })());
+        $this->client->expects($this->never())->method('iterateProducts');
+
+        $products = iterator_to_array($this->provider->fetchPromotionProducts($this->context(), $this->query()));
+
+        $this->assertCount(0, $products);
+    }
+
+    public function testFetchPromotionProductsExcludesProductsWhoseAmountDoesNotMatchAnyTramo(): void
+    {
+        $this->client->method('iteratePromotions')->willReturn((function () {
+            yield [
+                'id' => 6999,
+                'start_date' => '2026-08-15T00:00:00.000Z',
+                'end_date' => '2026-08-31T00:00:00.000Z',
+                'products' => [['id' => 99999, 'name' => '900 CUP', 'type' => 'FIXED_VALUE_RECHARGE']],
+            ];
+        })());
+        $this->client->method('iterateProducts')->willReturn((function () {
+            // 900 CUP no está entre los tramos pedidos (500, 625).
+            yield $this->catalogProduct(99999, 900.0);
+        })());
+
+        $products = iterator_to_array($this->provider->fetchPromotionProducts($this->context(), $this->query()));
+
+        $this->assertCount(0, $products);
     }
 }

--- a/tests/Provider/DTOne/DTOneHttpClientTest.php
+++ b/tests/Provider/DTOne/DTOneHttpClientTest.php
@@ -190,4 +190,36 @@ class DTOneHttpClientTest extends TestCase
         $this->assertCount(3, $items);
         $this->assertSame(2, $calls);
     }
+
+    /**
+     * GET /v1/promotions devuelve un array PLANO (no envuelto en "data",
+     * a diferencia de /v1/products) — esquema verificado contra
+     * https://developers.dtone.com/reference/getpromotions.
+     */
+    public function testIteratePromotionsFollowsPaginationOverAFlatArray(): void
+    {
+        $calls = 0;
+        $httpClient = new MockHttpClient(function (string $method, string $url) use (&$calls) {
+            $calls++;
+            $this->assertSame('GET', $method);
+            $this->assertStringContainsString('/v1/promotions', $url);
+
+            $page = $calls === 1
+                ? [['id' => 6999, 'title' => 'Promo A'], ['id' => 6987, 'title' => 'Promo B']]
+                : [['id' => 7001, 'title' => 'Promo C']];
+
+            return new MockResponse(json_encode($page), [
+                'http_code' => 200,
+                'response_headers' => ['x-total-pages: 2'],
+            ]);
+        });
+
+        $client = new DTOneHttpClient($httpClient, $this->credentialsResolver(), new NullLogger());
+
+        $items = iterator_to_array($client->iteratePromotions($this->context()));
+
+        $this->assertCount(3, $items);
+        $this->assertSame(2, $calls);
+        $this->assertSame(6999, $items[0]['id']);
+    }
 }

--- a/tests/Provider/Etecsa/EtecsaCommunicationProviderTest.php
+++ b/tests/Provider/Etecsa/EtecsaCommunicationProviderTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Tests\Provider\Etecsa;
+
+use App\Entity\Environment;
+use App\Enums\CommunicationProviderEnum;
+use App\Provider\Contract\ProviderContext;
+use App\Provider\Contract\PromotionCatalogQuery;
+use App\Provider\Etecsa\EtecsaCommunicationProvider;
+use App\Provider\Etecsa\EtecsaStatusMapper;
+use App\Repository\EnvironmentRepository;
+use App\Service\Etecsa\EtecsaGatewayClient;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \App\Provider\Etecsa\EtecsaCommunicationProvider::fetchPromotionProducts
+ *
+ * Cubre solo fetchPromotionProducts() (Fase 5C) — ETECSA no tiene concepto
+ * de "promoción" propio, delega en fetchProducts() sin filtrar.
+ */
+class EtecsaCommunicationProviderTest extends TestCase
+{
+    private EtecsaGatewayClient&MockObject $client;
+    private EnvironmentRepository&MockObject $environmentRepository;
+    private EtecsaCommunicationProvider $provider;
+
+    protected function setUp(): void
+    {
+        $this->client = $this->createMock(EtecsaGatewayClient::class);
+        $this->environmentRepository = $this->createMock(EnvironmentRepository::class);
+        $this->provider = new EtecsaCommunicationProvider($this->client, new EtecsaStatusMapper(), $this->environmentRepository);
+    }
+
+    public function testFetchPromotionProductsDelegatesToFetchProductsWithoutFiltering(): void
+    {
+        $environment = $this->createMock(Environment::class);
+        $this->environmentRepository->method('find')->with(4)->willReturn($environment);
+
+        $this->client->method('listPackages')->with($environment)->willReturn([
+            ['Id' => 100, 'Description' => 'Producto genérico', 'Enabled' => true],
+        ]);
+
+        $context = new ProviderContext(provider: CommunicationProviderEnum::ETECSA, environmentType: 'TEST', environmentId: 4);
+        $query = new PromotionCatalogQuery(
+            destinationCurrency: 'CUP',
+            destinationAmounts: [500.0],
+            activeFrom: new \DateTimeImmutable('2026-08-18T00:00:00+00:00'),
+            activeTo: new \DateTimeImmutable('2026-08-25T23:59:00+00:00'),
+        );
+
+        $products = iterator_to_array($this->provider->fetchPromotionProducts($context, $query));
+
+        $this->assertCount(1, $products);
+        $this->assertSame('100', $products[0]->externalId);
+        // Producto de monto flexible — igual que fetchProducts() normal.
+        $this->assertNull($products[0]->destinationAmount);
+    }
+}

--- a/tests/Provider/ProviderDispatchResolverTest.php
+++ b/tests/Provider/ProviderDispatchResolverTest.php
@@ -8,6 +8,7 @@ use App\Entity\ClientProviderRouting;
 use App\Entity\CommunicationPackage;
 use App\Entity\CommunicationPackageProviderProduct;
 use App\Entity\CommunicationProduct;
+use App\Entity\CommunicationPromotions;
 use App\Entity\Environment;
 use App\Enums\CommunicationProviderEnum;
 use App\Exception\MyCurrentException;
@@ -95,6 +96,15 @@ class ProviderDispatchResolverTest extends TestCase
             ->setDescription('Paquete')
             ->setDestinationAmount(500.0)
             ->setDestinationCurrency('CUP');
+    }
+
+    /**
+     * Tramo generado por una promoción — a diferencia de package(), NUNCA
+     * debe caer al matching automático por tupla.
+     */
+    private function promotionalPackage(): CommunicationPackage
+    {
+        return $this->package()->setPromotion($this->createMock(CommunicationPromotions::class));
     }
 
     public function testSelectsTheFirstDispatchableProviderInPriorityOrder(): void
@@ -322,5 +332,82 @@ class ProviderDispatchResolverTest extends TestCase
         $selected = $this->resolver->select($account, $package);
 
         $this->assertSame(CommunicationProviderEnum::ETECSA, $selected->provider);
+    }
+
+    public function testPromotionalPackageNeverFallsBackToAutomaticMatchingWithoutABinding(): void
+    {
+        $account = $this->account(1);
+        $package = $this->promotionalPackage();
+
+        $this->routingRepo->method('findActiveProvidersOrderedForClient')->willReturn([$this->routing('CSQ')]);
+        $this->availabilityService->method('canDispatchTo')->willReturn(true);
+        // Sin vínculo explícito (setUp ya deja findForPackageAndProvider en null).
+        $this->productRepository->expects($this->never())->method('findMatchingDestination');
+
+        $this->expectException(MyCurrentException::class);
+
+        $this->resolver->select($account, $package);
+    }
+
+    public function testPromotionalPackageSkipsAProviderWithoutABindingAndTriesTheNextOne(): void
+    {
+        $account = $this->account(1);
+        $package = $this->promotionalPackage();
+        $bound = $this->createMock(CommunicationProduct::class);
+        $bound->method('getExternalRef')->willReturn('ref-dtone');
+        $bound->method('isEnabled')->willReturn(true);
+        $bound->method('getEnvironment')->willReturn(null);
+        $binding = $this->createMock(CommunicationPackageProviderProduct::class);
+        $binding->method('getProduct')->willReturn($bound);
+
+        $this->routingRepo->method('findActiveProvidersOrderedForClient')
+            ->willReturn([$this->routing('CSQ'), $this->routing('DTONE')]);
+        $this->availabilityService->method('canDispatchTo')->willReturn(true);
+        $this->packageBindingRepo = $this->createMock(CommunicationPackageProviderProductRepository::class);
+        $this->packageBindingRepo->method('findForPackageAndProvider')
+            ->willReturnCallback(fn ($pkg, $provider) => $provider === 'DTONE' ? $binding : null);
+        $this->resolver = new ProviderDispatchResolver(
+            $this->routingRepo,
+            $this->productRepository,
+            $this->packageBindingRepo,
+            $this->availabilityService,
+            new ProductSaleTypeMatcher(),
+            $this->sysConfigRepo,
+        );
+        $this->productRepository->expects($this->never())->method('findMatchingDestination');
+
+        $selected = $this->resolver->select($account, $package);
+
+        $this->assertSame(CommunicationProviderEnum::DTONE, $selected->provider);
+        $this->assertSame('ref-dtone', $selected->externalRef);
+    }
+
+    public function testPromotionalPackageStillUsesAnExplicitBindingWhenPresent(): void
+    {
+        $account = $this->account(1);
+        $package = $this->promotionalPackage();
+        $bound = $this->createMock(CommunicationProduct::class);
+        $bound->method('getExternalRef')->willReturn('ref-bound');
+        $bound->method('isEnabled')->willReturn(true);
+        $bound->method('getEnvironment')->willReturn(null);
+        $binding = $this->createMock(CommunicationPackageProviderProduct::class);
+        $binding->method('getProduct')->willReturn($bound);
+
+        $this->routingRepo->method('findActiveProvidersOrderedForClient')->willReturn([$this->routing('ETECSA')]);
+        $this->availabilityService->method('canDispatchTo')->willReturn(true);
+        $this->packageBindingRepo = $this->createMock(CommunicationPackageProviderProductRepository::class);
+        $this->packageBindingRepo->method('findForPackageAndProvider')->willReturn($binding);
+        $this->resolver = new ProviderDispatchResolver(
+            $this->routingRepo,
+            $this->productRepository,
+            $this->packageBindingRepo,
+            $this->availabilityService,
+            new ProductSaleTypeMatcher(),
+            $this->sysConfigRepo,
+        );
+
+        $selected = $this->resolver->select($account, $package);
+
+        $this->assertSame('ref-bound', $selected->externalRef);
     }
 }

--- a/tests/Service/CommunicationPromotionServiceV2Test.php
+++ b/tests/Service/CommunicationPromotionServiceV2Test.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\DTO\CreateCommunicationPackageBatchDto;
+use App\DTO\CreatePromotionV2Dto;
+use App\Entity\CommunicationPackage;
+use App\Entity\Environment;
+use App\Exception\MyCurrentException;
+use App\Repository\EnvironmentRepository;
+use App\Repository\SysConfigRepository;
+use App\Service\CommunicationPromotionService;
+use App\Service\Pricing\CommunicationContractService;
+use App\Service\Pricing\CommunicationPackageAdminService;
+use App\Service\Pricing\ContractRangeResult;
+use App\Service\Pricing\TargetAccountResolver;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * @covers \App\Service\CommunicationPromotionService::createV2
+ *
+ * Cubre la generación de CommunicationPackage por rango para una promoción
+ * V2 (Fase 5B) — a diferencia de createPackagesForPromotion() (legacy), no
+ * depende de un producto de origen ni genera nada por cliente.
+ */
+class CommunicationPromotionServiceV2Test extends TestCase
+{
+    private EntityManagerInterface&MockObject $em;
+    private CommunicationPackageAdminService&MockObject $packageAdminService;
+    private CommunicationContractService&MockObject $contractService;
+    private CommunicationPromotionService $service;
+
+    protected function setUp(): void
+    {
+        $this->em = $this->createMock(EntityManagerInterface::class);
+        $this->packageAdminService = $this->createMock(CommunicationPackageAdminService::class);
+        $this->contractService = $this->createMock(CommunicationContractService::class);
+
+        $this->service = new CommunicationPromotionService(
+            $this->em,
+            $this->createMock(Security::class),
+            $this->createMock(ParameterBagInterface::class),
+            $this->createMock(MailerInterface::class),
+            $this->createMock(LoggerInterface::class),
+            $this->createMock(UserPasswordHasherInterface::class),
+            $this->createMock(EnvironmentRepository::class),
+            $this->createMock(SysConfigRepository::class),
+            $this->createMock(SerializerInterface::class),
+            $this->createMock(MessageBusInterface::class),
+            $this->createMock(TargetAccountResolver::class),
+            $this->packageAdminService,
+            $this->contractService,
+        );
+    }
+
+    private function dto(?int $environmentId = 4): CreatePromotionV2Dto
+    {
+        return new CreatePromotionV2Dto(
+            name: '24h Datos Ilimitados',
+            description: 'Réplica DTOne',
+            packageNameTemplate: 'Cubacel {monto} CUP',
+            packageDescriptionTemplate: 'Cubacel {monto} CUP',
+            startAt: '2026-08-18T00:00:00+00:00',
+            endAt: '2026-08-25T23:59:00+00:00',
+            environmentId: $environmentId,
+            destinationCurrency: 'CUP',
+            amountFrom: 500.0,
+            amountTo: 1250.0,
+            amountStep: 25.0,
+            priceFrom: 19.7,
+            priceTo: 49.25,
+            priceCurrency: 'USD',
+        );
+    }
+
+    public function testThrowsWhenEnvironmentDoesNotExist(): void
+    {
+        $envRepo = $this->createMock(EntityRepository::class);
+        $envRepo->method('find')->willReturn(null);
+        $this->em->method('getRepository')->with(Environment::class)->willReturn($envRepo);
+
+        $this->expectException(MyCurrentException::class);
+
+        $this->service->createV2($this->dto());
+    }
+
+    public function testGeneratesPackagesAndContractsForTheRange(): void
+    {
+        $environment = $this->createMock(Environment::class);
+        $envRepo = $this->createMock(EntityRepository::class);
+        $envRepo->method('find')->with(4)->willReturn($environment);
+        $this->em->method('getRepository')->with(Environment::class)->willReturn($envRepo);
+
+        $packages = [
+            (new CommunicationPackage())->setName('p1')->setDescription('p1')->setDestinationAmount(500.0)->setDestinationCurrency('CUP'),
+            (new CommunicationPackage())->setName('p2')->setDescription('p2')->setDestinationAmount(525.0)->setDestinationCurrency('CUP'),
+        ];
+
+        $this->packageAdminService->expects($this->once())
+            ->method('createBatch')
+            ->with($this->callback(function (CreateCommunicationPackageBatchDto $dto) {
+                return $dto->getFromAmount() === 500.0
+                    && $dto->getToAmount() === 1250.0
+                    && $dto->getStep() === 25.0
+                    && $dto->getDestinationCurrency() === 'CUP'
+                    && $dto->getIsActive() === true;
+            }))
+            ->willReturn($packages);
+
+        $contractResult = new ContractRangeResult(2, 0, 0, [10, 11], []);
+        $this->contractService->expects($this->once())
+            ->method('createForPromotionPackages')
+            ->with($packages, 19.7, 49.25, 'USD', '2026-08-18T00:00:00+00:00', '2026-08-25T23:59:00+00:00')
+            ->willReturn($contractResult);
+
+        $result = $this->service->createV2($this->dto());
+
+        $this->assertSame($packages, $result->packages);
+        $this->assertSame($contractResult, $result->contracts);
+        foreach ($result->packages as $package) {
+            $this->assertSame($result->promotion, $package->getPromotion());
+        }
+        $this->assertSame('24h Datos Ilimitados', $result->promotion->getName());
+        $this->assertNull($result->promotion->getProduct());
+    }
+
+    public function testAllowsASinglePackagePromotionWhenFromEqualsTo(): void
+    {
+        $environment = $this->createMock(Environment::class);
+        $envRepo = $this->createMock(EntityRepository::class);
+        $envRepo->method('find')->willReturn($environment);
+        $this->em->method('getRepository')->with(Environment::class)->willReturn($envRepo);
+
+        $single = [(new CommunicationPackage())->setName('p')->setDescription('p')->setDestinationAmount(500.0)->setDestinationCurrency('CUP')];
+
+        $this->packageAdminService->method('createBatch')->willReturn($single);
+        $this->contractService->method('createForPromotionPackages')->willReturn(new ContractRangeResult(1, 0, 0, [1], []));
+
+        $dto = new CreatePromotionV2Dto(
+            name: 'Bono único',
+            description: 'Bono único',
+            packageNameTemplate: 'Bono {monto} CUP',
+            packageDescriptionTemplate: 'Bono {monto} CUP',
+            startAt: '2026-08-18T00:00:00+00:00',
+            endAt: '2026-08-25T23:59:00+00:00',
+            environmentId: 4,
+            destinationCurrency: 'CUP',
+            amountFrom: 500.0,
+            amountTo: 500.0,
+            amountStep: 1.0,
+            priceFrom: 19.7,
+            priceTo: 19.7,
+            priceCurrency: 'USD',
+        );
+
+        $result = $this->service->createV2($dto);
+
+        $this->assertCount(1, $result->packages);
+    }
+}

--- a/tests/Service/CommunicationPromotionServiceV2Test.php
+++ b/tests/Service/CommunicationPromotionServiceV2Test.php
@@ -12,7 +12,9 @@ use App\Repository\SysConfigRepository;
 use App\Service\CommunicationPromotionService;
 use App\Service\Pricing\CommunicationContractService;
 use App\Service\Pricing\CommunicationPackageAdminService;
+use App\Service\Pricing\CommunicationPromotionEquivalenceService;
 use App\Service\Pricing\ContractRangeResult;
+use App\Service\Pricing\PromotionEquivalenceResult;
 use App\Service\Pricing\TargetAccountResolver;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
@@ -38,6 +40,7 @@ class CommunicationPromotionServiceV2Test extends TestCase
     private EntityManagerInterface&MockObject $em;
     private CommunicationPackageAdminService&MockObject $packageAdminService;
     private CommunicationContractService&MockObject $contractService;
+    private CommunicationPromotionEquivalenceService&MockObject $equivalenceService;
     private CommunicationPromotionService $service;
 
     protected function setUp(): void
@@ -45,6 +48,7 @@ class CommunicationPromotionServiceV2Test extends TestCase
         $this->em = $this->createMock(EntityManagerInterface::class);
         $this->packageAdminService = $this->createMock(CommunicationPackageAdminService::class);
         $this->contractService = $this->createMock(CommunicationContractService::class);
+        $this->equivalenceService = $this->createMock(CommunicationPromotionEquivalenceService::class);
 
         $this->service = new CommunicationPromotionService(
             $this->em,
@@ -60,6 +64,7 @@ class CommunicationPromotionServiceV2Test extends TestCase
             $this->createMock(TargetAccountResolver::class),
             $this->packageAdminService,
             $this->contractService,
+            $this->equivalenceService,
         );
     }
 
@@ -123,10 +128,17 @@ class CommunicationPromotionServiceV2Test extends TestCase
             ->with($packages, 19.7, 49.25, 'USD', '2026-08-18T00:00:00+00:00', '2026-08-25T23:59:00+00:00')
             ->willReturn($contractResult);
 
+        $equivalencesResult = new PromotionEquivalenceResult([['provider' => 'DTONE', 'matched' => 2, 'error' => null]], []);
+        $this->equivalenceService->expects($this->once())
+            ->method('populateEquivalences')
+            ->with($this->isInstanceOf(\App\Entity\CommunicationPromotions::class), $packages)
+            ->willReturn($equivalencesResult);
+
         $result = $this->service->createV2($this->dto());
 
         $this->assertSame($packages, $result->packages);
         $this->assertSame($contractResult, $result->contracts);
+        $this->assertSame($equivalencesResult, $result->equivalences);
         foreach ($result->packages as $package) {
             $this->assertSame($result->promotion, $package->getPromotion());
         }
@@ -145,6 +157,7 @@ class CommunicationPromotionServiceV2Test extends TestCase
 
         $this->packageAdminService->method('createBatch')->willReturn($single);
         $this->contractService->method('createForPromotionPackages')->willReturn(new ContractRangeResult(1, 0, 0, [1], []));
+        $this->equivalenceService->method('populateEquivalences')->willReturn(new PromotionEquivalenceResult([], []));
 
         $dto = new CreatePromotionV2Dto(
             name: 'Bono único',

--- a/tests/Service/Pricing/CommunicationContractServiceTest.php
+++ b/tests/Service/Pricing/CommunicationContractServiceTest.php
@@ -12,6 +12,7 @@ use App\Entity\CommunicationPackage;
 use App\Entity\Environment;
 use App\Entity\User;
 use App\Exception\MyCurrentException;
+use App\Repository\CommunicationContractRepository;
 use App\Repository\CommunicationPackageRepository;
 use App\Service\Pricing\CommunicationContractService;
 use App\Service\Pricing\TargetAccountResolver;
@@ -30,6 +31,7 @@ class CommunicationContractServiceTest extends TestCase
     private TargetAccountResolver&MockObject $targetAccountResolver;
     private Security&MockObject $security;
     private CommunicationPackageRepository&MockObject $packageRepository;
+    private CommunicationContractRepository&MockObject $contractRepository;
     private CommunicationContractService $service;
 
     protected function setUp(): void
@@ -38,8 +40,15 @@ class CommunicationContractServiceTest extends TestCase
         $this->targetAccountResolver = $this->createMock(TargetAccountResolver::class);
         $this->security = $this->createMock(Security::class);
         $this->packageRepository = $this->createMock(CommunicationPackageRepository::class);
+        $this->contractRepository = $this->createMock(CommunicationContractRepository::class);
 
-        $this->service = new CommunicationContractService($this->em, $this->targetAccountResolver, $this->security, $this->packageRepository);
+        $this->service = new CommunicationContractService(
+            $this->em,
+            $this->targetAccountResolver,
+            $this->security,
+            $this->packageRepository,
+            $this->contractRepository,
+        );
     }
 
     private function assignId(object $entity, int $id): void
@@ -66,6 +75,16 @@ class CommunicationContractServiceTest extends TestCase
         $this->assignId($package, $id);
 
         return $package;
+    }
+
+    private function contract(CommunicationPackage $package): CommunicationContract
+    {
+        return (new CommunicationContract())
+            ->addPackage($package)
+            ->setDestinationAmount((float) $package->getDestinationAmount())
+            ->setDestinationCurrency((string) $package->getDestinationCurrency())
+            ->setPrice(10.0)
+            ->setCurrency('USD');
     }
 
     public function testCreateSingleThrowsWhenPackageNotFound(): void
@@ -118,13 +137,9 @@ class CommunicationContractServiceTest extends TestCase
         $dto = new CreateCommunicationContractDto(communicationPackageId: 1, price: 8.0, currency: 'USD');
         $package = $this->package(1);
 
-        $contractRepo = $this->createMock(EntityRepository::class);
-        $contractRepo->method('findOneBy')->willReturn(null);
-
-        $this->em->method('getRepository')->willReturnMap([
-            [CommunicationPackage::class, $this->repoReturning($package)],
-            [CommunicationContract::class, $contractRepo],
-        ]);
+        $this->em->method('getRepository')->with(CommunicationPackage::class)
+            ->willReturn($this->repoReturning($package));
+        $this->contractRepository->method('findOpenContract')->willReturn(null);
 
         $this->em->expects($this->once())->method('persist')->with($this->isInstanceOf(CommunicationContract::class));
         $this->em->expects($this->once())->method('flush');
@@ -132,7 +147,8 @@ class CommunicationContractServiceTest extends TestCase
         $contract = $this->service->createSingle($dto);
 
         $this->assertNull($contract->getTenant());
-        $this->assertSame($package, $contract->getCommunicationPackage());
+        $this->assertCount(1, $contract->getPackages());
+        $this->assertTrue($contract->getPackages()->contains($package));
         $this->assertSame(8.0, $contract->getPrice());
         $this->assertSame('USD', $contract->getCurrency());
         // Snapshot copiado del paquete, no pedido a mano.
@@ -147,20 +163,14 @@ class CommunicationContractServiceTest extends TestCase
         $tenant = $this->createMock(Account::class);
         $environment = $this->createMock(Environment::class);
 
-        $existing = (new CommunicationContract())
-            ->setCommunicationPackage($package)
-            ->setTenant($tenant)
-            ->setDestinationAmount(500.0)
-            ->setDestinationCurrency('CUP')
-            ->setPrice(10.0)
-            ->setCurrency('USD');
+        $existing = $this->contract($package)->setTenant($tenant)->setPrice(10.0)->setCurrency('USD');
 
         $this->em->method('getRepository')->willReturnMap([
             [CommunicationPackage::class, $this->repoReturning($package)],
             [Environment::class, $this->repoReturning($environment)],
-            [CommunicationContract::class, $this->repoReturning($existing)],
         ]);
         $this->targetAccountResolver->method('resolveOne')->with($environment, 5)->willReturn($tenant);
+        $this->contractRepository->method('findOpenContract')->willReturn($existing);
 
         $this->em->expects($this->never())->method('persist');
 
@@ -170,19 +180,62 @@ class CommunicationContractServiceTest extends TestCase
         $this->assertSame(20.0, $contract->getPrice());
     }
 
+    public function testCreateSingleMergesASecondPackageWithSameTupleIntoTheSameContract(): void
+    {
+        $packageA = $this->package(1);
+        $packageB = $this->package(2);
+
+        // Un solo repo de CommunicationPackage para todo el test — stubear
+        // getRepository()->with(...) dos veces en el mismo mock hace que
+        // gane el primer stub configurado, no el segundo (pitfall conocido
+        // de PHPUnit con dobles createMock()).
+        $packageRepo = $this->createMock(EntityRepository::class);
+        $packageRepo->method('find')->willReturnCallback(
+            static fn (int $id) => match ($id) {
+                1 => $packageA,
+                2 => $packageB,
+                default => null,
+            }
+        );
+        $this->em->method('getRepository')->with(CommunicationPackage::class)->willReturn($packageRepo);
+        $this->em->method('persist')->willReturnCallback(fn ($e) => $this->assignId($e, 1));
+
+        $dtoA = new CreateCommunicationContractDto(communicationPackageId: 1, price: 8.0, currency: 'USD');
+        $this->contractRepository->method('findOpenContract')->willReturn(null);
+
+        $contractA = $this->service->createSingle($dtoA);
+        $this->assertCount(1, $contractA->getPackages());
+
+        // Segunda llamada, mismo tenant (null) y misma tupla (monto/moneda) —
+        // findOpenContract ahora "encuentra" el contrato recién creado.
+        $this->contractRepository = $this->createMock(CommunicationContractRepository::class);
+        $this->contractRepository->method('findOpenContract')->willReturn($contractA);
+        $this->service = new CommunicationContractService(
+            $this->em,
+            $this->targetAccountResolver,
+            $this->security,
+            $this->packageRepository,
+            $this->contractRepository,
+        );
+
+        $dtoB = new CreateCommunicationContractDto(communicationPackageId: 2, price: 9.0, currency: 'USD');
+        $contractB = $this->service->createSingle($dtoB);
+
+        $this->assertSame($contractA, $contractB);
+        $this->assertCount(2, $contractB->getPackages());
+        $this->assertTrue($contractB->getPackages()->contains($packageA));
+        $this->assertTrue($contractB->getPackages()->contains($packageB));
+    }
+
     public function testCreateSingleStampsCreatedByFromSecurity(): void
     {
         $dto = new CreateCommunicationContractDto(communicationPackageId: 1, price: 8.0, currency: 'USD');
         $package = $this->package(1);
         $user = $this->createMock(User::class);
 
-        $contractRepo = $this->createMock(EntityRepository::class);
-        $contractRepo->method('findOneBy')->willReturn(null);
-
-        $this->em->method('getRepository')->willReturnMap([
-            [CommunicationPackage::class, $this->repoReturning($package)],
-            [CommunicationContract::class, $contractRepo],
-        ]);
+        $this->em->method('getRepository')->with(CommunicationPackage::class)
+            ->willReturn($this->repoReturning($package));
+        $this->contractRepository->method('findOpenContract')->willReturn(null);
         $this->security->method('getUser')->willReturn($user);
 
         $contract = $this->service->createSingle($dto);
@@ -211,14 +264,11 @@ class CommunicationContractServiceTest extends TestCase
             ->with($environment, [])
             ->willReturn([$account1, $account2]);
 
-        $contractRepo = $this->createMock(EntityRepository::class);
-        $contractRepo->method('findOneBy')->willReturn(null);
-
         $this->em->method('getRepository')->willReturnMap([
             [CommunicationPackage::class, $this->repoReturning($package)],
             [Environment::class, $this->repoReturning($environment)],
-            [CommunicationContract::class, $contractRepo],
         ]);
+        $this->contractRepository->method('findOpenContract')->willReturn(null);
 
         $persisted = [];
         $this->em->method('persist')->willReturnCallback(function ($e) use (&$persisted) { $persisted[] = $e; });
@@ -281,10 +331,7 @@ class CommunicationContractServiceTest extends TestCase
             [150.0, 'CUP', $p150],
             [200.0, 'CUP', $p200],
         ]);
-
-        $contractRepo = $this->createMock(EntityRepository::class);
-        $contractRepo->method('findOneBy')->willReturn(null);
-        $this->em->method('getRepository')->willReturnMap([[CommunicationContract::class, $contractRepo]]);
+        $this->contractRepository->method('findOpenContract')->willReturn(null);
 
         $nextId = 100;
         $persisted = [];
@@ -329,10 +376,7 @@ class CommunicationContractServiceTest extends TestCase
                 default => null,
             }
         );
-
-        $contractRepo = $this->createMock(EntityRepository::class);
-        $contractRepo->method('findOneBy')->willReturn(null);
-        $this->em->method('getRepository')->willReturnMap([[CommunicationContract::class, $contractRepo]]);
+        $this->contractRepository->method('findOpenContract')->willReturn(null);
         $this->em->method('persist')->willReturnCallback(fn ($e) => $this->assignId($e, 1));
         $this->em->expects($this->once())->method('flush');
 
@@ -421,10 +465,7 @@ class CommunicationContractServiceTest extends TestCase
 
         $package = $this->package(1);
         $this->packageRepository->method('findByDestination')->willReturn($package);
-
-        $contractRepo = $this->createMock(EntityRepository::class);
-        $contractRepo->method('findOneBy')->willReturn(null);
-        $this->em->method('getRepository')->willReturnMap([[CommunicationContract::class, $contractRepo]]);
+        $this->contractRepository->method('findOpenContract')->willReturn(null);
 
         $persisted = [];
         $this->em->method('persist')->willReturnCallback(function ($e) use (&$persisted) {
@@ -441,10 +482,7 @@ class CommunicationContractServiceTest extends TestCase
 
     public function testUpdateOnlyTouchesProvidedFields(): void
     {
-        $contract = (new CommunicationContract())
-            ->setCommunicationPackage($this->package(1))
-            ->setDestinationAmount(500.0)->setDestinationCurrency('CUP')
-            ->setPrice(10.0)->setCurrency('USD');
+        $contract = $this->contract($this->package(1));
 
         $dto = new UpdateCommunicationContractDto(price: 12.0);
 
@@ -467,10 +505,7 @@ class CommunicationContractServiceTest extends TestCase
      */
     public function testUpdateNormalizesStartAtOffsetToUtcBeforePersisting(): void
     {
-        $contract = (new CommunicationContract())
-            ->setCommunicationPackage($this->package(1))
-            ->setDestinationAmount(500.0)->setDestinationCurrency('CUP')
-            ->setPrice(10.0)->setCurrency('USD');
+        $contract = $this->contract($this->package(1));
 
         $dto = new UpdateCommunicationContractDto(startAt: '2026-08-12T20:00:00-04:00');
 
@@ -482,70 +517,40 @@ class CommunicationContractServiceTest extends TestCase
         $this->assertSame('2026-08-13T00:00:00+00:00', $updated->getStartAt()?->format('c'));
     }
 
-    public function testUpdateReassignsPackageByDestinationAmount(): void
+    public function testUpdateRelabelsTupleWhenDestinationAmountChangesWithoutTouchingPackages(): void
     {
-        $oldPackage = $this->package(1);
-        $newPackage = $this->package(2);
-        $contract = (new CommunicationContract())
-            ->setCommunicationPackage($oldPackage)
-            ->setDestinationAmount(500.0)->setDestinationCurrency('CUP')
-            ->setPrice(10.0)->setCurrency('USD');
+        $package = $this->package(1);
+        $contract = $this->contract($package);
 
         $dto = new UpdateCommunicationContractDto(destinationAmount: 750.0);
 
-        $this->packageRepository->expects($this->once())
-            ->method('findByDestination')
-            ->with(750.0, 'CUP')
-            ->willReturn($newPackage);
-
-        $contractRepo = $this->createMock(EntityRepository::class);
-        $contractRepo->method('findOneBy')->willReturn(null);
-        $this->em->method('getRepository')->willReturnMap([[CommunicationContract::class, $contractRepo]]);
+        $this->contractRepository->expects($this->once())
+            ->method('findOpenContract')
+            ->with($contract->getTenant(), 750.0, 'CUP')
+            ->willReturn(null);
 
         $this->em->expects($this->once())->method('flush');
 
         $updated = $this->service->update($contract, $dto);
 
-        $this->assertSame($newPackage, $updated->getCommunicationPackage());
+        $this->assertSame(750.0, $updated->getDestinationAmount());
+        // La colección de paquetes no se recalcula al relabelar la tupla.
+        $this->assertCount(1, $updated->getPackages());
+        $this->assertTrue($updated->getPackages()->contains($package));
     }
 
-    public function testUpdateThrowsWhenDestinationAmountHasNoMatchingPackage(): void
-    {
-        $contract = (new CommunicationContract())
-            ->setCommunicationPackage($this->package(1))
-            ->setDestinationAmount(500.0)->setDestinationCurrency('CUP')
-            ->setPrice(10.0)->setCurrency('USD');
-
-        $dto = new UpdateCommunicationContractDto(destinationAmount: 999.0);
-
-        $this->packageRepository->method('findByDestination')->willReturn(null);
-        $this->em->expects($this->never())->method('flush');
-
-        $this->expectException(MyCurrentException::class);
-        $this->expectExceptionMessage('No existe ningún paquete');
-
-        $this->service->update($contract, $dto);
-    }
-
-    public function testUpdateThrowsWhenTargetPackageAlreadyHasOpenContractForTenant(): void
+    public function testUpdateThrowsWhenAnotherOpenContractAlreadyExistsForTheNewTuple(): void
     {
         $tenant = $this->createMock(Account::class);
-        $contract = (new CommunicationContract())
-            ->setCommunicationPackage($this->package(1))
-            ->setTenant($tenant)
-            ->setDestinationAmount(500.0)->setDestinationCurrency('CUP')
-            ->setPrice(10.0)->setCurrency('USD');
+        $contract = $this->contract($this->package(1))->setTenant($tenant);
 
-        $newPackage = $this->package(2);
         $existingConflict = $this->createMock(CommunicationContract::class);
 
         $dto = new UpdateCommunicationContractDto(destinationAmount: 750.0);
 
-        $this->packageRepository->method('findByDestination')->willReturn($newPackage);
-
-        $contractRepo = $this->createMock(EntityRepository::class);
-        $contractRepo->method('findOneBy')->willReturn($existingConflict);
-        $this->em->method('getRepository')->willReturnMap([[CommunicationContract::class, $contractRepo]]);
+        $this->contractRepository->method('findOpenContract')
+            ->with($tenant, 750.0, 'CUP')
+            ->willReturn($existingConflict);
 
         $this->em->expects($this->never())->method('flush');
 
@@ -555,12 +560,27 @@ class CommunicationContractServiceTest extends TestCase
         $this->service->update($contract, $dto);
     }
 
+    public function testUpdateAllowsKeepingTheSameTupleItAlreadyHas(): void
+    {
+        $contract = $this->contract($this->package(1));
+
+        $dto = new UpdateCommunicationContractDto(destinationAmount: 500.0, destinationCurrency: 'cup');
+
+        // findOpenContract() encuentra el propio contrato (misma tupla) — no
+        // es un conflicto real, no debe lanzar.
+        $this->contractRepository->method('findOpenContract')->willReturn($contract);
+
+        $this->em->expects($this->once())->method('flush');
+
+        $updated = $this->service->update($contract, $dto);
+
+        $this->assertSame(500.0, $updated->getDestinationAmount());
+        $this->assertSame('CUP', $updated->getDestinationCurrency());
+    }
+
     public function testCloseSetsEndAtAndFlushes(): void
     {
-        $contract = (new CommunicationContract())
-            ->setCommunicationPackage($this->package(1))
-            ->setDestinationAmount(500.0)->setDestinationCurrency('CUP')
-            ->setPrice(10.0)->setCurrency('USD');
+        $contract = $this->contract($this->package(1));
         $this->assertNull($contract->getEndAt());
 
         $this->em->expects($this->once())->method('flush');
@@ -572,10 +592,7 @@ class CommunicationContractServiceTest extends TestCase
 
     public function testDeleteRemovesAndFlushes(): void
     {
-        $contract = (new CommunicationContract())
-            ->setCommunicationPackage($this->package(1))
-            ->setDestinationAmount(500.0)->setDestinationCurrency('CUP')
-            ->setPrice(10.0)->setCurrency('USD');
+        $contract = $this->contract($this->package(1));
 
         $this->em->expects($this->once())->method('remove')->with($contract);
         $this->em->expects($this->once())->method('flush');
@@ -585,8 +602,8 @@ class CommunicationContractServiceTest extends TestCase
 
     public function testDeleteAllWithoutTenantRemovesEveryContract(): void
     {
-        $c1 = (new CommunicationContract())->setCommunicationPackage($this->package(1))->setDestinationAmount(500.0)->setDestinationCurrency('CUP')->setPrice(1.0)->setCurrency('USD');
-        $c2 = (new CommunicationContract())->setCommunicationPackage($this->package(2))->setDestinationAmount(600.0)->setDestinationCurrency('CUP')->setPrice(2.0)->setCurrency('USD');
+        $c1 = $this->contract($this->package(1))->setDestinationAmount(500.0)->setDestinationCurrency('CUP')->setPrice(1.0)->setCurrency('USD');
+        $c2 = $this->contract($this->package(2))->setDestinationAmount(600.0)->setDestinationCurrency('CUP')->setPrice(2.0)->setCurrency('USD');
 
         $contractRepo = $this->createMock(EntityRepository::class);
         $contractRepo->expects($this->once())->method('findBy')->with([])->willReturn([$c1, $c2]);
@@ -606,7 +623,7 @@ class CommunicationContractServiceTest extends TestCase
     {
         $tenant = $this->createMock(Account::class);
         $environment = $this->createMock(Environment::class);
-        $contract = (new CommunicationContract())->setCommunicationPackage($this->package(1))->setDestinationAmount(500.0)->setDestinationCurrency('CUP')->setPrice(1.0)->setCurrency('USD');
+        $contract = $this->contract($this->package(1))->setPrice(1.0)->setCurrency('USD');
 
         $contractRepo = $this->createMock(EntityRepository::class);
         $contractRepo->expects($this->once())->method('findBy')->with(['tenant' => $tenant])->willReturn([$contract]);

--- a/tests/Service/Pricing/CommunicationContractServiceTest.php
+++ b/tests/Service/Pricing/CommunicationContractServiceTest.php
@@ -227,6 +227,60 @@ class CommunicationContractServiceTest extends TestCase
         $this->assertTrue($contractB->getPackages()->contains($packageB));
     }
 
+    /**
+     * Fusionar un segundo paquete (ej. promocional) en un contrato "por
+     * defecto" ya existente e indefinido (endAt NULL) NO debe heredar el
+     * endAt corto del segundo alta — o el paquete original (no
+     * promocional) también dejaría de verse cuando el segundo expire. Este
+     * es exactamente el hallazgo que motivó todo el rediseño ManyToMany:
+     * sin este resguardo, fusionar reintroduce el mismo tipo de ocultación
+     * transitoria del catálogo normal que se intentaba evitar.
+     */
+    public function testMergingASecondPackageWithAShorterEndAtDoesNotShrinkTheExistingContractsWindow(): void
+    {
+        $packageA = $this->package(1);
+        $packageB = $this->package(2);
+
+        $packageRepo = $this->createMock(EntityRepository::class);
+        $packageRepo->method('find')->willReturnCallback(
+            static fn (int $id) => match ($id) {
+                1 => $packageA,
+                2 => $packageB,
+                default => null,
+            }
+        );
+        $this->em->method('getRepository')->with(CommunicationPackage::class)->willReturn($packageRepo);
+        $this->em->method('persist')->willReturnCallback(fn ($e) => $this->assignId($e, 1));
+
+        // Contrato "por defecto" indefinido (sin endAt) para el catálogo normal.
+        $dtoA = new CreateCommunicationContractDto(communicationPackageId: 1, price: 8.0, currency: 'USD');
+        $this->contractRepository->method('findOpenContract')->willReturn(null);
+        $contractA = $this->service->createSingle($dtoA);
+        $this->assertNull($contractA->getEndAt());
+
+        // Un segundo alta (ej. una promoción) sobre la misma tupla, con un
+        // endAt corto — findOpenContract ahora "encuentra" el contrato A.
+        $this->contractRepository = $this->createMock(CommunicationContractRepository::class);
+        $this->contractRepository->method('findOpenContract')->willReturn($contractA);
+        $this->service = new CommunicationContractService(
+            $this->em,
+            $this->targetAccountResolver,
+            $this->security,
+            $this->packageRepository,
+            $this->contractRepository,
+        );
+
+        $dtoB = new CreateCommunicationContractDto(communicationPackageId: 2, price: 9.0, currency: 'USD', endAt: '2026-08-25T00:00:00+00:00');
+        $contractB = $this->service->createSingle($dtoB);
+
+        $this->assertSame($contractA, $contractB);
+        $this->assertCount(2, $contractB->getPackages());
+        // El endAt corto de la fusión NO se aplicó — sigue indefinido.
+        $this->assertNull($contractB->getEndAt());
+        // El precio SÍ se actualiza — es la tupla compartida la que decide el precio.
+        $this->assertSame(9.0, $contractB->getPrice());
+    }
+
     public function testCreateSingleStampsCreatedByFromSecurity(): void
     {
         $dto = new CreateCommunicationContractDto(communicationPackageId: 1, price: 8.0, currency: 'USD');

--- a/tests/Service/Pricing/CommunicationPackageAdminServiceTest.php
+++ b/tests/Service/Pricing/CommunicationPackageAdminServiceTest.php
@@ -42,6 +42,19 @@ class CommunicationPackageAdminServiceTest extends TestCase
         return $repo;
     }
 
+    /**
+     * $contracts es el lado inverso (mappedBy) de CommunicationContract::
+     * $packages — no tiene un addContract() público porque nunca se muta
+     * desde este lado en producción; en el test se puebla por reflexión
+     * para simular "este paquete ya tiene un contrato asociado".
+     */
+    private function addContractTo(CommunicationPackage $package, CommunicationContract $contract): void
+    {
+        $property = new \ReflectionProperty($package, 'contracts');
+        $property->setAccessible(true);
+        $property->getValue($package)->add($contract);
+    }
+
     public function testCreatePersistsAllFields(): void
     {
         $dto = new CreateCommunicationPackageDto(
@@ -202,9 +215,8 @@ class CommunicationPackageAdminServiceTest extends TestCase
             ->setName('P')->setDescription('P')
             ->setDestinationAmount(1.0)->setDestinationCurrency('USD');
         $existingContract = $this->createMock(CommunicationContract::class);
+        $this->addContractTo($package, $existingContract);
 
-        $this->em->method('getRepository')->with(CommunicationContract::class)
-            ->willReturn($this->repoReturning($existingContract));
         $this->em->expects($this->never())->method('remove');
 
         $this->expectException(MyCurrentException::class);
@@ -219,8 +231,6 @@ class CommunicationPackageAdminServiceTest extends TestCase
             ->setName('P')->setDescription('P')
             ->setDestinationAmount(1.0)->setDestinationCurrency('USD');
 
-        $this->em->method('getRepository')->with(CommunicationContract::class)
-            ->willReturn($this->repoReturning(null));
         $this->em->expects($this->once())->method('remove')->with($package);
         $this->em->expects($this->once())->method('flush');
 

--- a/tests/Service/Pricing/CommunicationPromotionEquivalenceServiceTest.php
+++ b/tests/Service/Pricing/CommunicationPromotionEquivalenceServiceTest.php
@@ -173,6 +173,43 @@ class CommunicationPromotionEquivalenceServiceTest extends TestCase
         $this->assertSame(['DTONE'], $result->gaps[0]['missingProviders']);
     }
 
+    /**
+     * Bug real encontrado en pruebas E2E (2026-08-18): CSQ puede devolver
+     * más de un candidato para el MISMO monto nominal (ej. catálogo con
+     * duplicados). Sin esta guarda, dos upsertBinding() para la misma
+     * (package, provider) sin flush de por medio violan
+     * uniq_com_package_provider al hacer flush() al final — el primer
+     * candidato que cubre el tramo debe ganar, los siguientes se ignoran.
+     */
+    public function testASecondCandidateForTheSameTramoAndProviderDoesNotDuplicateTheBinding(): void
+    {
+        $packages = [$this->package(1, 500.0)];
+        $productA = $this->createMock(CommunicationProduct::class);
+        $productB = $this->createMock(CommunicationProduct::class);
+
+        $service = $this->makeService([
+            $this->fakeProvider(CommunicationProviderEnum::CSQ, [
+                $this->providerProduct('7854-500', 500.0),
+                $this->providerProduct('7854-500-dup', 500.0),
+            ]),
+        ]);
+        $this->productRepository->method('findOneBy')->willReturnCallback(
+            fn (array $criteria) => match ($criteria['externalRef']) {
+                '7854-500' => $productA,
+                '7854-500-dup' => $productB,
+                default => null,
+            }
+        );
+        $this->bindingRepo->method('findForPackageAndProvider')->willReturn(null);
+
+        $this->em->expects($this->once())->method('persist');
+
+        $result = $service->populateEquivalences($this->promotion(), $packages);
+
+        $this->assertSame(1, $result->providers[0]['matched']);
+        $this->assertSame([], $result->gaps);
+    }
+
     public function testAFlexibleAmountCandidateCoversEveryTramo(): void
     {
         $packages = [$this->package(1, 500.0), $this->package(2, 525.0)];

--- a/tests/Service/Pricing/CommunicationPromotionEquivalenceServiceTest.php
+++ b/tests/Service/Pricing/CommunicationPromotionEquivalenceServiceTest.php
@@ -1,0 +1,279 @@
+<?php
+
+namespace App\Tests\Service\Pricing;
+
+use App\Entity\CommunicationPackage;
+use App\Entity\CommunicationPackageProviderProduct;
+use App\Entity\CommunicationProduct;
+use App\Entity\CommunicationPromotions;
+use App\Entity\Environment;
+use App\Enums\CommunicationProviderEnum;
+use App\Provider\Contract\ProviderPromotionCatalogInterface;
+use App\Provider\Contract\ProviderProductDto;
+use App\Provider\ProviderContextFactory;
+use App\Provider\ProviderRegistry;
+use App\Provider\ProviderResolver;
+use App\Repository\ClientProviderRoutingRepository;
+use App\Repository\CommunicationPackageProviderProductRepository;
+use App\Repository\CommunicationPackageRepository;
+use App\Repository\CommunicationProductRepository;
+use App\Repository\SysConfigRepository;
+use App\Service\Pricing\CommunicationPromotionEquivalenceService;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * @covers \App\Service\Pricing\CommunicationPromotionEquivalenceService
+ *
+ * ProviderRegistry es `final` — no se mockea, se construye real con la
+ * lista de proveedores fake que necesita cada test (mismo patrón que
+ * DTOneHttpClientTest::credentialsResolver()).
+ */
+class CommunicationPromotionEquivalenceServiceTest extends TestCase
+{
+    private EntityManagerInterface&MockObject $em;
+    private CommunicationPackageProviderProductRepository&MockObject $bindingRepo;
+    private CommunicationProductRepository&MockObject $productRepository;
+    private CommunicationPackageRepository&MockObject $packageRepository;
+
+    protected function setUp(): void
+    {
+        $this->em = $this->createMock(EntityManagerInterface::class);
+        $this->bindingRepo = $this->createMock(CommunicationPackageProviderProductRepository::class);
+        $this->productRepository = $this->createMock(CommunicationProductRepository::class);
+        $this->packageRepository = $this->createMock(CommunicationPackageRepository::class);
+    }
+
+    /**
+     * @param list<ProviderPromotionCatalogInterface> $providers
+     */
+    private function makeService(array $providers): CommunicationPromotionEquivalenceService
+    {
+        $registry = new ProviderRegistry($providers);
+        $contextFactory = new ProviderContextFactory(new ProviderResolver(
+            $this->createMock(SysConfigRepository::class),
+            $this->createMock(ClientProviderRoutingRepository::class),
+            new NullLogger(),
+        ));
+
+        return new CommunicationPromotionEquivalenceService(
+            $this->em,
+            $registry,
+            $contextFactory,
+            $this->bindingRepo,
+            $this->productRepository,
+            $this->packageRepository,
+        );
+    }
+
+    private function assignId(object $entity, int $id): void
+    {
+        $property = new \ReflectionProperty($entity, 'id');
+        $property->setAccessible(true);
+        $property->setValue($entity, $id);
+    }
+
+    private function promotion(): CommunicationPromotions
+    {
+        $environment = $this->createMock(Environment::class);
+        $environment->method('getType')->willReturn('TEST');
+        $environment->method('getId')->willReturn(4);
+
+        return (new CommunicationPromotions())
+            ->setName('Promo')
+            ->setDescription('Promo')
+            ->setEnvironment($environment)
+            ->setStartAt(new \DateTimeImmutable('2026-08-18T00:00:00+00:00'))
+            ->setEndAt(new \DateTimeImmutable('2026-08-25T23:59:00+00:00'));
+    }
+
+    private function package(int $id, float $amount): CommunicationPackage
+    {
+        $package = (new CommunicationPackage())
+            ->setName("p{$id}")
+            ->setDescription("p{$id}")
+            ->setDestinationAmount($amount)
+            ->setDestinationCurrency('CUP');
+        $this->assignId($package, $id);
+
+        return $package;
+    }
+
+    private function providerProduct(string $externalId, ?float $destinationAmount): ProviderProductDto
+    {
+        return new ProviderProductDto(
+            externalId: $externalId,
+            name: 'p',
+            description: null,
+            productTypeRaw: null,
+            wholesalePrice: 1.0,
+            priceCurrency: 'USD',
+            destinationAmount: $destinationAmount,
+            destinationMinAmount: null,
+            destinationMaxAmount: null,
+            destinationUnit: $destinationAmount !== null ? 'CUP' : null,
+            benefits: [],
+            enabled: true,
+            validFrom: null,
+            validTo: null,
+            raw: [],
+            isMobileOrInternetService: true,
+            service: [],
+        );
+    }
+
+    private function fakeProvider(CommunicationProviderEnum $code, iterable $products): ProviderPromotionCatalogInterface&MockObject
+    {
+        $provider = $this->createMock(ProviderPromotionCatalogInterface::class);
+        $provider->method('getCode')->willReturn($code);
+        $provider->method('fetchPromotionProducts')->willReturn($products);
+
+        return $provider;
+    }
+
+    public function testReturnsEmptyResultWithoutTouchingProvidersWhenNoPackagesGiven(): void
+    {
+        $provider = $this->createMock(ProviderPromotionCatalogInterface::class);
+        $provider->method('getCode')->willReturn(CommunicationProviderEnum::DTONE);
+        $provider->expects($this->never())->method('fetchPromotionProducts');
+
+        $result = $this->makeService([$provider])->populateEquivalences($this->promotion(), []);
+
+        $this->assertSame([], $result->providers);
+        $this->assertSame([], $result->gaps);
+    }
+
+    public function testMatchesACandidateAgainstItsTramoAndCreatesTheBinding(): void
+    {
+        $packages = [$this->package(1, 500.0), $this->package(2, 525.0)];
+        $product500 = $this->createMock(CommunicationProduct::class);
+
+        $service = $this->makeService([
+            $this->fakeProvider(CommunicationProviderEnum::DTONE, [$this->providerProduct('35719', 500.0)]),
+        ]);
+        $this->productRepository->method('findOneBy')
+            ->with(['provider' => 'DTONE', 'externalRef' => '35719'])
+            ->willReturn($product500);
+        $this->bindingRepo->method('findForPackageAndProvider')->willReturn(null);
+
+        $this->em->expects($this->once())->method('persist')->with($this->isInstanceOf(CommunicationPackageProviderProduct::class));
+        $this->em->expects($this->once())->method('flush');
+
+        $result = $service->populateEquivalences($this->promotion(), $packages);
+
+        $this->assertSame('DTONE', $result->providers[0]['provider']);
+        $this->assertSame(1, $result->providers[0]['matched']);
+        $this->assertNull($result->providers[0]['error']);
+
+        // El tramo 525 no tiene candidato -> queda como hueco para DTONE.
+        $this->assertCount(1, $result->gaps);
+        $this->assertSame(2, $result->gaps[0]['packageId']);
+        $this->assertSame(['DTONE'], $result->gaps[0]['missingProviders']);
+    }
+
+    public function testAFlexibleAmountCandidateCoversEveryTramo(): void
+    {
+        $packages = [$this->package(1, 500.0), $this->package(2, 525.0)];
+        $product = $this->createMock(CommunicationProduct::class);
+
+        $service = $this->makeService([
+            $this->fakeProvider(CommunicationProviderEnum::ETECSA, [$this->providerProduct('100', null)]),
+        ]);
+        $this->productRepository->method('findOneBy')->willReturn($product);
+        $this->bindingRepo->method('findForPackageAndProvider')->willReturn(null);
+
+        $result = $service->populateEquivalences($this->promotion(), $packages);
+
+        $this->assertSame(2, $result->providers[0]['matched']);
+        $this->assertSame([], $result->gaps);
+    }
+
+    public function testSkipsACandidateNotYetSyncedAsACommunicationProduct(): void
+    {
+        $packages = [$this->package(1, 500.0)];
+
+        $service = $this->makeService([
+            $this->fakeProvider(CommunicationProviderEnum::DTONE, [$this->providerProduct('99999', 500.0)]),
+        ]);
+        $this->productRepository->method('findOneBy')->willReturn(null);
+        $this->em->expects($this->never())->method('persist');
+
+        $result = $service->populateEquivalences($this->promotion(), $packages);
+
+        $this->assertSame(0, $result->providers[0]['matched']);
+        $this->assertSame(['DTONE'], $result->gaps[0]['missingProviders']);
+    }
+
+    public function testAProviderErrorIsCapturedWithoutAbortingOtherProviders(): void
+    {
+        $packages = [$this->package(1, 500.0)];
+        $failing = $this->createMock(ProviderPromotionCatalogInterface::class);
+        $failing->method('getCode')->willReturn(CommunicationProviderEnum::DTONE);
+        $failing->method('fetchPromotionProducts')->willThrowException(new \RuntimeException('DTOne unavailable'));
+
+        $product = $this->createMock(CommunicationProduct::class);
+        $ok = $this->fakeProvider(CommunicationProviderEnum::CSQ, [$this->providerProduct('7854-500', 500.0)]);
+
+        $service = $this->makeService([$failing, $ok]);
+        $this->productRepository->method('findOneBy')->willReturn($product);
+        $this->bindingRepo->method('findForPackageAndProvider')->willReturn(null);
+
+        $result = $service->populateEquivalences($this->promotion(), $packages);
+
+        $this->assertSame('DTOne unavailable', $result->providers[0]['error']);
+        $this->assertSame(0, $result->providers[0]['matched']);
+        $this->assertSame('CSQ', $result->providers[1]['provider']);
+        $this->assertSame(1, $result->providers[1]['matched']);
+    }
+
+    public function testDoesNotDuplicateAnExistingBindingAndCountsItAsAlreadyCovered(): void
+    {
+        $packages = [$this->package(1, 500.0)];
+        $product = $this->createMock(CommunicationProduct::class);
+        $existingBinding = $this->createMock(CommunicationPackageProviderProduct::class);
+        $existingBinding->method('getProvider')->willReturn('DTONE');
+        $existingBinding->expects($this->once())->method('setProduct')->with($product);
+
+        $this->bindingRepo->method('findAllForPackage')->willReturn([$existingBinding]);
+        $this->bindingRepo->method('findForPackageAndProvider')->willReturn($existingBinding);
+        $service = $this->makeService([
+            $this->fakeProvider(CommunicationProviderEnum::DTONE, [$this->providerProduct('35719', 500.0)]),
+        ]);
+        $this->productRepository->method('findOneBy')->willReturn($product);
+        $this->em->expects($this->never())->method('persist');
+
+        $result = $service->populateEquivalences($this->promotion(), $packages);
+
+        // Ya estaba cubierto antes de correr -> no se cuenta como "matched" nuevo.
+        $this->assertSame(0, $result->providers[0]['matched']);
+        $this->assertSame([], $result->gaps);
+    }
+
+    public function testCoverageIsReadOnlyAndNeverCallsTheProvider(): void
+    {
+        $packages = [$this->package(1, 500.0)];
+        $this->packageRepository->method('findByPromotion')->willReturn($packages);
+
+        $provider = $this->createMock(ProviderPromotionCatalogInterface::class);
+        $provider->method('getCode')->willReturn(CommunicationProviderEnum::DTONE);
+        $provider->expects($this->never())->method('fetchPromotionProducts');
+
+        $result = $this->makeService([$provider])->coverage($this->promotion());
+
+        $this->assertSame([], $result->providers);
+        $this->assertSame(['DTONE'], $result->gaps[0]['missingProviders']);
+    }
+
+    public function testRefreshForPromotionReloadsPackagesFromRepository(): void
+    {
+        $packages = [$this->package(1, 500.0)];
+        $this->packageRepository->expects($this->once())->method('findByPromotion')->willReturn($packages);
+
+        $result = $this->makeService([])->refreshForPromotion($this->promotion());
+
+        $this->assertSame([], $result->providers);
+        $this->assertSame([], $result->gaps);
+    }
+}

--- a/tests/Service/Pricing/PackageCatalogResolverTest.php
+++ b/tests/Service/Pricing/PackageCatalogResolverTest.php
@@ -92,7 +92,7 @@ class PackageCatalogResolverTest extends TestCase
     private function contract(CommunicationPackage $package, float $price, string $currency = 'USD'): CommunicationContract
     {
         $contract = (new CommunicationContract())
-            ->setCommunicationPackage($package)
+            ->addPackage($package)
             ->setDestinationAmount($package->getDestinationAmount())
             ->setDestinationCurrency($package->getDestinationCurrency())
             ->setPrice($price)
@@ -137,6 +137,52 @@ class PackageCatalogResolverTest extends TestCase
         $this->assertCount(1, $offers);
         $this->assertSame(12.0, $offers[0]->price);
         $this->assertSame(PackageOfferSourceEnum::DEFAULT_CONTRACT, $offers[0]->source);
+    }
+
+    public function testCatalogForFlattensAllPackagesOfAContractSharedByTwo(): void
+    {
+        $account = $this->account(1);
+        $packageA = $this->package(10);
+        $packageB = $this->package(11);
+        $shared = (new CommunicationContract())
+            ->addPackage($packageA)
+            ->addPackage($packageB)
+            ->setDestinationAmount(500.0)
+            ->setDestinationCurrency('CUP')
+            ->setPrice(15.0)
+            ->setCurrency('USD');
+        $this->assignId($shared, 999);
+
+        $this->contractRepository->method('findActiveForTenant')->willReturn([$shared]);
+
+        $offers = $this->resolver->catalogFor($account);
+
+        $this->assertCount(2, $offers);
+        $this->assertSame([$packageA, $packageB], array_map(fn ($o) => $o->package, $offers));
+        $this->assertSame(15.0, $offers[0]->price);
+        $this->assertSame(15.0, $offers[1]->price);
+    }
+
+    public function testOfferForFindsAPackageThatIsNotTheFirstOfASharedContract(): void
+    {
+        $account = $this->account(1);
+        $packageA = $this->package(10);
+        $packageB = $this->package(11);
+        $shared = (new CommunicationContract())
+            ->addPackage($packageA)
+            ->addPackage($packageB)
+            ->setDestinationAmount(500.0)
+            ->setDestinationCurrency('CUP')
+            ->setPrice(15.0)
+            ->setCurrency('USD');
+
+        $this->contractRepository->method('findActiveForTenant')->willReturn([$shared]);
+
+        $offer = $this->resolver->offerFor($packageB, $account);
+
+        $this->assertNotNull($offer);
+        $this->assertSame($packageB, $offer->package);
+        $this->assertSame(15.0, $offer->price);
     }
 
     public function testCatalogForFallsBackToProductMaxWhenNoContractsAtAll(): void


### PR DESCRIPTION
## Resumen

- Promociones V2: genera `CommunicationPackage` por rango de montos (catálogo compartido, sin tenant) en vez de copias por cliente, con `CommunicationContract` "por defecto" interpolando precio linealmente entre los extremos del rango.
- Despacho estricto por proveedor para paquetes de origen promocional: sin una equivalencia explícita (`CommunicationPackageProviderProduct`), el proveedor simplemente no despacha ese tramo — nunca hay auto-match/fallback silencioso.
- Equivalencias por proveedor pobladas por un método común (`ProviderPromotionCatalogInterface::fetchPromotionProducts()`): ETECSA/CSQ delegan a `fetchProducts()` (un solo producto para toda la promoción, CSQ vía `articleId` compartido entre tramos); DTOne llama al endpoint real `GET /v1/promotions` (un producto distinto por tramo). El resultado reporta qué tramos quedaron sin cobertura por proveedor para curarlos a mano.
- **Hallazgo real durante las pruebas end-to-end** (promoción de 31 paquetes ocultando por completo el catálogo normal de 41 mientras la promoción estaba activa, por la precedencia "todo o nada" de `PackageCatalogResolver`): `CommunicationContract` pasa de `ManyToOne` a `ManyToMany` explícito con `CommunicationPackage` — un contrato define precio/visibilidad para `(tenant, destinationAmount, destinationCurrency)`, y dos paquetes que comparten esa tupla (ej. catálogo normal + promoción) convergen al MISMO contrato en vez de crear filas separadas, sin tocar la precedencia de `catalogFor()`.
- Corrección adicional encontrada en la propia verificación E2E: fusionar un paquete en un contrato ya existente e indefinido ya no hereda el `endAt` corto del nuevo alta — solo ensancha la ventana de vigencia, nunca la estrecha (o el paquete original también quedaría oculto cuando la promoción expirase).
- `DashboardCommunicationContractsController::list()` deja de hacer fetch-join de la colección `packages` en la consulta paginada (Doctrine no puede aplicar `setMaxResults()` de forma fiable sobre un fetch-join de colección to-many) y recarga las colecciones de la página en una segunda consulta acotada — verificado con un test funcional contra Postgres real.

## Test plan

- [x] `php bin/phpunit --no-coverage` — 944 tests en verde (Docker)
- [x] `vendor/bin/phpstan analyse` — sin errores
- [x] Verificación E2E real contra proveedores en vivo (DTOne/CSQ/ETECSA) creando una promoción real
- [x] Verificación E2E de la fusión de contratos: contrato por defecto a un monto X + promoción al mismo monto → mismo `CommunicationContract`, `endAt` indefinido preservado, ambos paquetes visibles en `GET /communication/packages/catalog`
- [x] Migración aplicada y verificada en BD real (196 contratos → 196 filas de tabla puente sin pérdida de datos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019akFNicpzpVzZSjSVqvGRs