### PR TITLE
feat(sales): nombre de la promoción en ventas V2 de paquetes

### DIFF
--- a/src/Controller/DashboardSalesController.php
+++ b/src/Controller/DashboardSalesController.php
@@ -61,7 +61,12 @@ class DashboardSalesController extends AbstractController
             ->createQueryBuilder('s')
             ->leftJoin('s.tenant', 'a')
             ->leftJoin('a.client', 'c')
-            ->leftJoin('a.environment', 'e');
+            ->leftJoin('a.environment', 'e')
+            // getPromotionName() (grupo sale:list) recorre
+            // catalogPackage->promotion — sin estos joins, el normalizer
+            // dispara 2 queries lazy por fila con catalogPackage seteado.
+            ->leftJoin('s.catalogPackage', 'cp')->addSelect('cp')
+            ->leftJoin('cp.promotion', 'promo')->addSelect('promo');
 
         // Filtro por tipo: recharge, sale o ambos
         $type = $request->query->get('type');

--- a/src/DTO/Out/SaleInfoListOutDto.php
+++ b/src/DTO/Out/SaleInfoListOutDto.php
@@ -14,4 +14,6 @@ class SaleInfoListOutDto
     public ?float $totalPrice = null;
     public ?string $state = null;
     public ?string $type = null;
+    /** Nombre de la promoción si el paquete vendido es V2 y proviene de una — null en ventas normales y en toda venta V1 legacy. */
+    public ?string $promotionName = null;
 }

--- a/src/Entity/CommunicationSaleInfo.php
+++ b/src/Entity/CommunicationSaleInfo.php
@@ -583,6 +583,28 @@ class CommunicationSaleInfo
         return $this;
     }
 
+    /**
+     * Nombre de la promoción si el paquete vendido es un CommunicationPackage
+     * (V2) generado por una promoción — null en ventas normales y en toda
+     * venta V1 legacy ($package). Derivado de $catalogPackage->$promotion
+     * (snapshot fijo desde que se creó el paquete, ver
+     * CommunicationPackage::$promotion), no de $this->promotion —ese campo
+     * solo se usa en el flujo de recargas reservadas
+     * (CommunicationSaleService::processReserve()), nunca en venta de
+     * paquetes.
+     *
+     * Alcance V1 descartado a propósito: CommunicationClientPackage::
+     * $promotionItems se filtra por fecha ACTUAL (startAt<=now<=endAt), no
+     * es un snapshot histórico — una venta antigua de una promo ya vencida
+     * no se detectaría como promocional, así que no es un dato confiable
+     * para mostrar en el listado de ventas.
+     */
+    #[Groups(['sale:list', 'sale:detail'])]
+    public function getPromotionName(): ?string
+    {
+        return $this->catalogPackage?->getPromotion()?->getName();
+    }
+
     public function getDispatchProduct(): ?CommunicationProduct
     {
         return $this->dispatchProduct;

--- a/tests/Controller/DashboardSalesControllerPromotionNameFunctionalTest.php
+++ b/tests/Controller/DashboardSalesControllerPromotionNameFunctionalTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Tests\Controller;
+
+use App\Controller\DashboardSalesController;
+use App\Entity\Account;
+use App\Entity\CommunicationPackage;
+use App\Entity\CommunicationPromotions;
+use App\Entity\CommunicationSalePackage;
+use App\Enums\CommunicationStateEnum;
+use App\Service\CommunicationSaleService;
+use App\Tests\Functional\Provider\ProviderFunctionalTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * @covers \App\Controller\DashboardSalesController
+ *
+ * Contra Postgres real — el listado usa un join a catalogPackage->promotion
+ * (ManyToOne x2, sin fan-out de paginación, a diferencia del caso
+ * ManyToMany de CommunicationContract) para poblar
+ * CommunicationSaleInfo::getPromotionName() sin N+1; solo se verifica de
+ * verdad contra el serializer + query real.
+ */
+class DashboardSalesControllerPromotionNameFunctionalTest extends ProviderFunctionalTestCase
+{
+    private function controller(): DashboardSalesController
+    {
+        $controller = new DashboardSalesController(
+            $this->em,
+            self::getContainer()->get(NormalizerInterface::class),
+            self::getContainer()->get(CommunicationSaleService::class),
+            self::getContainer()->get(MessageBusInterface::class),
+        );
+        // list() llama a $this->getUser()/isGranted() (AbstractController) —
+        // requiere un container real con el security context ya autenticado.
+        $controller->setContainer(self::getContainer());
+
+        return $controller;
+    }
+
+    private function sale(Account $tenant, ?CommunicationPackage $catalogPackage, string $clientTransactionId): CommunicationSalePackage
+    {
+        $sale = (new CommunicationSalePackage())
+            ->setTenant($tenant)
+            ->setClientTransactionId($clientTransactionId)
+            ->setAmount(10.0)
+            ->setCurrency('USD')
+            ->setTotalPrice(10.0)
+            ->setState(CommunicationStateEnum::COMPLETED)
+            ->setProvider('CSQ')
+            ->setIdentificationNumber('12345')
+            ->setName('Cliente de prueba');
+
+        if ($catalogPackage !== null) {
+            $sale->setCatalogPackage($catalogPackage);
+        }
+
+        $this->em->persist($sale);
+
+        return $sale;
+    }
+
+    public function testListIncludesThePromotionNameForAV2PromotionalSale(): void
+    {
+        $client = $this->createClient();
+        $environment = $this->createEnvironment();
+        $account = $this->createAccount($client, $environment);
+        $this->authenticateAsAdmin($this->createAdminUser());
+
+        $promotion = (new CommunicationPromotions())
+            ->setName('Promo Verano 2026')
+            ->setDescription('Promoción de prueba')
+            ->setStartAt(new \DateTimeImmutable('-1 day'))
+            ->setEndAt(new \DateTimeImmutable('+30 days'));
+        $this->em->persist($promotion);
+
+        $package = (new CommunicationPackage())
+            ->setName('Promo UI 500 CUP')->setDescription('P')
+            ->setDestinationAmount(500.0)->setDestinationCurrency('CUP')
+            ->setPromotion($promotion);
+        $this->em->persist($package);
+
+        $promoSale = $this->sale($account, $package, 'promo-tx-1');
+        $normalSale = $this->sale($account, null, 'normal-tx-1');
+        $this->em->flush();
+
+        $response = $this->controller()->list(new Request(['accountId' => (string) $account->getId(), 'limit' => '50']));
+        $data = json_decode($response->getContent(), true);
+
+        $byId = [];
+        foreach ($data['results'] as $row) {
+            $byId[$row['id']] = $row;
+        }
+
+        $this->assertSame('Promo Verano 2026', $byId[$promoSale->getId()]['promotionName'] ?? null);
+        $this->assertArrayNotHasKey('promotionName', $byId[$normalSale->getId()]);
+    }
+}

--- a/tests/Entity/CommunicationSaleInfoPromotionNameTest.php
+++ b/tests/Entity/CommunicationSaleInfoPromotionNameTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Tests\Entity;
+
+use App\Entity\CommunicationPackage;
+use App\Entity\CommunicationPromotions;
+use App\Entity\CommunicationSalePackage;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Attribute\Groups;
+
+/**
+ * @covers \App\Entity\CommunicationSaleInfo
+ *
+ * getPromotionName() alimenta el badge "Promoción" del listado de ventas
+ * en el dashboard (Balance operativo > Paquetes) — alcance V2 solamente
+ * (decisión explícita: CommunicationClientPackage::$promotionItems, V1, se
+ * filtra por fecha actual y no es un snapshot histórico confiable).
+ */
+class CommunicationSaleInfoPromotionNameTest extends TestCase
+{
+    public function testReturnsNullWhenSaleHasNoCatalogPackage(): void
+    {
+        $sale = new CommunicationSalePackage();
+
+        $this->assertNull($sale->getPromotionName());
+    }
+
+    public function testReturnsNullWhenCatalogPackageHasNoPromotion(): void
+    {
+        $package = (new CommunicationPackage())
+            ->setName('P')->setDescription('P')
+            ->setDestinationAmount(500.0)->setDestinationCurrency('CUP');
+
+        $sale = (new CommunicationSalePackage())->setCatalogPackage($package);
+
+        $this->assertNull($sale->getPromotionName());
+    }
+
+    public function testReturnsThePromotionNameWhenCatalogPackageComesFromAPromotion(): void
+    {
+        $promotion = (new CommunicationPromotions())->setName('Promo Verano 2026');
+        $package = (new CommunicationPackage())
+            ->setName('Promo UI 500 CUP')->setDescription('P')
+            ->setDestinationAmount(500.0)->setDestinationCurrency('CUP')
+            ->setPromotion($promotion);
+
+        $sale = (new CommunicationSalePackage())->setCatalogPackage($package);
+
+        $this->assertSame('Promo Verano 2026', $sale->getPromotionName());
+    }
+
+    public function testGetPromotionNameIsExposedInListAndDetailGroups(): void
+    {
+        $reflection = new \ReflectionMethod(CommunicationSalePackage::class, 'getPromotionName');
+        $attributes = $reflection->getAttributes(Groups::class);
+
+        $this->assertNotEmpty($attributes, 'getPromotionName() debería tener un atributo #[Groups].');
+
+        /** @var Groups $groups */
+        $groups = $attributes[0]->newInstance();
+
+        $this->assertContains('sale:list', $groups->groups);
+        $this->assertContains('sale:detail', $groups->groups);
+    }
+}


### PR DESCRIPTION
## Resumen
- `CommunicationSaleInfo::getPromotionName()` deriva el nombre de la promoción desde `catalogPackage->promotion` (snapshot fijo del catálogo V2 en el momento de la venta), expuesto en los grupos `sale:list`/`sale:detail`.
- Alcance V2 solamente: se descarta V1 legacy porque `CommunicationClientPackage::$promotionItems` se filtra por fecha actual, no es un snapshot histórico confiable para ventas antiguas.
- `DashboardSalesController::list()` agrega joins a `catalogPackage`/`promotion` para evitar N+1 en el listado.
- `SaleInfoListOutDto` documenta el nuevo campo `promotionName` (heredado por `SaleInfoDetailOutDto`).

## Test plan
- [x] `tests/Entity/CommunicationSaleInfoPromotionNameTest.php` (4 tests, unitario)
- [x] `tests/Controller/DashboardSalesControllerPromotionNameFunctionalTest.php` (funcional, Postgres real)
- [x] Suite completa: `php bin/phpunit --no-coverage` (999 tests, verde)
- [x] `vendor/bin/phpstan analyse` (sin errores)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019akFNicpzpVzZSjSVqvGRs