### PR TITLE
feat(promotions): franja horaria opcional para beneficios de datos ilimitados

### DIFF
--- a/src/DTO/CreatePromotionV2Dto.php
+++ b/src/DTO/CreatePromotionV2Dto.php
@@ -95,6 +95,15 @@ class CreatePromotionV2Dto implements IInput
                     'base' => ['type' => 'integer'],
                     'promotion_bonus' => ['type' => 'integer'],
                 ]],
+                // Franja horaria diaria de vigencia de este beneficio (uso
+                // pensado para DATA/ILIM — "internet ilimitado de 01:00 a
+                // 06:00"). Ambos null = vigente las 24h. Solo informativa:
+                // no se valida contra ningún otro campo ni se aplica en
+                // lógica de despacho.
+                'schedule' => ['type' => 'object', 'nullable' => true, 'default' => null, 'properties' => [
+                    'start' => ['type' => 'string', 'nullable' => true, 'example' => '01:00'],
+                    'end' => ['type' => 'string', 'nullable' => true, 'example' => '06:00'],
+                ]],
             ],
         ],
     ])]
@@ -181,6 +190,56 @@ class CreatePromotionV2Dto implements IInput
             $context->buildViolation('El monto final debe ser mayor o igual al monto inicial')
                 ->atPath('amountTo')
                 ->addViolation();
+        }
+    }
+
+    /**
+     * `schedule` es opcional y puramente informativo (ver docblock de la
+     * clase) — no se valida contra el `type`/`unit` del beneficio, solo su
+     * propia forma: ambos extremos null (24h) o ambos presentes en formato
+     * HH:mm y distintos entre sí (una franja de largo cero no tiene
+     * sentido).
+     */
+    #[Assert\Callback]
+    public function validateBenefitsSchedule(ExecutionContextInterface $context): void
+    {
+        if ($this->benefits === null) {
+            return;
+        }
+
+        foreach ($this->benefits as $index => $benefit) {
+            if (!is_array($benefit) || !array_key_exists('schedule', $benefit) || $benefit['schedule'] === null) {
+                continue;
+            }
+
+            $schedule = $benefit['schedule'];
+            $path = "benefits[{$index}].schedule";
+
+            if (!is_array($schedule) || !array_key_exists('start', $schedule) || !array_key_exists('end', $schedule)) {
+                $context->buildViolation('schedule debe tener start y end (ambos null, o ambos "HH:mm")')
+                    ->atPath($path)
+                    ->addViolation();
+                continue;
+            }
+
+            [$start, $end] = [$schedule['start'], $schedule['end']];
+            if ($start === null && $end === null) {
+                continue;
+            }
+
+            $timeFormat = '/^([01]\d|2[0-3]):[0-5]\d$/';
+            if (!is_string($start) || !is_string($end) || !preg_match($timeFormat, $start) || !preg_match($timeFormat, $end)) {
+                $context->buildViolation('schedule.start/end deben ser ambos null (24h) o ambos "HH:mm"')
+                    ->atPath($path)
+                    ->addViolation();
+                continue;
+            }
+
+            if ($start === $end) {
+                $context->buildViolation('schedule.start y schedule.end no pueden ser iguales')
+                    ->atPath($path)
+                    ->addViolation();
+            }
         }
     }
 

--- a/tests/DTO/CreatePromotionV2DtoTest.php
+++ b/tests/DTO/CreatePromotionV2DtoTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Tests\DTO;
+
+use App\DTO\CreatePromotionV2Dto;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Validation;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @covers \App\DTO\CreatePromotionV2Dto
+ *
+ * Primer test de DTO en el repo (no existía tests/DTO/) — cubre
+ * específicamente validateBenefitsSchedule(), la única lógica de
+ * validación nueva; el resto de constraints (#[Assert\NotBlank] etc.) ya
+ * las ejercita Symfony y no aportan valor repetirlas aquí.
+ */
+class CreatePromotionV2DtoTest extends TestCase
+{
+    private ValidatorInterface $validator;
+
+    protected function setUp(): void
+    {
+        $this->validator = Validation::createValidatorBuilder()
+            ->enableAttributeMapping()
+            ->getValidator();
+    }
+
+    private function dto(?array $benefits): CreatePromotionV2Dto
+    {
+        return new CreatePromotionV2Dto(
+            name: 'Promo',
+            description: 'Promo',
+            packageNameTemplate: 'Promo {monto}',
+            packageDescriptionTemplate: 'Promo {monto}',
+            startAt: '2026-08-18T00:00:00+00:00',
+            endAt: '2026-08-25T00:00:00+00:00',
+            environmentId: 1,
+            destinationCurrency: 'CUP',
+            amountFrom: 500.0,
+            amountTo: 500.0,
+            amountStep: 1.0,
+            priceFrom: 10.0,
+            priceTo: 10.0,
+            priceCurrency: 'USD',
+            benefits: $benefits,
+        );
+    }
+
+    private function scheduleViolations(?array $benefits): array
+    {
+        $violations = $this->validator->validate($this->dto($benefits));
+
+        $result = [];
+        foreach ($violations as $v) {
+            if (str_contains($v->getPropertyPath(), 'schedule')) {
+                $result[] = $v->getMessage();
+            }
+        }
+
+        return $result;
+    }
+
+    public function testNoBenefitsIsValid(): void
+    {
+        $this->assertSame([], $this->scheduleViolations(null));
+    }
+
+    public function testBenefitWithoutScheduleKeyIsValid(): void
+    {
+        $benefits = [['type' => 'DATA', 'unit' => 'ILIM', 'unit_type' => 'DATA']];
+        $this->assertSame([], $this->scheduleViolations($benefits));
+    }
+
+    public function testScheduleWithBothNullMeans24hAndIsValid(): void
+    {
+        $benefits = [['type' => 'DATA', 'unit' => 'ILIM', 'unit_type' => 'DATA', 'schedule' => ['start' => null, 'end' => null]]];
+        $this->assertSame([], $this->scheduleViolations($benefits));
+    }
+
+    public function testScheduleWithBothValidTimesIsValid(): void
+    {
+        $benefits = [['type' => 'DATA', 'unit' => 'ILIM', 'unit_type' => 'DATA', 'schedule' => ['start' => '01:00', 'end' => '06:00']]];
+        $this->assertSame([], $this->scheduleViolations($benefits));
+    }
+
+    public function testScheduleWithOnlyStartSetIsInvalid(): void
+    {
+        $benefits = [['type' => 'DATA', 'unit' => 'ILIM', 'unit_type' => 'DATA', 'schedule' => ['start' => '01:00', 'end' => null]]];
+        $this->assertNotEmpty($this->scheduleViolations($benefits));
+    }
+
+    public function testScheduleWithMalformedTimeIsInvalid(): void
+    {
+        $benefits = [['type' => 'DATA', 'unit' => 'ILIM', 'unit_type' => 'DATA', 'schedule' => ['start' => '1am', 'end' => '06:00']]];
+        $this->assertNotEmpty($this->scheduleViolations($benefits));
+    }
+
+    public function testScheduleWithOutOfRangeTimeIsInvalid(): void
+    {
+        $benefits = [['type' => 'DATA', 'unit' => 'ILIM', 'unit_type' => 'DATA', 'schedule' => ['start' => '25:00', 'end' => '06:00']]];
+        $this->assertNotEmpty($this->scheduleViolations($benefits));
+    }
+
+    public function testScheduleWithEqualStartAndEndIsInvalid(): void
+    {
+        $benefits = [['type' => 'DATA', 'unit' => 'ILIM', 'unit_type' => 'DATA', 'schedule' => ['start' => '01:00', 'end' => '01:00']]];
+        $this->assertNotEmpty($this->scheduleViolations($benefits));
+    }
+
+    public function testScheduleMissingEndKeyEntirelyIsInvalid(): void
+    {
+        $benefits = [['type' => 'DATA', 'unit' => 'ILIM', 'unit_type' => 'DATA', 'schedule' => ['start' => '01:00']]];
+        $this->assertNotEmpty($this->scheduleViolations($benefits));
+    }
+}


### PR DESCRIPTION
## Resumen

- Un beneficio `DATA`/`ILIM` en una promoción V2 puede necesitar acotar cuándo está vigente el "internet ilimitado" (ej. 01:00–06:00) en vez de las 24h por defecto.
- El campo `benefits[].schedule{start,end}` ya existía en el schema de salida (`CommunicationPackage`/`CommunicationClientPackage`) pero siempre viajaba `null`, sin lectura ni validación en ningún lado — era un placeholder sin implementar.
- `CreatePromotionV2Dto::validateBenefitsSchedule()` valida su forma: ambos extremos `null` (24h) o ambos presentes en `"HH:mm"` y distintos entre sí.
- Puramente informativo (decisión explícita — no bloquea despacho ni venta) y acotado a promociones V2. El resto del flujo (`CommunicationPromotionService::createV2()` → `CommunicationPackageAdminService::createBatch()`) ya pasaba `benefits` sin tocar, así que no requirió más cambios: `applyCreditBenefitDefaults()` solo muta beneficios `CREDITS`+`CURRENCY`, dejando `DATA`/`ILIM` (con su `schedule`) intacto.

## Test plan

- [x] `tests/DTO/CreatePromotionV2DtoTest.php` (nuevo — primer test de DTO del repo) — 9 casos cubriendo null/null válido, HH:mm válido, mitad ausente, formato inválido, fuera de rango, start==end, clave faltante
- [x] `php bin/phpunit --no-coverage` — 953 tests en verde (Docker)
- [x] `vendor/bin/phpstan analyse` — sin errores

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019akFNicpzpVzZSjSVqvGRs