### PR TITLE
feat(catalog): /communication/packages sirve V2 para cuentas marcadas V2

### DIFF
--- a/src/Entity/CommunicationPackage.php
+++ b/src/Entity/CommunicationPackage.php
@@ -29,13 +29,19 @@ use Symfony\Component\Serializer\Attribute\Groups;
  * paquetes distintos pueden compartir tupla a propósito (ej. "Recarga 500
  * CUP" y "Bono navideño 500 CUP").
  *
- * `#[ApiResource]` en URI PROPIA (V2 Fase 3) — no reemplaza todavía a
- * /communication/packages (V1, CommunicationClientPackage): ese switch por
- * cliente es una fase posterior, una vez verificado que la forma del JSON
- * es idéntica. CommunicationPackageCatalogProvider bypasea el provider
- * Doctrine estándar (PackageCatalogResolver ya decide el conjunto completo
- * de paquetes visibles, no solo su precio), así que CurrentUserExtension no
- * llega a intervenir en esta operación en absoluto.
+ * `#[ApiResource]` en URI PROPIA (V2 Fase 3): `/communication/packages/catalog`.
+ * CommunicationPackageCatalogProvider bypasea el provider Doctrine estándar
+ * (PackageCatalogResolver ya decide el conjunto completo de paquetes
+ * visibles, no solo su precio), así que CurrentUserExtension no llega a
+ * intervenir en esta operación en absoluto.
+ *
+ * Desde el switch por cliente (ver CatalogVersionResolver), esta misma
+ * entidad también se sirve bajo `/communication/packages` (la URI histórica
+ * de CommunicationClientPackage/V1) para las cuentas marcadas V2 —
+ * CommunicationClientPackageProvider/ItemProvider/UpcomingPackagesProvider
+ * delegan aquí cuando corresponde. El grupo `comPackage:read` se mantiene
+ * deliberadamente con el mismo shape que V1 (ver getPromotions() más abajo)
+ * para que ambas URLs devuelvan JSON compatible.
  */
 #[ORM\Entity(repositoryClass: CommunicationPackageRepository::class)]
 #[ORM\HasLifecycleCallbacks]
@@ -233,9 +239,13 @@ class CommunicationPackage
     private bool $isActive = true;
 
     #[ORM\Column]
+    #[Groups(['comPackage:read'])]
+    #[ApiProperty(types: 'https://scheme.org/DateTime')]
     private ?\DateTimeImmutable $activeStartAt = null;
 
     #[ORM\Column(nullable: true)]
+    #[Groups(['comPackage:read'])]
+    #[ApiProperty(types: 'https://scheme.org/DateTime')]
     private ?\DateTimeImmutable $activeEndAt = null;
 
     #[ORM\Column]
@@ -560,5 +570,45 @@ class CommunicationPackage
         $this->promotion = $promotion;
 
         return $this;
+    }
+
+    /**
+     * Paridad de shape con CommunicationClientPackage::getPromotions() — V1
+     * devuelve un array de 0 o 1 CommunicationPromotions
+     * ($promotions[] = getPromotionItems()->first()). En V2 la relación es
+     * un ManyToOne simple, así que el array se construye directo, sin
+     * filtro de ventana: un paquete de promoción solo está en el catálogo
+     * mientras su propia ventana lo esté (ver isActiveAt()/findActiveCatalog()),
+     * y en /upcoming la promoción futura es justamente lo que se quiere
+     * mostrar.
+     *
+     * @return list<CommunicationPromotions>
+     */
+    #[Groups(['comPackage:read'])]
+    public function getPromotions(): array
+    {
+        return $this->promotion !== null ? [$this->promotion] : [];
+    }
+
+    /**
+     * Vigente en el instante dado — mismo criterio que
+     * CommunicationContract::isActiveAt(), aplicado al PAQUETE (no a su
+     * contrato): PackageCatalogResolver::offersFromContracts() no filtra
+     * por esto hoy (paquetes de promociones futuras pueden colarse en el
+     * catálogo antes de tiempo si su contrato ya está vigente) — este
+     * método es lo que usan CommunicationPackageCatalogProvider y
+     * CatalogPackageVisibilityResolver para cerrar ese hueco, sin tocar la
+     * precedencia de PackageCatalogResolver.
+     */
+    public function isActiveAt(\DateTimeImmutable $now): bool
+    {
+        if (!$this->isActive) {
+            return false;
+        }
+        if ($this->activeStartAt !== null && $this->activeStartAt > $now) {
+            return false;
+        }
+
+        return $this->activeEndAt === null || $this->activeEndAt > $now;
     }
 }

--- a/src/Repository/CommunicationPackageRepository.php
+++ b/src/Repository/CommunicationPackageRepository.php
@@ -47,6 +47,32 @@ class CommunicationPackageRepository extends ServiceEntityRepository
     }
 
     /**
+     * Paquetes que entrarán en vigencia a futuro (típicamente tramos de una
+     * promoción V2 aún no arrancada) — alimenta
+     * /communication/packages/upcoming para cuentas V2
+     * (UpcomingPackageCatalogResolver). Complemento exacto de
+     * findActiveCatalog(): un paquete nunca puede salir en las dos a la vez.
+     * Sin filtro de tenant: el catálogo V2 es compartido.
+     *
+     * @return list<CommunicationPackage>
+     */
+    public function findUpcoming(?\DateTimeImmutable $now = null): array
+    {
+        $now ??= new \DateTimeImmutable();
+
+        return $this->createQueryBuilder('p')
+            ->andWhere('p.isActive = :active')
+            ->andWhere('p.activeStartAt > :now')
+            ->setParameter('active', true)
+            ->setParameter('now', $now)
+            ->orderBy('p.activeStartAt', 'ASC')
+            ->addOrderBy('p.displayOrder', 'ASC')
+            ->addOrderBy('p.id', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
      * Paquete cuyo destino coincide con la tupla dada, con tolerancia de
      * coma flotante (DestinationKey::EPSILON) — usado por
      * CommunicationContractService::createByRange() para resolver, monto a

--- a/src/Service/Catalog/CatalogPackageVisibilityResolver.php
+++ b/src/Service/Catalog/CatalogPackageVisibilityResolver.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Service\Catalog;
+
+use App\Entity\Account;
+use App\Entity\CommunicationPackage;
+use App\Repository\CommunicationPackageProviderProductRepository;
+use App\Service\Pricing\PackageCatalogResolver;
+use App\Service\Pricing\PackageOfferSourceEnum;
+
+/**
+ * Criterio de "¿este CommunicationPackage (V2) es visible para este tenant
+ * ahora mismo?" — extraído de CommunicationPackageCatalogItemProvider para
+ * poder reutilizarlo también desde CommunicationClientPackageItemProvider
+ * (V1) cuando CatalogVersionResolver::isV2() delega en el catálogo V2 sobre
+ * la URL histórica `/communication/packages/{id}`.
+ *
+ * Un paquete que existe pero no es visible para este tenant (fuera de su
+ * contrato), sin proveedor que lo cubra (UNAVAILABLE), fuera de su propia
+ * ventana activa, o sin ningún vínculo explícito paquete→producto
+ * (CommunicationPackageProviderProduct) se trata igual que "no
+ * encontrado" — mismo criterio que CommunicationPackageCatalogProvider
+ * aplica al listado, para no mostrar en el detalle algo que no aparece en
+ * la colección.
+ */
+class CatalogPackageVisibilityResolver
+{
+    public function __construct(
+        private readonly PackageCatalogResolver $catalogResolver,
+        private readonly CommunicationPackageProviderProductRepository $bindingRepo,
+    ) {
+    }
+
+    public function visibleFor(CommunicationPackage $package, Account $tenant, ?\DateTimeImmutable $now = null): ?CommunicationPackage
+    {
+        $now ??= new \DateTimeImmutable();
+
+        if (!$package->isActiveAt($now)) {
+            return null;
+        }
+
+        $offer = $this->catalogResolver->offerFor($package, $tenant, $now);
+        if ($offer === null || $offer->source === PackageOfferSourceEnum::UNAVAILABLE) {
+            return null;
+        }
+
+        if ($this->bindingRepo->findAllForPackage($package) === []) {
+            return null;
+        }
+
+        return $package;
+    }
+}

--- a/src/Service/Catalog/UpcomingPackageCatalogResolver.php
+++ b/src/Service/Catalog/UpcomingPackageCatalogResolver.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Service\Catalog;
+
+use App\Entity\Account;
+use App\Entity\CommunicationContract;
+use App\Entity\CommunicationPackage;
+use App\Repository\CommunicationContractRepository;
+use App\Repository\CommunicationPackageRepository;
+use App\Service\Pricing\PackageOfferSourceEnum;
+use App\Service\Pricing\ResolvedPackageOffer;
+
+/**
+ * `/communication/packages/upcoming` para cuentas V2 — paquetes que
+ * entrarán en vigencia a futuro (ver
+ * CommunicationPackageRepository::findUpcoming()), con un precio de
+ * preview inyectado.
+ *
+ * No se usa PackageCatalogResolver aquí a propósito: su precedencia exige
+ * contrato VIGENTE (isActiveAt(now)), y el contrato de una promoción futura
+ * no lo está todavía — nunca lo resolvería. Esto lee directamente
+ * CommunicationPackage::getContracts() en un servicio exclusivo del
+ * preview, sin tocar la precedencia de PackageCatalogResolver::catalogFor()/
+ * offerFor().
+ */
+class UpcomingPackageCatalogResolver
+{
+    public function __construct(
+        private readonly CommunicationPackageRepository $packageRepository,
+        private readonly CommunicationContractRepository $contractRepository,
+    ) {
+    }
+
+    /**
+     * @return list<CommunicationPackage>
+     */
+    public function upcomingFor(Account $tenant, ?\DateTimeImmutable $now = null): array
+    {
+        $now ??= new \DateTimeImmutable();
+
+        $ownActiveContracts = $this->contractRepository->findActiveForTenant($tenant, $now);
+
+        $packages = [];
+        foreach ($this->packageRepository->findUpcoming($now) as $package) {
+            // Fuga de prioridad de tenant: si la cuenta ya tiene contrato(s)
+            // propio(s) vigente(s) y ninguno cubre este paquete, cuando la
+            // promoción arranque su contrato "por defecto" NO le va a ganar
+            // al contrato propio (ver PackageCatalogResolver::catalogFor())
+            // — no tiene sentido mostrar un preview de algo que después no
+            // le va a aparecer.
+            if ($ownActiveContracts !== [] && !$this->coveredByAnyContract($package, $ownActiveContracts)) {
+                continue;
+            }
+
+            $contract = $this->previewContractFor($package, $tenant);
+            if ($contract === null) {
+                continue;
+            }
+
+            $package->setResolvedOffer(new ResolvedPackageOffer(
+                package: $package,
+                price: (float) $contract->getPrice(),
+                currency: (string) $contract->getCurrency(),
+                source: PackageOfferSourceEnum::PROMOTION,
+                contractId: $contract->getId(),
+                note: 'Preview: contrato aún no vigente (paquete futuro).',
+            ));
+
+            $packages[] = $package;
+        }
+
+        return $packages;
+    }
+
+    /**
+     * @param list<CommunicationContract> $contracts
+     */
+    private function coveredByAnyContract(CommunicationPackage $package, array $contracts): bool
+    {
+        foreach ($contracts as $contract) {
+            if ($contract->getPackages()->contains($package)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Contrato a mostrar como preview: preferir uno del propio tenant, si
+     * no hay, uno "por defecto" (tenant NULL); dentro de cada grupo, el de
+     * startAt más temprano. Desde la Fase 6 (ManyToMany) un paquete puede
+     * colgar de más de un contrato a la vez.
+     */
+    private function previewContractFor(CommunicationPackage $package, Account $tenant): ?CommunicationContract
+    {
+        $ownContract = null;
+        $defaultContract = null;
+
+        foreach ($package->getContracts() as $contract) {
+            $contractTenant = $contract->getTenant();
+            if ($contractTenant !== null && $contractTenant->getId() === $tenant->getId()) {
+                if ($ownContract === null || $contract->getStartAt() < $ownContract->getStartAt()) {
+                    $ownContract = $contract;
+                }
+            } elseif ($contractTenant === null) {
+                if ($defaultContract === null || $contract->getStartAt() < $defaultContract->getStartAt()) {
+                    $defaultContract = $contract;
+                }
+            }
+        }
+
+        return $ownContract ?? $defaultContract;
+    }
+}

--- a/src/State/CommunicationClientPackageItemProvider.php
+++ b/src/State/CommunicationClientPackageItemProvider.php
@@ -6,6 +6,9 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use App\Entity\Account;
 use App\Entity\CommunicationClientPackage;
+use App\Repository\CommunicationPackageRepository;
+use App\Service\Catalog\CatalogPackageVisibilityResolver;
+use App\Service\Catalog\CatalogVersionResolver;
 use App\Service\Pricing\PackageSalePriceResolver;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -17,6 +20,14 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
  * listado colección lo hacía a través de
  * CommunicationClientPackageProvider), así que un GET por id podía mostrar
  * un importe distinto al que veía el mismo cliente en el listado.
+ *
+ * Switch V2: para cuentas marcadas V2 (CatalogVersionResolver::isV2()), el
+ * id ya no pertenece al espacio de CommunicationClientPackage — no se puede
+ * delegar en el item provider Doctrine decorado (resolvería la clase
+ * equivocada, porque $operation sigue apuntando a CommunicationClientPackage),
+ * así que se busca el CommunicationPackage directamente por repositorio y
+ * se aplica el mismo criterio de visibilidad que /communication/packages/catalog/{id}
+ * (CatalogPackageVisibilityResolver).
  */
 class CommunicationClientPackageItemProvider implements ProviderInterface
 {
@@ -25,14 +36,28 @@ class CommunicationClientPackageItemProvider implements ProviderInterface
         private readonly ProviderInterface $itemProvider,
         private readonly Security $security,
         private readonly PackageSalePriceResolver $salePriceResolver,
+        private readonly CatalogVersionResolver $catalogVersion,
+        private readonly CommunicationPackageRepository $packageRepository,
+        private readonly CatalogPackageVisibilityResolver $visibility,
     ) {
     }
 
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
     {
+        $tenant = $this->security->getUser();
+
+        if ($tenant instanceof Account && $this->catalogVersion->isV2($tenant)) {
+            $id = $uriVariables['id'] ?? null;
+            if (!is_numeric($id)) {
+                return null;
+            }
+            $package = $this->packageRepository->find((int) $id);
+
+            return $package === null ? null : $this->visibility->visibleFor($package, $tenant);
+        }
+
         $package = $this->itemProvider->provide($operation, $uriVariables, $context);
 
-        $tenant = $this->security->getUser();
         if ($package instanceof CommunicationClientPackage && $tenant instanceof Account) {
             $package->setResolvedSalePrice($this->salePriceResolver->resolve($package, $tenant));
         }

--- a/src/State/CommunicationClientPackageProvider.php
+++ b/src/State/CommunicationClientPackageProvider.php
@@ -9,6 +9,7 @@ use App\Entity\CommunicationClientPackage;
 use App\Entity\CommunicationPricePackage;
 use App\Repository\CommunicationClientPackageRepository;
 use App\Repository\CommunicationPricePackageRepository;
+use App\Service\Catalog\CatalogVersionResolver;
 use App\Service\PackagePriceService;
 use App\Service\Pricing\PackageMaterializationService;
 use App\Service\Pricing\PackageSalePriceResolver;
@@ -18,6 +19,15 @@ use Psr\Log\LoggerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
+/**
+ * GET /communication/packages (colección) — legacy V1
+ * (CommunicationClientPackage) por defecto. Para cuentas marcadas V2
+ * (CatalogVersionResolver::isV2()) delega TODO en
+ * CommunicationPackageCatalogProvider (catálogo V2 compartido) al inicio de
+ * provide(), sin tocar nada de la materialización/resolución de precio V1
+ * que sigue abajo — la rama V1 queda intacta a propósito, para que sea
+ * testeable como regresión pura.
+ */
 class CommunicationClientPackageProvider implements ProviderInterface
 {
 
@@ -30,6 +40,12 @@ class CommunicationClientPackageProvider implements ProviderInterface
         private readonly PackageMaterializationService $materializationService,
         private readonly Security $security,
         private readonly PackageSalePriceResolver $salePriceResolver,
+        private readonly CatalogVersionResolver $catalogVersion,
+        // CommunicationPackageCatalogProvider es `final` — se inyecta por su
+        // interfaz (mockeable en tests) con el servicio explícito, mismo
+        // idioma que el resto de este constructor.
+        #[Autowire(service: CommunicationPackageCatalogProvider::class)]
+        private readonly ProviderInterface $catalogProvider,
         #[Autowire('@monolog.logger.provider')]
         private readonly LoggerInterface $providerLogger,
     )
@@ -38,6 +54,16 @@ class CommunicationClientPackageProvider implements ProviderInterface
 
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
     {
+        // Switch V2 (ver docblock de clase): para cuentas marcadas V2, esta
+        // misma URL sirve CommunicationPackage en vez de
+        // CommunicationClientPackage — se reutiliza CommunicationPackageCatalogProvider
+        // por delegación directa (su provide() ya es agnóstico de
+        // $operation/$uriVariables) sin tocar nada de lo que sigue.
+        $tenant = $this->security->getUser();
+        if ($tenant instanceof Account && $this->catalogVersion->isV2($tenant)) {
+            return $this->catalogProvider->provide($operation, $uriVariables, $context);
+        }
+
         $clientPackages = $this->itemProvider->provide($operation, $uriVariables, $context);
 
         if ($clientPackages instanceof \Countable && $clientPackages->count() === 0) {

--- a/src/State/CommunicationPackageCatalogItemProvider.php
+++ b/src/State/CommunicationPackageCatalogItemProvider.php
@@ -6,32 +6,24 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use App\Entity\Account;
 use App\Entity\CommunicationPackage;
-use App\Repository\CommunicationPackageProviderProductRepository;
-use App\Service\Pricing\PackageCatalogResolver;
-use App\Service\Pricing\PackageOfferSourceEnum;
+use App\Service\Catalog\CatalogPackageVisibilityResolver;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 /**
  * GET /communication/packages/catalog/{id} — análogo a
  * CommunicationClientPackageItemProvider (V1): decora el item provider
- * Doctrine por defecto y resuelve la oferta con PackageCatalogResolver, que
- * decide visibilidad además de precio. Un paquete que existe pero no es
- * visible para este tenant (fuera de su contrato), sin proveedor que lo
- * cubra (UNAVAILABLE), o sin ningún vínculo explícito paquete→producto
- * (CommunicationPackageProviderProduct) se trata igual que "no
- * encontrado" — mismo criterio de exclusión que
- * PackageCatalogResolver::catalogFor()/CommunicationPackageCatalogProvider
- * aplican al listado, para no mostrar en el detalle algo que no aparece en
- * la colección.
+ * Doctrine por defecto y delega el criterio de visibilidad en
+ * CatalogPackageVisibilityResolver (compartido con la delegación V1→V2 de
+ * `/communication/packages/{id}` para cuentas V2 — ver
+ * CommunicationClientPackageItemProvider).
  */
 final class CommunicationPackageCatalogItemProvider implements ProviderInterface
 {
     public function __construct(
         #[Autowire(service: 'api_platform.doctrine.orm.state.item_provider')]
         private readonly ProviderInterface $itemProvider,
-        private readonly PackageCatalogResolver $catalogResolver,
-        private readonly CommunicationPackageProviderProductRepository $bindingRepo,
+        private readonly CatalogPackageVisibilityResolver $visibility,
         private readonly Security $security,
     ) {
     }
@@ -48,15 +40,6 @@ final class CommunicationPackageCatalogItemProvider implements ProviderInterface
             return null;
         }
 
-        $offer = $this->catalogResolver->offerFor($package, $tenant);
-        if ($offer === null || $offer->source === PackageOfferSourceEnum::UNAVAILABLE) {
-            return null;
-        }
-
-        if ($this->bindingRepo->findAllForPackage($package) === []) {
-            return null;
-        }
-
-        return $package;
+        return $this->visibility->visibleFor($package, $tenant);
     }
 }

--- a/src/State/CommunicationPackageCatalogProvider.php
+++ b/src/State/CommunicationPackageCatalogProvider.php
@@ -26,6 +26,15 @@ use Symfony\Bundle\SecurityBundle\Security;
  * despachan de verdad. Este filtro es exclusivo de la vista móvil: el
  * dashboard (preview(), coverage()) sigue usando PackageCatalogResolver sin
  * este recorte, porque ahí el admin necesita ver el paquete PARA vincularlo.
+ *
+ * Tampoco se muestra un paquete fuera de su propia ventana activa
+ * (CommunicationPackage::isActiveAt()) — PackageCatalogResolver::
+ * offersFromContracts() no filtra por esto (solo mira si el CONTRATO está
+ * vigente, no el paquete), así que un paquete de promoción futura cuyo
+ * contrato ya esté vigente (ej. reutilizó el contrato "por defecto" del
+ * catálogo normal al mismo monto — ver upsertContract()) podía colarse aquí
+ * antes de tiempo. Ese mismo paquete SÍ debe aparecer en /upcoming
+ * (UpcomingPackageCatalogResolver), nunca en los dos a la vez.
  */
 final class CommunicationPackageCatalogProvider implements ProviderInterface
 {
@@ -46,9 +55,11 @@ final class CommunicationPackageCatalogProvider implements ProviderInterface
             return [];
         }
 
+        $now = new \DateTimeImmutable();
+
         $packages = array_map(
             static fn (ResolvedPackageOffer $offer): CommunicationPackage => $offer->package,
-            $this->catalogResolver->catalogFor($tenant),
+            $this->catalogResolver->catalogFor($tenant, $now),
         );
 
         $boundIds = $this->bindingRepo->findPackageIdsWithBindings(
@@ -57,7 +68,7 @@ final class CommunicationPackageCatalogProvider implements ProviderInterface
 
         return array_values(array_filter(
             $packages,
-            static fn (CommunicationPackage $p) => in_array($p->getId(), $boundIds, true)
+            static fn (CommunicationPackage $p) => in_array($p->getId(), $boundIds, true) && $p->isActiveAt($now)
         ));
     }
 }

--- a/src/State/UpcomingPackagesProvider.php
+++ b/src/State/UpcomingPackagesProvider.php
@@ -7,16 +7,26 @@ use ApiPlatform\State\ProviderInterface;
 use App\Entity\Account;
 use App\Entity\CommunicationClientPackage;
 use App\Entity\CommunicationPromotions;
+use App\Service\Catalog\CatalogVersionResolver;
+use App\Service\Catalog\UpcomingPackageCatalogResolver;
 use App\Service\Pricing\PackageSalePriceResolver;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 
+/**
+ * GET /communication/packages/upcoming — legacy V1 por defecto (paquetes de
+ * promociones legacy aún no arrancadas, vía CommunicationClientPackage::
+ * $promotionItems). Para cuentas marcadas V2 delega en
+ * UpcomingPackageCatalogResolver (paquetes V2 con activeStartAt futuro).
+ */
 class UpcomingPackagesProvider implements ProviderInterface
 {
     public function __construct(
         private readonly EntityManagerInterface $em,
         private readonly Security $security,
         private readonly PackageSalePriceResolver $salePriceResolver,
+        private readonly CatalogVersionResolver $catalogVersion,
+        private readonly UpcomingPackageCatalogResolver $upcomingResolver,
     ) {}
 
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
@@ -24,6 +34,10 @@ class UpcomingPackagesProvider implements ProviderInterface
         $user = $this->security->getUser();
         if (!$user instanceof Account) {
             return [];
+        }
+
+        if ($this->catalogVersion->isV2($user)) {
+            return $this->upcomingResolver->upcomingFor($user);
         }
 
         $now = new \DateTimeImmutable();

--- a/tests/Entity/CommunicationPackageShapeParityTest.php
+++ b/tests/Entity/CommunicationPackageShapeParityTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace App\Tests\Entity;
+
+use App\Entity\CommunicationClientPackage;
+use App\Entity\CommunicationPackage;
+use App\Entity\CommunicationPromotions;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Attribute\Groups;
+
+/**
+ * Guard de regresión: `/communication/packages` sirve V1
+ * (CommunicationClientPackage) o V2 (CommunicationPackage) según
+ * CatalogVersionResolver::isV2() — ambas clases deben publicar el mismo
+ * juego de claves en el grupo 'comPackage:read' para que la app móvil no
+ * vea un shape distinto al cambiar de versión. Si este test falla tras
+ * agregar un campo a una sola de las dos clases, hay que decidir a
+ * propósito si el otro catálogo también lo necesita (o documentar por qué
+ * no).
+ *
+ * @covers \App\Entity\CommunicationPackage
+ */
+class CommunicationPackageShapeParityTest extends TestCase
+{
+    /**
+     * @return list<string> nombres de campo tal como los vería el cliente
+     *   (propiedades tal cual, getX()/isX() normalizados a x)
+     */
+    private function comPackageReadKeys(string $class): array
+    {
+        $reflection = new \ReflectionClass($class);
+        $keys = [];
+
+        foreach ($reflection->getProperties() as $property) {
+            if ($this->hasGroup($property->getAttributes(Groups::class), 'comPackage:read')) {
+                $keys[] = $property->getName();
+            }
+        }
+
+        foreach ($reflection->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
+            if (!$this->hasGroup($method->getAttributes(Groups::class), 'comPackage:read')) {
+                continue;
+            }
+            $name = $method->getName();
+            if (preg_match('/^(get|is)([A-Z].*)$/', $name, $m)) {
+                $keys[] = lcfirst($m[2]);
+            } else {
+                $keys[] = $name;
+            }
+        }
+
+        sort($keys);
+
+        return array_values(array_unique($keys));
+    }
+
+    /**
+     * @param array<\ReflectionAttribute> $attributes
+     */
+    private function hasGroup(array $attributes, string $group): bool
+    {
+        foreach ($attributes as $attribute) {
+            /** @var Groups $groups */
+            $groups = $attribute->newInstance();
+            if (in_array($group, $groups->groups, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function testV2CoversEveryKeyThatV1Exposes(): void
+    {
+        $v1Keys = $this->comPackageReadKeys(CommunicationClientPackage::class);
+        $v2Keys = $this->comPackageReadKeys(CommunicationPackage::class);
+
+        $missingInV2 = array_values(array_diff($v1Keys, $v2Keys));
+
+        $this->assertSame(
+            [],
+            $missingInV2,
+            'CommunicationPackage (V2) no expone estas claves que sí expone CommunicationClientPackage (V1) en comPackage:read: ' . implode(', ', $missingInV2)
+        );
+    }
+
+    public function testGetPromotionsReturnsEmptyArrayWhenNoPromotion(): void
+    {
+        $package = (new CommunicationPackage())
+            ->setName('P')->setDescription('P')
+            ->setDestinationAmount(500.0)->setDestinationCurrency('CUP');
+
+        $this->assertSame([], $package->getPromotions());
+    }
+
+    public function testGetPromotionsReturnsSingleElementArrayWhenPromotionSet(): void
+    {
+        $promotion = $this->createMock(CommunicationPromotions::class);
+        $package = (new CommunicationPackage())
+            ->setName('P')->setDescription('P')
+            ->setDestinationAmount(500.0)->setDestinationCurrency('CUP')
+            ->setPromotion($promotion);
+
+        $this->assertSame([$promotion], $package->getPromotions());
+    }
+
+    public function testIsActiveAtWithinOpenEndedWindow(): void
+    {
+        $now = new \DateTimeImmutable('2026-08-18 12:00:00');
+        $package = (new CommunicationPackage())
+            ->setName('P')->setDescription('P')
+            ->setDestinationAmount(500.0)->setDestinationCurrency('CUP')
+            ->setActiveStartAt($now->modify('-1 day'));
+
+        $this->assertTrue($package->isActiveAt($now));
+    }
+
+    public function testIsActiveAtFalseBeforeStart(): void
+    {
+        $now = new \DateTimeImmutable('2026-08-18 12:00:00');
+        $package = (new CommunicationPackage())
+            ->setName('P')->setDescription('P')
+            ->setDestinationAmount(500.0)->setDestinationCurrency('CUP')
+            ->setActiveStartAt($now->modify('+1 day'));
+
+        $this->assertFalse($package->isActiveAt($now));
+    }
+
+    public function testIsActiveAtFalseAfterEnd(): void
+    {
+        $now = new \DateTimeImmutable('2026-08-18 12:00:00');
+        $package = (new CommunicationPackage())
+            ->setName('P')->setDescription('P')
+            ->setDestinationAmount(500.0)->setDestinationCurrency('CUP')
+            ->setActiveStartAt($now->modify('-2 days'))
+            ->setActiveEndAt($now->modify('-1 day'));
+
+        $this->assertFalse($package->isActiveAt($now));
+    }
+
+    public function testIsActiveAtFalseWhenNotActive(): void
+    {
+        $now = new \DateTimeImmutable('2026-08-18 12:00:00');
+        $package = (new CommunicationPackage())
+            ->setName('P')->setDescription('P')
+            ->setDestinationAmount(500.0)->setDestinationCurrency('CUP')
+            ->setActiveStartAt($now->modify('-1 day'))
+            ->setIsActive(false);
+
+        $this->assertFalse($package->isActiveAt($now));
+    }
+}

--- a/tests/Functional/Pricing/CommunicationPackageRepositoryTest.php
+++ b/tests/Functional/Pricing/CommunicationPackageRepositoryTest.php
@@ -109,4 +109,50 @@ class CommunicationPackageRepositoryTest extends FunctionalTestCase
             array_map(static fn (CommunicationPackage $p) => $p->getId(), $result),
         );
     }
+
+    public function testFindUpcomingExcludesInactivePackages(): void
+    {
+        $now = new \DateTimeImmutable();
+        $this->package(isActive: false, activeStartAt: $now->modify('+1 day'));
+        $this->em->flush();
+
+        $this->assertSame([], $this->repository()->findUpcoming($now));
+    }
+
+    public function testFindUpcomingExcludesPackagesAlreadyActive(): void
+    {
+        $now = new \DateTimeImmutable();
+        $this->package(activeStartAt: $now->modify('-1 day'));
+        $this->em->flush();
+
+        $this->assertSame([], $this->repository()->findUpcoming($now));
+    }
+
+    public function testFindUpcomingIncludesFuturePackages(): void
+    {
+        $now = new \DateTimeImmutable();
+        $future = $this->package(activeStartAt: $now->modify('+1 day'));
+        $this->em->flush();
+
+        $result = $this->repository()->findUpcoming($now);
+
+        $this->assertCount(1, $result);
+        $this->assertSame($future->getId(), $result[0]->getId());
+    }
+
+    public function testFindUpcomingOrdersByActiveStartAtThenDisplayOrderThenId(): void
+    {
+        $now = new \DateTimeImmutable();
+        $later = $this->package(activeStartAt: $now->modify('+3 days'));
+        $second = $this->package(activeStartAt: $now->modify('+1 day'), displayOrder: 10);
+        $first = $this->package(activeStartAt: $now->modify('+1 day'), displayOrder: 0);
+        $this->em->flush();
+
+        $result = $this->repository()->findUpcoming($now);
+
+        $this->assertSame(
+            [$first->getId(), $second->getId(), $later->getId()],
+            array_map(static fn (CommunicationPackage $p) => $p->getId(), $result),
+        );
+    }
 }

--- a/tests/Functional/Provider/CommunicationPackagesV2SwitchFunctionalTest.php
+++ b/tests/Functional/Provider/CommunicationPackagesV2SwitchFunctionalTest.php
@@ -1,0 +1,369 @@
+<?php
+
+namespace App\Tests\Functional\Provider;
+
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use App\Entity\Account;
+use App\Entity\CommunicationClientPackage;
+use App\Entity\CommunicationContract;
+use App\Entity\CommunicationPackage;
+use App\Entity\CommunicationPackageProviderProduct;
+use App\Entity\CommunicationProduct;
+use App\Entity\Environment;
+use App\Entity\SysConfig;
+use App\Repository\SysConfigRepository;
+use App\Service\Catalog\CatalogVersionResolver;
+use App\State\CommunicationClientPackageItemProvider;
+use App\State\CommunicationClientPackageProvider;
+use App\State\UpcomingPackagesProvider;
+
+/**
+ * @covers \App\State\CommunicationClientPackageProvider
+ * @covers \App\State\CommunicationClientPackageItemProvider
+ * @covers \App\State\UpcomingPackagesProvider
+ *
+ * Verificación end-to-end del switch V1/V2 de `/communication/packages`
+ * contra Postgres real — el mock no puede validar que
+ * CatalogVersionResolver realmente lee sys_config, ni que el shape
+ * serializado real de ambas entidades coincide.
+ */
+class CommunicationPackagesV2SwitchFunctionalTest extends ProviderFunctionalTestCase
+{
+    private static int $counter = 0;
+
+    /**
+     * El caché de sys_config (SysConfigRepository) NO está atado a la
+     * transacción de BD que FunctionalTestCase revierte en tearDown() — es
+     * un pool aparte que sobrevive entre tests dentro del mismo proceso de
+     * PHPUnit. Sin esto, un valor cacheado durante este test (ej.
+     * communications.catalog.version.default = 'v2') podía quedar vigente
+     * para OTRO test que corre después en la misma suite, aunque la fila de
+     * sys_config ya se haya revertido — así se detectó
+     * CommunicationSaleServiceProviderGuardFunctionalTest fallando solo en
+     * la suite completa, nunca en aislamiento.
+     */
+    protected function tearDown(): void
+    {
+        // Antes de que parent::tearDown() haga rollback y potencialmente
+        // apague el kernel — self::getContainer() debe llamarse mientras
+        // el kernel siga arriba.
+        self::getContainer()->get(SysConfigRepository::class)->invalidateCache();
+        parent::tearDown();
+    }
+
+    private function sysConfigRepo(): SysConfigRepository
+    {
+        return self::getContainer()->get(SysConfigRepository::class);
+    }
+
+    private function setCatalogVersionDefault(string $version): void
+    {
+        $config = (new SysConfig())
+            ->setPropertyName(CatalogVersionResolver::DEFAULT_VERSION_KEY)
+            ->setPropertyValue($version)
+            ->setIsActive(true);
+        $this->em->persist($config);
+        $this->em->flush();
+        $this->sysConfigRepo()->invalidateCache();
+    }
+
+    private function setCatalogVersionV2Clients(string $csv): void
+    {
+        $config = (new SysConfig())
+            ->setPropertyName(CatalogVersionResolver::V2_CLIENTS_KEY)
+            ->setPropertyValue($csv)
+            ->setIsActive(true);
+        $this->em->persist($config);
+        $this->em->flush();
+        $this->sysConfigRepo()->invalidateCache();
+    }
+
+    private function v2Package(
+        ?\DateTimeImmutable $activeStartAt = null,
+        ?\DateTimeImmutable $activeEndAt = null,
+        bool $isActive = true,
+    ): CommunicationPackage {
+        self::$counter++;
+
+        $package = (new CommunicationPackage())
+            ->setName("Paquete V2 {$this::$counter}")
+            ->setDescription("Paquete V2 {$this::$counter}")
+            ->setDestinationAmount(500.0)
+            ->setDestinationCurrency('CUP')
+            ->setIsActive($isActive);
+
+        if ($activeStartAt !== null) {
+            $package->setActiveStartAt($activeStartAt);
+        }
+        if ($activeEndAt !== null) {
+            $package->setActiveEndAt($activeEndAt);
+        }
+
+        $this->em->persist($package);
+
+        return $package;
+    }
+
+    private function defaultContractFor(CommunicationPackage $package, float $price = 15.0, ?\DateTimeImmutable $startAt = null): CommunicationContract
+    {
+        $contract = (new CommunicationContract())
+            ->addPackage($package)
+            ->setDestinationAmount((float) $package->getDestinationAmount())
+            ->setDestinationCurrency((string) $package->getDestinationCurrency())
+            ->setPrice($price)
+            ->setCurrency('USD');
+        if ($startAt !== null) {
+            $contract->setStartAt($startAt);
+        }
+        $this->em->persist($contract);
+
+        return $contract;
+    }
+
+    private function bindProvider(CommunicationPackage $package, Environment $environment, string $provider = 'CSQ'): void
+    {
+        self::$counter++;
+
+        $product = (new CommunicationProduct())
+            ->setEnvironment($environment)
+            ->setPackageId(200000 + self::$counter)
+            ->setPackageType('RECHARGE')
+            ->setPrice(10.0)
+            ->setEnabled(true)
+            ->setDescription("Producto V2 funcional {$this::$counter}")
+            ->setProvider($provider)
+            ->setExternalRef((string) (200000 + self::$counter));
+        $this->em->persist($product);
+
+        $binding = (new CommunicationPackageProviderProduct())
+            ->setCommunicationPackage($package)
+            ->setProvider($provider)
+            ->setProduct($product);
+        $this->em->persist($binding);
+    }
+
+    private function v1PackageProvider(): CommunicationClientPackageProvider
+    {
+        return self::getContainer()->get(CommunicationClientPackageProvider::class);
+    }
+
+    private function v1ItemProvider(): CommunicationClientPackageItemProvider
+    {
+        return self::getContainer()->get(CommunicationClientPackageItemProvider::class);
+    }
+
+    private function upcomingProvider(): UpcomingPackagesProvider
+    {
+        return self::getContainer()->get(UpcomingPackagesProvider::class);
+    }
+
+    // ---- 1. default v1 → sigue viendo CommunicationClientPackage (regresión) ----
+
+    public function testDefaultV1ServesLegacyClientPackages(): void
+    {
+        $this->setCatalogVersionDefault('v1');
+
+        $client = $this->createClient();
+        $environment = $this->createEnvironment();
+        $account = $this->createAccount($client, $environment);
+        $this->createSellablePackage($environment, $account, 'CSQ');
+        $this->authenticateAs($account);
+
+        $result = $this->v1PackageProvider()->provide(new GetCollection(class: CommunicationClientPackage::class));
+
+        $this->assertNotEmpty(iterator_to_array($result));
+        foreach ($result as $item) {
+            $this->assertInstanceOf(CommunicationClientPackage::class, $item);
+        }
+    }
+
+    // ---- 2. default v2 → CommunicationPackage con precio del contrato ----
+
+    public function testDefaultV2ServesV2PackagesWithContractPrice(): void
+    {
+        $this->setCatalogVersionDefault('v2');
+
+        $client = $this->createClient();
+        $environment = $this->createEnvironment();
+        $account = $this->createAccount($client, $environment);
+        $this->authenticateAs($account);
+
+        $package = $this->v2Package(activeStartAt: new \DateTimeImmutable('-1 day'));
+        $this->defaultContractFor($package, 15.0);
+        $this->bindProvider($package, $environment);
+        $this->em->flush();
+
+        $result = $this->v1PackageProvider()->provide(new GetCollection(class: CommunicationClientPackage::class));
+
+        $this->assertCount(1, $result);
+        $this->assertInstanceOf(CommunicationPackage::class, $result[0]);
+        $this->assertSame($package->getId(), $result[0]->getId());
+        $this->assertSame(15.0, $result[0]->getAmount());
+    }
+
+    // ---- 3. cliente en v2.clients con default v1 → V2 (precedencia del resolver) ----
+
+    public function testClientInV2ClientsListOverridesTheGlobalDefault(): void
+    {
+        $this->setCatalogVersionDefault('v1');
+
+        $client = $this->createClient();
+        $environment = $this->createEnvironment();
+        $account = $this->createAccount($client, $environment);
+        $this->authenticateAs($account);
+        $this->setCatalogVersionV2Clients((string) $client->getId());
+
+        $package = $this->v2Package(activeStartAt: new \DateTimeImmutable('-1 day'));
+        $this->defaultContractFor($package, 20.0);
+        $this->bindProvider($package, $environment);
+        $this->em->flush();
+
+        $result = $this->v1PackageProvider()->provide(new GetCollection(class: CommunicationClientPackage::class));
+
+        $this->assertCount(1, $result);
+        $this->assertInstanceOf(CommunicationPackage::class, $result[0]);
+    }
+
+    // ---- 4. /upcoming ----
+
+    public function testUpcomingReturnsFuturePackageWithContractPricePreview(): void
+    {
+        $this->setCatalogVersionDefault('v2');
+
+        $client = $this->createClient();
+        $environment = $this->createEnvironment();
+        $account = $this->createAccount($client, $environment);
+        $this->authenticateAs($account);
+
+        $now = new \DateTimeImmutable();
+        $future = $this->v2Package(activeStartAt: $now->modify('+1 day'));
+        $this->defaultContractFor($future, 12.0, $now->modify('+1 day'));
+        $this->em->flush();
+        $this->em->clear();
+
+        $this->authenticateAs($this->em->getRepository(Account::class)->find($account->getId()));
+
+        $result = $this->upcomingProvider()->provide(new GetCollection(class: CommunicationPackage::class));
+
+        $this->assertCount(1, $result);
+        $this->assertSame(12.0, $result[0]->getAmount());
+    }
+
+    public function testUpcomingOmitsPackageWhenTenantHasOwnActiveContractThatDoesNotCoverIt(): void
+    {
+        $this->setCatalogVersionDefault('v2');
+
+        $client = $this->createClient();
+        $environment = $this->createEnvironment();
+        $account = $this->createAccount($client, $environment);
+
+        $now = new \DateTimeImmutable();
+        $otherPackage = $this->v2Package(activeStartAt: $now->modify('-1 day'));
+        $ownContract = $this->defaultContractFor($otherPackage, 5.0, $now->modify('-1 day'));
+        $ownContract->setTenant($account);
+
+        $future = $this->v2Package(activeStartAt: $now->modify('+1 day'));
+        $this->defaultContractFor($future, 12.0, $now->modify('+1 day'));
+        $this->em->flush();
+        $this->em->clear();
+
+        $account = $this->em->getRepository(Account::class)->find($account->getId());
+        $this->authenticateAs($account);
+
+        $result = $this->upcomingProvider()->provide(new GetCollection(class: CommunicationPackage::class));
+
+        $this->assertSame([], $result);
+    }
+
+    // ---- 5. {id} V2 ----
+
+    public function testItemV2ReturnsTheVisiblePackageById(): void
+    {
+        $this->setCatalogVersionDefault('v2');
+
+        $client = $this->createClient();
+        $environment = $this->createEnvironment();
+        $account = $this->createAccount($client, $environment);
+        $this->authenticateAs($account);
+
+        $package = $this->v2Package(activeStartAt: new \DateTimeImmutable('-1 day'));
+        $this->defaultContractFor($package, 18.0);
+        $this->bindProvider($package, $environment);
+        $this->em->flush();
+
+        $result = $this->v1ItemProvider()->provide(new Get(class: CommunicationClientPackage::class), ['id' => (string) $package->getId()]);
+
+        $this->assertInstanceOf(CommunicationPackage::class, $result);
+        $this->assertSame($package->getId(), $result->getId());
+    }
+
+    public function testItemV2ReturnsNullForAnIdThatBelongsToTheLegacyPackageSpace(): void
+    {
+        $this->setCatalogVersionDefault('v2');
+
+        $client = $this->createClient();
+        $environment = $this->createEnvironment();
+        $account = $this->createAccount($client, $environment);
+        $this->authenticateAs($account);
+
+        $v1Package = $this->createSellablePackage($environment, $account, 'CSQ');
+
+        $result = $this->v1ItemProvider()->provide(new Get(class: CommunicationClientPackage::class), ['id' => (string) $v1Package->getId()]);
+
+        $this->assertNull($result);
+    }
+
+    // ---- 6. ventana activa (bug 0.3) ----
+
+    public function testListingExcludesAPackageOutsideItsOwnActiveWindow(): void
+    {
+        $this->setCatalogVersionDefault('v2');
+
+        $client = $this->createClient();
+        $environment = $this->createEnvironment();
+        $account = $this->createAccount($client, $environment);
+        $this->authenticateAs($account);
+
+        $now = new \DateTimeImmutable();
+        $active = $this->v2Package(activeStartAt: $now->modify('-1 day'));
+        $sharedContract = $this->defaultContractFor($active, 10.0);
+        $this->bindProvider($active, $environment);
+
+        // Reutiliza el MISMO contrato default (misma tupla) para un paquete
+        // de promoción futura — reproduce el bug 0.3: el contrato ya está
+        // vigente aunque el paquete no lo esté.
+        $future = $this->v2Package(activeStartAt: $now->modify('+1 day'));
+        $sharedContract->addPackage($future);
+        $this->bindProvider($future, $environment);
+        $this->em->flush();
+
+        $result = $this->v1PackageProvider()->provide(new GetCollection(class: CommunicationClientPackage::class));
+
+        $ids = array_map(static fn (CommunicationPackage $p) => $p->getId(), iterator_to_array($result));
+        $this->assertContains($active->getId(), $ids);
+        $this->assertNotContains($future->getId(), $ids);
+    }
+
+    // ---- Shape autoritativo: serializer real ----
+
+    public function testRealSerializerProducesTheSameKeysForBothCatalogVersions(): void
+    {
+        $serializer = self::getContainer()->get('api_platform.serializer');
+
+        $v1 = (new CommunicationClientPackage())
+            ->setTenant($this->createAccount($this->createClient(), $this->createEnvironment()))
+            ->setName('P')->setDescription('P')->setAmount(1.0)->setCurrency('USD')
+            ->setActiveEndAt(new \DateTimeImmutable('+1 year'));
+        $this->em->persist($v1);
+
+        $v2 = $this->v2Package(activeStartAt: new \DateTimeImmutable('-1 day'));
+        $this->em->flush();
+
+        $v1Data = $serializer->normalize($v1, 'json', ['groups' => ['comPackage:read']]);
+        $v2Data = $serializer->normalize($v2, 'json', ['groups' => ['comPackage:read']]);
+
+        $missingInV2 = array_diff(array_keys($v1Data), array_keys($v2Data));
+        $this->assertSame([], $missingInV2, 'El serializer real confirma que V2 cubre todas las claves de V1: ' . implode(', ', $missingInV2));
+    }
+}

--- a/tests/Service/Catalog/CatalogPackageVisibilityResolverTest.php
+++ b/tests/Service/Catalog/CatalogPackageVisibilityResolverTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Tests\Service\Catalog;
+
+use App\Entity\Account;
+use App\Entity\CommunicationPackage;
+use App\Entity\CommunicationPackageProviderProduct;
+use App\Repository\CommunicationPackageProviderProductRepository;
+use App\Service\Catalog\CatalogPackageVisibilityResolver;
+use App\Service\Pricing\PackageCatalogResolver;
+use App\Service\Pricing\PackageOfferSourceEnum;
+use App\Service\Pricing\ResolvedPackageOffer;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \App\Service\Catalog\CatalogPackageVisibilityResolver
+ */
+class CatalogPackageVisibilityResolverTest extends TestCase
+{
+    private PackageCatalogResolver&MockObject $catalogResolver;
+    private CommunicationPackageProviderProductRepository&MockObject $bindingRepo;
+    private CatalogPackageVisibilityResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->catalogResolver = $this->createMock(PackageCatalogResolver::class);
+        $this->bindingRepo = $this->createMock(CommunicationPackageProviderProductRepository::class);
+        $this->bindingRepo->method('findAllForPackage')->willReturn([$this->createMock(CommunicationPackageProviderProduct::class)]);
+
+        $this->resolver = new CatalogPackageVisibilityResolver($this->catalogResolver, $this->bindingRepo);
+    }
+
+    private function package(): CommunicationPackage
+    {
+        return (new CommunicationPackage())->setName('P')->setDescription('P')->setDestinationAmount(500.0)->setDestinationCurrency('CUP');
+    }
+
+    public function testReturnsNullWhenPackageIsNotVisibleForTenant(): void
+    {
+        $package = $this->package();
+        $account = $this->createMock(Account::class);
+
+        $this->catalogResolver->expects($this->once())
+            ->method('offerFor')
+            ->with($package, $account)
+            ->willReturn(null);
+
+        $this->assertNull($this->resolver->visibleFor($package, $account));
+    }
+
+    public function testReturnsNullWhenOfferIsUnavailable(): void
+    {
+        $package = $this->package();
+        $account = $this->createMock(Account::class);
+
+        $this->catalogResolver->method('offerFor')->willReturn(
+            new ResolvedPackageOffer($package, 0.0, 'USD', PackageOfferSourceEnum::UNAVAILABLE)
+        );
+
+        $this->assertNull($this->resolver->visibleFor($package, $account));
+    }
+
+    public function testReturnsNullWhenPackageHasNoExplicitBinding(): void
+    {
+        $package = $this->package();
+        $account = $this->createMock(Account::class);
+
+        $this->catalogResolver->method('offerFor')->willReturn(
+            new ResolvedPackageOffer($package, 25.69, 'USD', PackageOfferSourceEnum::PRODUCT_MAX)
+        );
+        $this->bindingRepo = $this->createMock(CommunicationPackageProviderProductRepository::class);
+        $this->bindingRepo->method('findAllForPackage')->willReturn([]);
+        $this->resolver = new CatalogPackageVisibilityResolver($this->catalogResolver, $this->bindingRepo);
+
+        $this->assertNull($this->resolver->visibleFor($package, $account));
+    }
+
+    public function testReturnsNullWhenPackageIsOutsideItsOwnActiveWindow(): void
+    {
+        $now = new \DateTimeImmutable();
+        $package = $this->package()->setActiveStartAt($now->modify('+1 day'));
+        $account = $this->createMock(Account::class);
+
+        $this->catalogResolver->expects($this->never())->method('offerFor');
+
+        $this->assertNull($this->resolver->visibleFor($package, $account, $now));
+    }
+
+    public function testReturnsThePackageWhenOfferIsResolvedAndWithinWindow(): void
+    {
+        $package = $this->package();
+        $account = $this->createMock(Account::class);
+
+        $this->catalogResolver->method('offerFor')->willReturn(
+            new ResolvedPackageOffer($package, 25.69, 'USD', PackageOfferSourceEnum::PRODUCT_MAX)
+        );
+
+        $this->assertSame($package, $this->resolver->visibleFor($package, $account));
+    }
+}

--- a/tests/Service/Catalog/UpcomingPackageCatalogResolverTest.php
+++ b/tests/Service/Catalog/UpcomingPackageCatalogResolverTest.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace App\Tests\Service\Catalog;
+
+use App\Entity\Account;
+use App\Entity\CommunicationContract;
+use App\Entity\CommunicationPackage;
+use App\Repository\CommunicationContractRepository;
+use App\Repository\CommunicationPackageRepository;
+use App\Service\Catalog\UpcomingPackageCatalogResolver;
+use App\Service\Pricing\PackageOfferSourceEnum;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \App\Service\Catalog\UpcomingPackageCatalogResolver
+ */
+class UpcomingPackageCatalogResolverTest extends TestCase
+{
+    private CommunicationPackageRepository&MockObject $packageRepository;
+    private CommunicationContractRepository&MockObject $contractRepository;
+    private UpcomingPackageCatalogResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->packageRepository = $this->createMock(CommunicationPackageRepository::class);
+        $this->contractRepository = $this->createMock(CommunicationContractRepository::class);
+
+        $this->resolver = new UpcomingPackageCatalogResolver($this->packageRepository, $this->contractRepository);
+    }
+
+    private function assignId(object $entity, int $id): void
+    {
+        $property = new \ReflectionProperty($entity, 'id');
+        $property->setAccessible(true);
+        $property->setValue($entity, $id);
+    }
+
+    private function package(int $id): CommunicationPackage
+    {
+        $package = (new CommunicationPackage())
+            ->setName("Promo {$id}")->setDescription("Promo {$id}")
+            ->setDestinationAmount(500.0)->setDestinationCurrency('CUP');
+        $this->assignId($package, $id);
+
+        return $package;
+    }
+
+    private function contract(?Account $tenant, float $price, \DateTimeImmutable $startAt, string $currency = 'USD'): CommunicationContract
+    {
+        $contract = (new CommunicationContract())
+            ->setTenant($tenant)
+            ->setDestinationAmount(500.0)->setDestinationCurrency('CUP')
+            ->setPrice($price)->setCurrency($currency)
+            ->setStartAt($startAt);
+        $this->assignId($contract, random_int(1000, 999999));
+
+        return $contract;
+    }
+
+    /**
+     * $contract->addPackage($package) solo actualiza el lado propietario
+     * (CommunicationContract::$packages) — el lado inverso
+     * (CommunicationPackage::$contracts, mappedBy) solo lo resuelve Doctrine
+     * vía SQL al hidratar desde una consulta real. En un test unitario sin
+     * EntityManager hay que sincronizarlo a mano (mismo patrón que
+     * CommunicationPackageAdminServiceTest::addContractTo() en la Fase 6).
+     */
+    private function linkContractToPackage(CommunicationContract $contract, CommunicationPackage $package): void
+    {
+        $contract->addPackage($package);
+
+        $property = new \ReflectionProperty($package, 'contracts');
+        $property->setAccessible(true);
+        $property->getValue($package)->add($contract);
+    }
+
+    public function testReturnsEmptyArrayWhenNoUpcomingPackages(): void
+    {
+        $tenant = $this->createMock(Account::class);
+        $this->packageRepository->method('findUpcoming')->willReturn([]);
+        $this->contractRepository->method('findActiveForTenant')->willReturn([]);
+
+        $this->assertSame([], $this->resolver->upcomingFor($tenant));
+    }
+
+    public function testSkipsPackagesWithoutAnyContract(): void
+    {
+        $tenant = $this->createMock(Account::class);
+        $tenant->method('getId')->willReturn(1);
+        $package = $this->package(1);
+
+        $this->packageRepository->method('findUpcoming')->willReturn([$package]);
+        $this->contractRepository->method('findActiveForTenant')->willReturn([]);
+
+        $this->assertSame([], $this->resolver->upcomingFor($tenant));
+    }
+
+    public function testPrefersTheTenantsOwnContractOverTheDefaultOne(): void
+    {
+        $tenant = $this->createMock(Account::class);
+        $tenant->method('getId')->willReturn(1);
+        $package = $this->package(1);
+
+        $now = new \DateTimeImmutable();
+        $default = $this->contract(null, 10.0, $now->modify('+1 day'));
+        $own = $this->contract($tenant, 8.0, $now->modify('+1 day'));
+        $this->linkContractToPackage($default, $package);
+        $this->linkContractToPackage($own, $package);
+
+        $this->packageRepository->method('findUpcoming')->willReturn([$package]);
+        $this->contractRepository->method('findActiveForTenant')->willReturn([]);
+
+        $result = $this->resolver->upcomingFor($tenant);
+
+        $this->assertCount(1, $result);
+        $this->assertSame(8.0, $result[0]->getAmount());
+        $this->assertSame(PackageOfferSourceEnum::PROMOTION, $result[0]->getResolvedOffer()?->source);
+        $this->assertSame($own->getId(), $result[0]->getResolvedOffer()?->contractId);
+    }
+
+    public function testUsesTheDefaultContractWhenTenantHasNoneOfItsOwn(): void
+    {
+        $tenant = $this->createMock(Account::class);
+        $tenant->method('getId')->willReturn(1);
+        $package = $this->package(1);
+
+        $now = new \DateTimeImmutable();
+        $default = $this->contract(null, 12.0, $now->modify('+1 day'));
+        $this->linkContractToPackage($default, $package);
+
+        $this->packageRepository->method('findUpcoming')->willReturn([$package]);
+        $this->contractRepository->method('findActiveForTenant')->willReturn([]);
+
+        $result = $this->resolver->upcomingFor($tenant);
+
+        $this->assertCount(1, $result);
+        $this->assertSame(12.0, $result[0]->getAmount());
+        $this->assertSame('USD', $result[0]->getCurrency());
+    }
+
+    public function testSkipsPackageWhenTenantHasOwnActiveContractsButNoneCoversIt(): void
+    {
+        $tenant = $this->createMock(Account::class);
+        $tenant->method('getId')->willReturn(1);
+        $upcomingPackage = $this->package(1);
+        $otherPackage = $this->package(2);
+
+        $now = new \DateTimeImmutable();
+        $default = $this->contract(null, 12.0, $now->modify('+1 day'));
+        $this->linkContractToPackage($default, $upcomingPackage);
+
+        // La cuenta tiene un contrato propio activo, pero para OTRO
+        // paquete — no cubre el que está por arrancar.
+        $ownActiveContract = $this->contract($tenant, 5.0, $now->modify('-1 day'));
+        $this->linkContractToPackage($ownActiveContract, $otherPackage);
+
+        $this->packageRepository->method('findUpcoming')->willReturn([$upcomingPackage]);
+        $this->contractRepository->method('findActiveForTenant')->willReturn([$ownActiveContract]);
+
+        $this->assertSame([], $this->resolver->upcomingFor($tenant));
+    }
+
+    public function testShowsPreviewWhenTenantsOwnActiveContractAlreadyCoversTheUpcomingPackage(): void
+    {
+        $tenant = $this->createMock(Account::class);
+        $tenant->method('getId')->willReturn(1);
+        $package = $this->package(1);
+
+        $now = new \DateTimeImmutable();
+        // El mismo contrato propio activo YA cubre este paquete (ej. el
+        // paquete comparte tupla con el catálogo normal del tenant) — no se
+        // omite.
+        $ownActiveContract = $this->contract($tenant, 9.0, $now->modify('-1 day'));
+        $this->linkContractToPackage($ownActiveContract, $package);
+
+        $this->packageRepository->method('findUpcoming')->willReturn([$package]);
+        $this->contractRepository->method('findActiveForTenant')->willReturn([$ownActiveContract]);
+
+        $result = $this->resolver->upcomingFor($tenant);
+
+        $this->assertCount(1, $result);
+        $this->assertSame(9.0, $result[0]->getAmount());
+    }
+}

--- a/tests/State/CommunicationClientPackageItemProviderTest.php
+++ b/tests/State/CommunicationClientPackageItemProviderTest.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace App\Tests\State;
+
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\State\ProviderInterface;
+use App\Entity\Account;
+use App\Entity\CommunicationClientPackage;
+use App\Entity\CommunicationPackage;
+use App\Repository\CommunicationPackageRepository;
+use App\Repository\SysConfigRepository;
+use App\Service\Catalog\CatalogPackageVisibilityResolver;
+use App\Service\Catalog\CatalogVersionResolver;
+use App\Service\Pricing\PackageSalePriceResolver;
+use App\Service\Pricing\PriceSourceEnum;
+use App\Service\Pricing\ResolvedSalePrice;
+use App\State\CommunicationClientPackageItemProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Security;
+
+/**
+ * @covers \App\State\CommunicationClientPackageItemProvider
+ */
+class CommunicationClientPackageItemProviderTest extends TestCase
+{
+    private ProviderInterface&MockObject $itemProvider;
+    private Security&MockObject $security;
+    private PackageSalePriceResolver&MockObject $salePriceResolver;
+    private SysConfigRepository&MockObject $sysConfigRepo;
+    private CatalogVersionResolver $catalogVersion;
+    private CommunicationPackageRepository&MockObject $packageRepository;
+    private CatalogPackageVisibilityResolver&MockObject $visibility;
+    private CommunicationClientPackageItemProvider $provider;
+
+    protected function setUp(): void
+    {
+        $this->itemProvider = $this->createMock(ProviderInterface::class);
+        $this->security = $this->createMock(Security::class);
+        $this->salePriceResolver = $this->createMock(PackageSalePriceResolver::class);
+        // CatalogVersionResolver es `final` — se construye real con
+        // SysConfigRepository mockeado (mismo patrón que
+        // CommunicationClientPackageProviderTest). Por defecto isV2() da
+        // false.
+        $this->sysConfigRepo = $this->createMock(SysConfigRepository::class);
+        $this->catalogVersion = new CatalogVersionResolver($this->sysConfigRepo);
+        $this->packageRepository = $this->createMock(CommunicationPackageRepository::class);
+        $this->visibility = $this->createMock(CatalogPackageVisibilityResolver::class);
+
+        $this->provider = new CommunicationClientPackageItemProvider(
+            $this->itemProvider,
+            $this->security,
+            $this->salePriceResolver,
+            $this->catalogVersion,
+            $this->packageRepository,
+            $this->visibility,
+        );
+    }
+
+    // ---- Rama V1 (comportamiento intacto) ----
+
+    public function testV1DelegatesInInnerProviderAndResolvesSalePrice(): void
+    {
+        $package = $this->createMock(CommunicationClientPackage::class);
+        $tenant = $this->createMock(Account::class);
+
+        $this->itemProvider->method('provide')->willReturn($package);
+        $this->security->method('getUser')->willReturn($tenant);
+        $this->salePriceResolver->expects($this->once())->method('resolve')->with($package, $tenant)
+            ->willReturn(new ResolvedSalePrice(10.0, 'USD', PriceSourceEnum::CONTRACT));
+        $this->packageRepository->expects($this->never())->method('find');
+
+        $result = $this->provider->provide(new Get());
+
+        $this->assertSame($package, $result);
+    }
+
+    public function testV1ReturnsNullFromInnerProviderUntouched(): void
+    {
+        $this->itemProvider->method('provide')->willReturn(null);
+        $this->security->method('getUser')->willReturn($this->createMock(Account::class));
+
+        $result = $this->provider->provide(new Get());
+
+        $this->assertNull($result);
+    }
+
+    // ---- Rama V2 ----
+
+    public function testV2FetchesFromPackageRepositoryInsteadOfInnerProvider(): void
+    {
+        $tenant = $this->createMock(Account::class);
+        $this->security->method('getUser')->willReturn($tenant);
+        $this->sysConfigRepo->method('findCachedValue')
+            ->with(CatalogVersionResolver::DEFAULT_VERSION_KEY)
+            ->willReturn('v2');
+
+        $package = $this->createMock(CommunicationPackage::class);
+        $this->packageRepository->expects($this->once())->method('find')->with(42)->willReturn($package);
+        $this->visibility->method('visibleFor')->with($package, $tenant)->willReturn($package);
+
+        $this->itemProvider->expects($this->never())->method('provide');
+        $this->salePriceResolver->expects($this->never())->method('resolve');
+
+        $result = $this->provider->provide(new Get(), ['id' => '42']);
+
+        $this->assertSame($package, $result);
+    }
+
+    public function testV2ReturnsNullWhenVisibilityResolverRejectsThePackage(): void
+    {
+        $tenant = $this->createMock(Account::class);
+        $this->security->method('getUser')->willReturn($tenant);
+        $this->sysConfigRepo->method('findCachedValue')->willReturn('v2');
+
+        $package = $this->createMock(CommunicationPackage::class);
+        $this->packageRepository->method('find')->willReturn($package);
+        $this->visibility->method('visibleFor')->willReturn(null);
+
+        $result = $this->provider->provide(new Get(), ['id' => '42']);
+
+        $this->assertNull($result);
+    }
+
+    public function testV2ReturnsNullWhenPackageDoesNotExist(): void
+    {
+        $tenant = $this->createMock(Account::class);
+        $this->security->method('getUser')->willReturn($tenant);
+        $this->sysConfigRepo->method('findCachedValue')->willReturn('v2');
+
+        $this->packageRepository->method('find')->willReturn(null);
+        $this->visibility->expects($this->never())->method('visibleFor');
+
+        $result = $this->provider->provide(new Get(), ['id' => '999']);
+
+        $this->assertNull($result);
+    }
+
+    public function testV2ReturnsNullWhenIdIsMissing(): void
+    {
+        $tenant = $this->createMock(Account::class);
+        $this->security->method('getUser')->willReturn($tenant);
+        $this->sysConfigRepo->method('findCachedValue')->willReturn('v2');
+
+        $this->packageRepository->expects($this->never())->method('find');
+
+        $result = $this->provider->provide(new Get(), []);
+
+        $this->assertNull($result);
+    }
+
+    public function testV2ReturnsNullWhenIdIsNotNumeric(): void
+    {
+        $tenant = $this->createMock(Account::class);
+        $this->security->method('getUser')->willReturn($tenant);
+        $this->sysConfigRepo->method('findCachedValue')->willReturn('v2');
+
+        $this->packageRepository->expects($this->never())->method('find');
+
+        $result = $this->provider->provide(new Get(), ['id' => 'not-a-number']);
+
+        $this->assertNull($result);
+    }
+}

--- a/tests/State/CommunicationClientPackageProviderTest.php
+++ b/tests/State/CommunicationClientPackageProviderTest.php
@@ -6,10 +6,13 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use App\Entity\Account;
 use App\Entity\CommunicationClientPackage;
+use App\Entity\CommunicationPackage;
 use App\Entity\CommunicationPricePackage;
 use App\Entity\Environment;
 use App\Repository\CommunicationClientPackageRepository;
 use App\Repository\CommunicationPricePackageRepository;
+use App\Repository\SysConfigRepository;
+use App\Service\Catalog\CatalogVersionResolver;
 use App\Service\PackagePriceService;
 use App\Service\Pricing\PackageMaterializationService;
 use App\Service\Pricing\PackageSalePriceResolver;
@@ -32,6 +35,9 @@ class CommunicationClientPackageProviderTest extends TestCase
     private PackageMaterializationService&MockObject $materializationService;
     private Security&MockObject $security;
     private PackageSalePriceResolver&MockObject $salePriceResolver;
+    private SysConfigRepository&MockObject $sysConfigRepo;
+    private CatalogVersionResolver $catalogVersion;
+    private ProviderInterface&MockObject $catalogProvider;
     private CommunicationClientPackageProvider $provider;
 
     protected function setUp(): void
@@ -42,6 +48,13 @@ class CommunicationClientPackageProviderTest extends TestCase
         $this->materializationService = $this->createMock(PackageMaterializationService::class);
         $this->security = $this->createMock(Security::class);
         $this->salePriceResolver = $this->createMock(PackageSalePriceResolver::class);
+        // CatalogVersionResolver es `final` — no se puede mockear con
+        // createMock(), se construye real con su única dependencia
+        // (SysConfigRepository) mockeada. Por defecto isV2() da false (sin
+        // valor cacheado), igual que en producción sin el flag seteado.
+        $this->sysConfigRepo = $this->createMock(SysConfigRepository::class);
+        $this->catalogVersion = new CatalogVersionResolver($this->sysConfigRepo);
+        $this->catalogProvider = $this->createMock(ProviderInterface::class);
 
         $this->provider = new CommunicationClientPackageProvider(
             $this->itemProvider,
@@ -50,6 +63,8 @@ class CommunicationClientPackageProviderTest extends TestCase
             $this->materializationService,
             $this->security,
             $this->salePriceResolver,
+            $this->catalogVersion,
+            $this->catalogProvider,
             $this->createMock(LoggerInterface::class),
         );
     }
@@ -179,5 +194,41 @@ class CommunicationClientPackageProviderTest extends TestCase
         $result = $this->provider->provide($this->createMock(Operation::class));
 
         $this->assertSame($materialized, $result);
+    }
+
+    public function testDelegatesToCatalogProviderWhenAccountIsV2(): void
+    {
+        $tenant = $this->accountWithEnvironment();
+        $this->security->method('getUser')->willReturn($tenant);
+        $this->sysConfigRepo->method('findCachedValue')
+            ->with(CatalogVersionResolver::DEFAULT_VERSION_KEY)
+            ->willReturn('v2');
+
+        $v2Packages = [$this->createMock(CommunicationPackage::class)];
+        $this->catalogProvider->expects($this->once())->method('provide')->willReturn($v2Packages);
+
+        $this->itemProvider->expects($this->never())->method('provide');
+        $this->materializationService->expects($this->never())->method('materializeForTenant');
+        $this->salePriceResolver->expects($this->never())->method('resolveMany');
+
+        $result = $this->provider->provide($this->createMock(Operation::class));
+
+        $this->assertSame($v2Packages, $result);
+    }
+
+    public function testKeepsLegacyPathWhenAccountIsNotV2(): void
+    {
+        $tenant = $this->accountWithEnvironment();
+        $this->security->method('getUser')->willReturn($tenant);
+        $this->sysConfigRepo->method('findCachedValue')->willReturn(null);
+
+        $collection = $this->countableCollection([$this->createMock(CommunicationClientPackage::class)]);
+        $this->itemProvider->expects($this->once())->method('provide')->willReturn($collection);
+        $this->catalogProvider->expects($this->never())->method('provide');
+        $this->salePriceResolver->expects($this->once())->method('resolveMany');
+
+        $result = $this->provider->provide($this->createMock(Operation::class));
+
+        $this->assertSame($collection, $result);
     }
 }

--- a/tests/State/CommunicationPackageCatalogItemProviderTest.php
+++ b/tests/State/CommunicationPackageCatalogItemProviderTest.php
@@ -6,12 +6,8 @@ use ApiPlatform\Metadata\Get;
 use ApiPlatform\State\ProviderInterface;
 use App\Entity\Account;
 use App\Entity\CommunicationPackage;
-use App\Entity\CommunicationPackageProviderProduct;
 use App\Entity\User;
-use App\Repository\CommunicationPackageProviderProductRepository;
-use App\Service\Pricing\PackageCatalogResolver;
-use App\Service\Pricing\PackageOfferSourceEnum;
-use App\Service\Pricing\ResolvedPackageOffer;
+use App\Service\Catalog\CatalogPackageVisibilityResolver;
 use App\State\CommunicationPackageCatalogItemProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -19,26 +15,26 @@ use Symfony\Bundle\SecurityBundle\Security;
 
 /**
  * @covers \App\State\CommunicationPackageCatalogItemProvider
+ *
+ * Desde la extracción de CatalogPackageVisibilityResolver, este provider
+ * solo hace fetch + chequeo de Account + delegación — el criterio de
+ * visibilidad en sí (offerFor/binding/ventana activa) se prueba en
+ * tests/Service/Catalog/CatalogPackageVisibilityResolverTest.php.
  */
 class CommunicationPackageCatalogItemProviderTest extends TestCase
 {
     private ProviderInterface&MockObject $innerProvider;
-    private PackageCatalogResolver&MockObject $catalogResolver;
-    private CommunicationPackageProviderProductRepository&MockObject $bindingRepo;
+    private CatalogPackageVisibilityResolver&MockObject $visibility;
     private Security&MockObject $security;
     private CommunicationPackageCatalogItemProvider $provider;
 
     protected function setUp(): void
     {
         $this->innerProvider = $this->createMock(ProviderInterface::class);
-        $this->catalogResolver = $this->createMock(PackageCatalogResolver::class);
-        $this->bindingRepo = $this->createMock(CommunicationPackageProviderProductRepository::class);
-        // Con vínculo por defecto — los tests existentes ejercitan el
-        // camino de resolución normal, sin cambios.
-        $this->bindingRepo->method('findAllForPackage')->willReturn([$this->createMock(CommunicationPackageProviderProduct::class)]);
+        $this->visibility = $this->createMock(CatalogPackageVisibilityResolver::class);
         $this->security = $this->createMock(Security::class);
 
-        $this->provider = new CommunicationPackageCatalogItemProvider($this->innerProvider, $this->catalogResolver, $this->bindingRepo, $this->security);
+        $this->provider = new CommunicationPackageCatalogItemProvider($this->innerProvider, $this->visibility, $this->security);
     }
 
     private function package(): CommunicationPackage
@@ -49,7 +45,7 @@ class CommunicationPackageCatalogItemProviderTest extends TestCase
     public function testReturnsNullWhenInnerProviderFindsNoPackage(): void
     {
         $this->innerProvider->method('provide')->willReturn(null);
-        $this->catalogResolver->expects($this->never())->method('offerFor');
+        $this->visibility->expects($this->never())->method('visibleFor');
 
         $result = $this->provider->provide(new Get());
 
@@ -60,7 +56,7 @@ class CommunicationPackageCatalogItemProviderTest extends TestCase
     {
         $this->innerProvider->method('provide')->willReturn($this->package());
         $this->security->method('getUser')->willReturn(null);
-        $this->catalogResolver->expects($this->never())->method('offerFor');
+        $this->visibility->expects($this->never())->method('visibleFor');
 
         $result = $this->provider->provide(new Get());
 
@@ -71,22 +67,22 @@ class CommunicationPackageCatalogItemProviderTest extends TestCase
     {
         $this->innerProvider->method('provide')->willReturn($this->package());
         $this->security->method('getUser')->willReturn($this->createMock(User::class));
-        $this->catalogResolver->expects($this->never())->method('offerFor');
+        $this->visibility->expects($this->never())->method('visibleFor');
 
         $result = $this->provider->provide(new Get());
 
         $this->assertNull($result);
     }
 
-    public function testReturnsNullWhenPackageIsNotVisibleForTenant(): void
+    public function testReturnsNullWhenVisibilityResolverRejectsThePackage(): void
     {
         $package = $this->package();
         $account = $this->createMock(Account::class);
 
         $this->innerProvider->method('provide')->willReturn($package);
         $this->security->method('getUser')->willReturn($account);
-        $this->catalogResolver->expects($this->once())
-            ->method('offerFor')
+        $this->visibility->expects($this->once())
+            ->method('visibleFor')
             ->with($package, $account)
             ->willReturn(null);
 
@@ -95,51 +91,14 @@ class CommunicationPackageCatalogItemProviderTest extends TestCase
         $this->assertNull($result);
     }
 
-    public function testReturnsNullWhenOfferIsUnavailable(): void
+    public function testReturnsThePackageWhenVisibilityResolverAcceptsIt(): void
     {
         $package = $this->package();
         $account = $this->createMock(Account::class);
 
         $this->innerProvider->method('provide')->willReturn($package);
         $this->security->method('getUser')->willReturn($account);
-        $this->catalogResolver->method('offerFor')->willReturn(
-            new ResolvedPackageOffer($package, 0.0, 'USD', PackageOfferSourceEnum::UNAVAILABLE)
-        );
-
-        $result = $this->provider->provide(new Get());
-
-        $this->assertNull($result);
-    }
-
-    public function testReturnsNullWhenPackageHasNoExplicitBinding(): void
-    {
-        $package = $this->package();
-        $account = $this->createMock(Account::class);
-
-        $this->innerProvider->method('provide')->willReturn($package);
-        $this->security->method('getUser')->willReturn($account);
-        $this->catalogResolver->method('offerFor')->willReturn(
-            new ResolvedPackageOffer($package, 25.69, 'USD', PackageOfferSourceEnum::PRODUCT_MAX)
-        );
-        $this->bindingRepo = $this->createMock(CommunicationPackageProviderProductRepository::class);
-        $this->bindingRepo->method('findAllForPackage')->willReturn([]);
-        $this->provider = new CommunicationPackageCatalogItemProvider($this->innerProvider, $this->catalogResolver, $this->bindingRepo, $this->security);
-
-        $result = $this->provider->provide(new Get());
-
-        $this->assertNull($result);
-    }
-
-    public function testReturnsThePackageWhenOfferIsResolved(): void
-    {
-        $package = $this->package();
-        $account = $this->createMock(Account::class);
-
-        $this->innerProvider->method('provide')->willReturn($package);
-        $this->security->method('getUser')->willReturn($account);
-        $this->catalogResolver->method('offerFor')->willReturn(
-            new ResolvedPackageOffer($package, 25.69, 'USD', PackageOfferSourceEnum::PRODUCT_MAX)
-        );
+        $this->visibility->method('visibleFor')->with($package, $account)->willReturn($package);
 
         $result = $this->provider->provide(new Get());
 

--- a/tests/State/CommunicationPackageCatalogProviderTest.php
+++ b/tests/State/CommunicationPackageCatalogProviderTest.php
@@ -104,4 +104,24 @@ class CommunicationPackageCatalogProviderTest extends TestCase
 
         $this->assertSame([$bound], $result);
     }
+
+    public function testExcludesPackagesOutsideTheirOwnActiveWindow(): void
+    {
+        $account = $this->createMock(Account::class);
+        $this->security->method('getUser')->willReturn($account);
+
+        $now = new \DateTimeImmutable();
+        $active = $this->packageWithId(1, 'Active');
+        $future = $this->packageWithId(2, 'Future')->setActiveStartAt($now->modify('+1 day'));
+
+        $this->catalogResolver->method('catalogFor')->willReturn([
+            new ResolvedPackageOffer($active, 10.0, 'USD', PackageOfferSourceEnum::PRODUCT_MAX),
+            new ResolvedPackageOffer($future, 20.0, 'USD', PackageOfferSourceEnum::PRODUCT_MAX),
+        ]);
+        $this->bindingRepo->method('findPackageIdsWithBindings')->willReturn([1, 2]);
+
+        $result = $this->provider->provide(new GetCollection());
+
+        $this->assertSame([$active], $result);
+    }
 }

--- a/tests/State/UpcomingPackagesProviderTest.php
+++ b/tests/State/UpcomingPackagesProviderTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Tests\State;
+
+use ApiPlatform\Metadata\GetCollection;
+use App\Entity\Account;
+use App\Entity\CommunicationPackage;
+use App\Entity\User;
+use App\Repository\SysConfigRepository;
+use App\Service\Catalog\CatalogVersionResolver;
+use App\Service\Catalog\UpcomingPackageCatalogResolver;
+use App\Service\Pricing\PackageSalePriceResolver;
+use App\State\UpcomingPackagesProvider;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Security;
+
+/**
+ * @covers \App\State\UpcomingPackagesProvider
+ */
+class UpcomingPackagesProviderTest extends TestCase
+{
+    private EntityManagerInterface&MockObject $em;
+    private Security&MockObject $security;
+    private PackageSalePriceResolver&MockObject $salePriceResolver;
+    private SysConfigRepository&MockObject $sysConfigRepo;
+    private CatalogVersionResolver $catalogVersion;
+    private UpcomingPackageCatalogResolver&MockObject $upcomingResolver;
+    private UpcomingPackagesProvider $provider;
+
+    protected function setUp(): void
+    {
+        $this->em = $this->createMock(EntityManagerInterface::class);
+        $this->security = $this->createMock(Security::class);
+        $this->salePriceResolver = $this->createMock(PackageSalePriceResolver::class);
+        // CatalogVersionResolver es `final` — se construye real con
+        // SysConfigRepository mockeado. Por defecto isV2() da false.
+        $this->sysConfigRepo = $this->createMock(SysConfigRepository::class);
+        $this->catalogVersion = new CatalogVersionResolver($this->sysConfigRepo);
+        $this->upcomingResolver = $this->createMock(UpcomingPackageCatalogResolver::class);
+
+        $this->provider = new UpcomingPackagesProvider(
+            $this->em,
+            $this->security,
+            $this->salePriceResolver,
+            $this->catalogVersion,
+            $this->upcomingResolver,
+        );
+    }
+
+    public function testReturnsEmptyArrayWhenUserIsNotAnAccountWithoutCallingIsV2(): void
+    {
+        $this->security->method('getUser')->willReturn($this->createMock(User::class));
+        $this->sysConfigRepo->expects($this->never())->method('findCachedValue');
+        $this->em->expects($this->never())->method('getRepository');
+
+        $result = $this->provider->provide(new GetCollection());
+
+        $this->assertSame([], $result);
+    }
+
+    public function testV2DelegatesInTheUpcomingResolverWithoutTouchingTheEntityManager(): void
+    {
+        $tenant = $this->createMock(Account::class);
+        $this->security->method('getUser')->willReturn($tenant);
+        $this->sysConfigRepo->method('findCachedValue')
+            ->with(CatalogVersionResolver::DEFAULT_VERSION_KEY)
+            ->willReturn('v2');
+
+        $v2Packages = [$this->createMock(CommunicationPackage::class)];
+        $this->upcomingResolver->expects($this->once())->method('upcomingFor')->with($tenant)->willReturn($v2Packages);
+        $this->em->expects($this->never())->method('getRepository');
+        $this->em->expects($this->never())->method('createQueryBuilder');
+
+        $result = $this->provider->provide(new GetCollection());
+
+        $this->assertSame($v2Packages, $result);
+    }
+}


### PR DESCRIPTION
## Resumen

- Fase pendiente documentada desde el rediseño V2: el catálogo compartido `CommunicationPackage` vivía en su propia URL `/communication/packages/catalog`, sin uso real de la app móvil. `CatalogVersionResolver::isV2()` solo se consultaba en el flujo de venta, nunca en el de lectura.
- Ahora `/communication/packages` (+ `/{id}` + `/upcoming`), la URL histórica que la app móvil ya consume, sirve V2 para las cuentas marcadas V2 — la rama V1 queda intacta para el resto.
- `CommunicationPackage` gana paridad de shape con V1 en `comPackage:read` (`activeStartAt`/`activeEndAt`, `promotions`) — verificado con el serializer real.
- `CatalogPackageVisibilityResolver` centraliza el criterio de visibilidad compartido entre `/catalog/{id}` y el nuevo `/communication/packages/{id}`.
- `UpcomingPackageCatalogResolver` resuelve el preview de precio de paquetes futuros directamente desde `CommunicationPackage::getContracts()` (nunca vía `PackageCatalogResolver`, cuya precedencia no se toca).

## Dos bugs preexistentes encontrados y corregidos (el switch los hacía más visibles)

1. Un paquete de promoción futura podía colarse en el listado si su contrato reutilizó uno ya vigente — `PackageCatalogResolver::offersFromContracts()` no mira la ventana activa del paquete. Fix: `CommunicationPackage::isActiveAt()` nuevo, aplicado en listado/detalle V2.
2. `/upcoming` podía mostrar promos que la cuenta no iba a poder comprar cuando arrancaran (su contrato propio activo tiene prioridad). `UpcomingPackageCatalogResolver` las omite.
3. Desalineamiento de espacio de ids: `CommunicationSaleService::admitV2()` ya buscaba por `CommunicationPackage`, pero el listado nunca devolvía esos ids — el switch cierra ese hueco.

## Test plan

- [x] `php bin/phpunit --no-coverage` — 994 tests en verde (Docker), incluido con `--order-by=random`
- [x] `vendor/bin/phpstan analyse` — sin errores
- [x] Test funcional nuevo contra Postgres real (`CommunicationPackagesV2SwitchFunctionalTest`, 9 casos): regresión V1, default V2, cliente en lista V2 con default V1, upcoming (+ fix de fuga por prioridad de tenant), detalle por id (incluye 404 cruzando catálogos), ventana activa, shape con el serializer real
- [x] Verificación E2E real contra datos de desarrollo reales (cuenta real, 41 paquetes V2 reales): listado y detalle por id coinciden exactamente

## Riesgo

El flag `communications.catalog.version.default` ya está en `v2` en este entorno — el deploy afecta lectura real de inmediato para cuentas sin contrato propio. Decisión explícita del owner: mergear tal cual, sin piloto gradual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019akFNicpzpVzZSjSVqvGRs