### PR TITLE
fix(promotions): promociones V2 visibles para clientes con contrato propio

### DIFF
--- a/src/Controller/DashboardPromotionController.php
+++ b/src/Controller/DashboardPromotionController.php
@@ -15,6 +15,7 @@ use App\Entity\Environment;
 use App\OpenApi\Attribute\DashboardEndpoint;
 use App\Repository\CommunicationPromotionsRepository;
 use App\Service\CommunicationPromotionService;
+use App\Service\Pricing\CommunicationContractService;
 use App\Service\Pricing\CommunicationPromotionBindingService;
 use App\Service\Pricing\CommunicationPromotionEquivalenceService;
 use App\Service\Pricing\PromotionEquivalenceResult;
@@ -37,6 +38,7 @@ class DashboardPromotionController extends AbstractController
         private readonly CommunicationPromotionService $promotionService,
         private readonly CommunicationPromotionBindingService $bindingService,
         private readonly CommunicationPromotionEquivalenceService $equivalenceService,
+        private readonly CommunicationContractService $contractService,
     ) {
     }
 
@@ -143,6 +145,7 @@ class DashboardPromotionController extends AbstractController
             'contracts' => [
                 'created' => $result->contracts->created,
                 'updated' => $result->contracts->updated,
+                'tenantContractsLinked' => $result->tenantContractsLinked,
             ],
             'equivalences' => $this->serializeEquivalenceResult($result->equivalences),
         ], Response::HTTP_CREATED);
@@ -171,6 +174,21 @@ class DashboardPromotionController extends AbstractController
         }
 
         return $this->json($this->serializeEquivalenceResult($this->equivalenceService->refreshForPromotion($promotion)));
+    }
+
+    #[Route('/{id}/v2/tenant-contracts/link', name: 'dashboard_promotions_v2_tenant_contracts_link', methods: ['POST'])]
+    #[IsGranted('ROLE_ADMIN')]
+    #[DashboardEndpoint(summary: 'Vincula los contratos propios de clientes existentes a los paquetes de una promoción V2', tag: 'Promotions')]
+    public function linkTenantContracts(int $id): JsonResponse
+    {
+        $promotion = $this->repository->find($id);
+        if ($promotion === null) {
+            return $this->json(['error' => ['message' => 'Promotion not found']], Response::HTTP_NOT_FOUND);
+        }
+
+        $linked = $this->contractService->linkTenantContractsForPromotion($promotion);
+
+        return $this->json(['tenantContractsLinked' => $linked]);
     }
 
     #[Route('/{id}', name: 'dashboard_promotions_update', methods: ['PATCH', 'PUT'])]

--- a/src/Repository/CommunicationContractRepository.php
+++ b/src/Repository/CommunicationContractRepository.php
@@ -4,6 +4,7 @@ namespace App\Repository;
 
 use App\Entity\Account;
 use App\Entity\CommunicationContract;
+use App\Entity\CommunicationPackage;
 use App\Service\Pricing\DestinationKey;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\QueryBuilder;
@@ -58,6 +59,26 @@ class CommunicationContractRepository extends ServiceEntityRepository
 
         return $this->baseActiveQueryBuilder($now)
             ->andWhere('c.tenant IS NULL')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * Contratos propios vigentes que YA cubren un paquete dado — usado para
+     * encontrar, dado el paquete regular equivalente a uno de promoción,
+     * qué tenants tienen contrato propio sobre él (ver
+     * CommunicationContractService::linkTenantContractsToPromotionPackage()).
+     *
+     * @return list<CommunicationContract>
+     */
+    public function findActiveTenantContractsForPackage(CommunicationPackage $package, ?\DateTimeImmutable $now = null): array
+    {
+        $now ??= new \DateTimeImmutable();
+
+        return $this->baseActiveQueryBuilder($now)
+            ->andWhere('c.tenant IS NOT NULL')
+            ->andWhere(':package MEMBER OF c.packages')
+            ->setParameter('package', $package)
             ->getQuery()
             ->getResult();
     }

--- a/src/Service/CommunicationPromotionService.php
+++ b/src/Service/CommunicationPromotionService.php
@@ -487,8 +487,10 @@ class CommunicationPromotionService extends CommonService
             $dto->getEndAt(),
         );
 
+        $tenantContractsLinked = $this->contractService->linkTenantContractsToPromotionPackages($packages);
+
         $equivalences = $this->equivalenceService->populateEquivalences($promotion, $packages);
 
-        return new CreatePromotionV2Result($promotion, $packages, $contractResult, $equivalences);
+        return new CreatePromotionV2Result($promotion, $packages, $contractResult, $tenantContractsLinked, $equivalences);
     }
 }

--- a/src/Service/CreatePromotionV2Result.php
+++ b/src/Service/CreatePromotionV2Result.php
@@ -11,10 +11,12 @@ use App\Service\Pricing\PromotionEquivalenceResult;
  * Resultado de CommunicationPromotionService::createV2() — la promoción,
  * los CommunicationPackage generados por rango (todos marcados con esta
  * promoción), el resultado de los CommunicationContract "por defecto"
- * creados para ellos, y el reporte del auto-poblado de equivalencias por
- * proveedor (Fase 5D) — qué proveedores cubrieron cuántos tramos, y qué
- * huecos quedaron (ver PromotionEquivalenceResult::$gaps) para que el
- * admin los cure a mano.
+ * creados para ellos, cuántos contratos propios de tenants existentes se
+ * vincularon a esos paquetes (ver CommunicationContractService::
+ * linkTenantContractsToPromotionPackages()), y el reporte del
+ * auto-poblado de equivalencias por proveedor (Fase 5D) — qué
+ * proveedores cubrieron cuántos tramos, y qué huecos quedaron (ver
+ * PromotionEquivalenceResult::$gaps) para que el admin los cure a mano.
  */
 final readonly class CreatePromotionV2Result
 {
@@ -25,6 +27,7 @@ final readonly class CreatePromotionV2Result
         public CommunicationPromotions $promotion,
         public array $packages,
         public ContractRangeResult $contracts,
+        public int $tenantContractsLinked,
         public PromotionEquivalenceResult $equivalences,
     ) {
     }

--- a/src/Service/Pricing/CommunicationContractService.php
+++ b/src/Service/Pricing/CommunicationContractService.php
@@ -9,6 +9,7 @@ use App\DTO\UpdateCommunicationContractDto;
 use App\Entity\Account;
 use App\Entity\CommunicationContract;
 use App\Entity\CommunicationPackage;
+use App\Entity\CommunicationPromotions;
 use App\Entity\Environment;
 use App\Entity\User;
 use App\Exception\MyCurrentException;
@@ -220,6 +221,67 @@ class CommunicationContractService
         $contractIds = array_map(static fn (CommunicationContract $c) => $c->getId(), $contracts);
 
         return new ContractRangeResult($created, $updated, 0, $contractIds, []);
+    }
+
+    /**
+     * Vincula, a cada paquete de promoción recién creado, los contratos
+     * propios que un tenant YA tenga sobre su paquete regular equivalente
+     * (misma tupla monto/moneda, sin promoción) — sin esto, un cliente con
+     * contrato propio nunca ve la promoción: PackageCatalogResolver::
+     * catalogFor() solo mira los contratos propios del tenant cuando
+     * existen (precedencia #1), y los contratos "por defecto" (tenant IS
+     * NULL) que createForPromotionPackages() genera quedan fuera de esa
+     * rama por completo.
+     *
+     * No crea contratos nuevos ni toca precio/moneda/fechas: reutiliza el
+     * MISMO contrato que el tenant ya tiene para el paquete regular (misma
+     * tupla por la que upsertContract() ya impide crear uno nuevo ahí — el
+     * índice único uniq_com_contract_open_per_tenant_amount lo garantiza),
+     * solo lo asocia también al paquete de promoción. Idempotente:
+     * addPackage() ya comprueba contains() antes de agregar.
+     *
+     * @param list<CommunicationPackage> $promoPackages
+     */
+    public function linkTenantContractsToPromotionPackages(array $promoPackages): int
+    {
+        $linked = 0;
+        foreach ($promoPackages as $promoPackage) {
+            $regularPackage = $this->packageRepository->findByDestination(
+                (float) $promoPackage->getDestinationAmount(),
+                (string) $promoPackage->getDestinationCurrency(),
+            );
+            if ($regularPackage === null) {
+                continue;
+            }
+
+            foreach ($this->contractRepository->findActiveTenantContractsForPackage($regularPackage) as $contract) {
+                if ($contract->getPackages()->contains($promoPackage)) {
+                    continue;
+                }
+                $contract->addPackage($promoPackage);
+                $linked++;
+            }
+        }
+
+        if ($linked > 0) {
+            $this->em->flush();
+        }
+
+        return $linked;
+    }
+
+    /**
+     * Acción manual "vincular contratos de clientes" sobre una promoción V2
+     * ya creada — recarga sus tramos desde BD y vuelve a correr
+     * linkTenantContractsToPromotionPackages(). Mismo espíritu que
+     * CommunicationPromotionEquivalenceService::refreshForPromotion():
+     * cubre tanto el caso de un cliente que negoció su contrato propio
+     * DESPUÉS de creada la promoción, como el de promociones creadas antes
+     * de que este vínculo existiera.
+     */
+    public function linkTenantContractsForPromotion(CommunicationPromotions $promotion): int
+    {
+        return $this->linkTenantContractsToPromotionPackages($this->packageRepository->findByPromotion($promotion));
     }
 
     /**

--- a/tests/Controller/DashboardPromotionControllerTest.php
+++ b/tests/Controller/DashboardPromotionControllerTest.php
@@ -13,6 +13,7 @@ use App\Exception\MyCurrentException;
 use App\Repository\CommunicationPromotionsRepository;
 use App\Service\CommunicationPromotionService;
 use App\Service\CreatePromotionV2Result;
+use App\Service\Pricing\CommunicationContractService;
 use App\Service\Pricing\CommunicationPromotionBindingService;
 use App\Service\Pricing\CommunicationPromotionEquivalenceService;
 use App\Service\Pricing\ContractRangeResult;
@@ -37,6 +38,7 @@ class DashboardPromotionControllerTest extends TestCase
     private CommunicationPromotionBindingService&MockObject $bindingService;
     private CommunicationPromotionService&MockObject $promotionService;
     private CommunicationPromotionEquivalenceService&MockObject $equivalenceService;
+    private CommunicationContractService&MockObject $contractService;
     private NormalizerInterface&MockObject $serializer;
     private DashboardPromotionController $controller;
 
@@ -46,6 +48,7 @@ class DashboardPromotionControllerTest extends TestCase
         $this->bindingService = $this->createMock(CommunicationPromotionBindingService::class);
         $this->promotionService = $this->createMock(CommunicationPromotionService::class);
         $this->equivalenceService = $this->createMock(CommunicationPromotionEquivalenceService::class);
+        $this->contractService = $this->createMock(CommunicationContractService::class);
         $this->serializer = $this->createMock(NormalizerInterface::class);
         $this->serializer->method('normalize')->willReturn([]);
 
@@ -56,6 +59,7 @@ class DashboardPromotionControllerTest extends TestCase
             $this->promotionService,
             $this->bindingService,
             $this->equivalenceService,
+            $this->contractService,
         );
 
         $container = $this->createMock(ContainerInterface::class);
@@ -192,7 +196,7 @@ class DashboardPromotionControllerTest extends TestCase
             [['provider' => 'DTONE', 'matched' => 2, 'error' => null]],
             [],
         );
-        $result = new CreatePromotionV2Result($promotion, $packages, new ContractRangeResult(2, 0, 0, [1, 2], []), $equivalences);
+        $result = new CreatePromotionV2Result($promotion, $packages, new ContractRangeResult(2, 0, 0, [1, 2], []), 3, $equivalences);
         $this->promotionService->expects($this->once())->method('createV2')->willReturn($result);
 
         $response = $this->controller->createV2($this->v2Dto());
@@ -203,6 +207,7 @@ class DashboardPromotionControllerTest extends TestCase
         $this->assertCount(2, $data['packages']);
         $this->assertEquals(500.0, $data['packages'][0]['destinationAmount']);
         $this->assertSame(2, $data['contracts']['created']);
+        $this->assertSame(3, $data['contracts']['tenantContractsLinked']);
         $this->assertSame('DTONE', $data['equivalences']['providers'][0]['provider']);
         $this->assertSame([], $data['equivalences']['gaps']);
     }
@@ -261,5 +266,26 @@ class DashboardPromotionControllerTest extends TestCase
 
         $data = json_decode($response->getContent(), true);
         $this->assertSame(5, $data['providers'][0]['matched']);
+    }
+
+    public function testLinkTenantContractsReturnsNotFoundWhenPromotionDoesNotExist(): void
+    {
+        $this->repository->method('find')->willReturn(null);
+
+        $response = $this->controller->linkTenantContracts(999);
+
+        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+    }
+
+    public function testLinkTenantContractsDelegatesToTheContractService(): void
+    {
+        $promotion = new CommunicationPromotions();
+        $this->repository->method('find')->willReturn($promotion);
+        $this->contractService->expects($this->once())->method('linkTenantContractsForPromotion')->with($promotion)->willReturn(4);
+
+        $response = $this->controller->linkTenantContracts(1);
+
+        $data = json_decode($response->getContent(), true);
+        $this->assertSame(4, $data['tenantContractsLinked']);
     }
 }

--- a/tests/Functional/Pricing/CommunicationContractRepositoryTest.php
+++ b/tests/Functional/Pricing/CommunicationContractRepositoryTest.php
@@ -23,14 +23,14 @@ class CommunicationContractRepositoryTest extends ProviderFunctionalTestCase
         return self::getContainer()->get(CommunicationContractRepository::class);
     }
 
-    private function communicationPackage(): CommunicationPackage
+    private function communicationPackage(float $amount = 500.0): CommunicationPackage
     {
         self::$counter++;
 
         $package = (new CommunicationPackage())
             ->setName("Paquete {$this::$counter}")
             ->setDescription("Paquete {$this::$counter}")
-            ->setDestinationAmount(500.0)
+            ->setDestinationAmount($amount)
             ->setDestinationCurrency('CUP');
 
         $this->em->persist($package);
@@ -240,5 +240,50 @@ class CommunicationContractRepositoryTest extends ProviderFunctionalTestCase
 
         $this->assertSame($default->getId(), $this->repository()->findOpenContract(null, 500.0, 'CUP')?->getId());
         $this->assertNull($this->repository()->findOpenContract($account, 500.0, 'CUP'));
+    }
+
+    public function testFindActiveTenantContractsForPackageReturnsOnlyContractsCoveringThatPackage(): void
+    {
+        $now = new \DateTimeImmutable();
+        $client = $this->createClient();
+        $environment = $this->createEnvironment();
+        $account = $this->createAccount($client, $environment);
+
+        $covered = $this->communicationPackage(500.0);
+        $notCovered = $this->communicationPackage(600.0);
+        $covering = $this->contract($covered, $account, $now->modify('-1 day'));
+        $this->contract($notCovered, $account, $now->modify('-1 day'));
+        $this->em->flush();
+
+        $result = $this->repository()->findActiveTenantContractsForPackage($covered, $now);
+
+        $this->assertCount(1, $result);
+        $this->assertSame($covering->getId(), $result[0]->getId());
+    }
+
+    public function testFindActiveTenantContractsForPackageExcludesDefaultContracts(): void
+    {
+        $now = new \DateTimeImmutable();
+        $package = $this->communicationPackage();
+        // Contrato "por defecto" (tenant NULL) cubriendo el mismo paquete —
+        // no debe aparecer, solo contratos propios de tenant.
+        $this->contract($package, null, $now->modify('-1 day'));
+        $this->em->flush();
+
+        $this->assertSame([], $this->repository()->findActiveTenantContractsForPackage($package, $now));
+    }
+
+    public function testFindActiveTenantContractsForPackageExcludesExpiredContracts(): void
+    {
+        $now = new \DateTimeImmutable();
+        $client = $this->createClient();
+        $environment = $this->createEnvironment();
+        $account = $this->createAccount($client, $environment);
+
+        $package = $this->communicationPackage();
+        $this->contract($package, $account, $now->modify('-2 days'), $now->modify('-1 day'));
+        $this->em->flush();
+
+        $this->assertSame([], $this->repository()->findActiveTenantContractsForPackage($package, $now));
     }
 }

--- a/tests/Functional/Provider/CommunicationPackagesV2SwitchFunctionalTest.php
+++ b/tests/Functional/Provider/CommunicationPackagesV2SwitchFunctionalTest.php
@@ -11,9 +11,11 @@ use App\Entity\CommunicationPackage;
 use App\Entity\CommunicationPackageProviderProduct;
 use App\Entity\CommunicationProduct;
 use App\Entity\Environment;
+use App\DTO\CreatePromotionV2Dto;
 use App\Entity\SysConfig;
 use App\Repository\SysConfigRepository;
 use App\Service\Catalog\CatalogVersionResolver;
+use App\Service\CommunicationPromotionService;
 use App\State\CommunicationClientPackageItemProvider;
 use App\State\CommunicationClientPackageProvider;
 use App\State\UpcomingPackagesProvider;
@@ -343,6 +345,73 @@ class CommunicationPackagesV2SwitchFunctionalTest extends ProviderFunctionalTest
         $ids = array_map(static fn (CommunicationPackage $p) => $p->getId(), iterator_to_array($result));
         $this->assertContains($active->getId(), $ids);
         $this->assertNotContains($future->getId(), $ids);
+    }
+
+    // ---- 7. contrato propio del tenant no oculta promociones nuevas (bug reportado 2026-08-19) ----
+
+    /**
+     * Regresión del bug real encontrado en staging: un tenant con contrato
+     * propio sobre el catálogo regular nunca veía promociones nuevas
+     * (createV2() solo genera contratos "por defecto", tenant IS NULL, y
+     * PackageCatalogResolver::catalogFor() ignora esa rama por completo en
+     * cuanto el tenant tiene AL MENOS un contrato propio). Fix:
+     * CommunicationContractService::linkTenantContractsToPromotionPackages()
+     * vincula el paquete de promoción al MISMO contrato que el tenant ya
+     * tiene para su equivalente regular.
+     */
+    public function testTenantWithOwnContractStillSeesANewPromotionalPackage(): void
+    {
+        $this->setCatalogVersionDefault('v2');
+
+        $client = $this->createClient();
+        $environment = $this->createEnvironment();
+        $account = $this->createAccount($client, $environment);
+        $this->authenticateAs($account);
+
+        // Paquete regular ya existente, con contrato PROPIO del tenant (no
+        // "por defecto") — reproduce exactamente el caso de Comremit en
+        // staging.
+        $regularPackage = $this->v2Package(activeStartAt: new \DateTimeImmutable('-30 days'));
+        $ownContract = $this->defaultContractFor($regularPackage, 10.0, new \DateTimeImmutable('-30 days'));
+        $ownContract->setTenant($account);
+        $this->bindProvider($regularPackage, $environment);
+        $this->em->flush();
+
+        /** @var CommunicationPromotionService $promotionService */
+        $promotionService = self::getContainer()->get(CommunicationPromotionService::class);
+        $dto = new CreatePromotionV2Dto(
+            name: 'Promo regresión',
+            description: 'Promo regresión',
+            packageNameTemplate: 'Promo {monto} CUP',
+            packageDescriptionTemplate: 'Promo {monto} CUP',
+            startAt: (new \DateTimeImmutable('-1 day'))->format('c'),
+            endAt: (new \DateTimeImmutable('+5 days'))->format('c'),
+            environmentId: $environment->getId(),
+            destinationCurrency: 'CUP',
+            amountFrom: (float) $regularPackage->getDestinationAmount(),
+            amountTo: (float) $regularPackage->getDestinationAmount(),
+            amountStep: 1.0,
+            priceFrom: 25.0,
+            priceTo: 25.0,
+            priceCurrency: 'USD',
+        );
+
+        $result = $promotionService->createV2($dto);
+        $promoPackage = $result->packages[0];
+        $this->bindProvider($promoPackage, $environment);
+        $this->em->flush();
+        $this->em->clear();
+
+        $this->assertSame(1, $result->tenantContractsLinked);
+
+        $account = $this->em->getRepository(Account::class)->find($account->getId());
+        $this->authenticateAs($account);
+
+        $listed = $this->v1PackageProvider()->provide(new GetCollection(class: CommunicationClientPackage::class));
+        $ids = array_map(static fn (CommunicationPackage $p) => $p->getId(), iterator_to_array($listed));
+
+        $this->assertContains($regularPackage->getId(), $ids);
+        $this->assertContains($promoPackage->getId(), $ids, 'La promoción debe verse aunque el tenant ya tenga contrato propio.');
     }
 
     // ---- Shape autoritativo: serializer real ----

--- a/tests/Service/CommunicationPromotionServiceV2Test.php
+++ b/tests/Service/CommunicationPromotionServiceV2Test.php
@@ -128,6 +128,11 @@ class CommunicationPromotionServiceV2Test extends TestCase
             ->with($packages, 19.7, 49.25, 'USD', '2026-08-18T00:00:00+00:00', '2026-08-25T23:59:00+00:00')
             ->willReturn($contractResult);
 
+        $this->contractService->expects($this->once())
+            ->method('linkTenantContractsToPromotionPackages')
+            ->with($packages)
+            ->willReturn(3);
+
         $equivalencesResult = new PromotionEquivalenceResult([['provider' => 'DTONE', 'matched' => 2, 'error' => null]], []);
         $this->equivalenceService->expects($this->once())
             ->method('populateEquivalences')
@@ -138,6 +143,7 @@ class CommunicationPromotionServiceV2Test extends TestCase
 
         $this->assertSame($packages, $result->packages);
         $this->assertSame($contractResult, $result->contracts);
+        $this->assertSame(3, $result->tenantContractsLinked);
         $this->assertSame($equivalencesResult, $result->equivalences);
         foreach ($result->packages as $package) {
             $this->assertSame($result->promotion, $package->getPromotion());
@@ -157,6 +163,7 @@ class CommunicationPromotionServiceV2Test extends TestCase
 
         $this->packageAdminService->method('createBatch')->willReturn($single);
         $this->contractService->method('createForPromotionPackages')->willReturn(new ContractRangeResult(1, 0, 0, [1], []));
+        $this->contractService->method('linkTenantContractsToPromotionPackages')->willReturn(0);
         $this->equivalenceService->method('populateEquivalences')->willReturn(new PromotionEquivalenceResult([], []));
 
         $dto = new CreatePromotionV2Dto(

--- a/tests/Service/Pricing/CommunicationContractServiceTest.php
+++ b/tests/Service/Pricing/CommunicationContractServiceTest.php
@@ -9,6 +9,7 @@ use App\DTO\UpdateCommunicationContractDto;
 use App\Entity\Account;
 use App\Entity\CommunicationContract;
 use App\Entity\CommunicationPackage;
+use App\Entity\CommunicationPromotions;
 use App\Entity\Environment;
 use App\Entity\User;
 use App\Exception\MyCurrentException;
@@ -714,5 +715,89 @@ class CommunicationContractServiceTest extends TestCase
         $this->expectExceptionMessage('Tenant not found');
 
         $this->service->deleteAll(5, 9);
+    }
+
+    public function testLinkTenantContractsSkipsPromoPackagesWithoutARegularEquivalent(): void
+    {
+        $promoPackage = $this->package(1);
+        $this->packageRepository->method('findByDestination')->willReturn(null);
+
+        $this->contractRepository->expects($this->never())->method('findActiveTenantContractsForPackage');
+        $this->em->expects($this->never())->method('flush');
+
+        $linked = $this->service->linkTenantContractsToPromotionPackages([$promoPackage]);
+
+        $this->assertSame(0, $linked);
+    }
+
+    public function testLinkTenantContractsAddsThePromoPackageToEachTenantContractCoveringTheRegularEquivalent(): void
+    {
+        $promoPackage = $this->package(1);
+        $regularPackage = $this->package(2);
+        $this->packageRepository->method('findByDestination')
+            ->with(500.0, 'CUP')
+            ->willReturn($regularPackage);
+
+        $tenantA = $this->createMock(Account::class);
+        $tenantB = $this->createMock(Account::class);
+        $contractA = $this->contract($regularPackage)->setTenant($tenantA);
+        $contractB = $this->contract($regularPackage)->setTenant($tenantB);
+
+        $this->contractRepository->expects($this->once())
+            ->method('findActiveTenantContractsForPackage')
+            ->with($regularPackage)
+            ->willReturn([$contractA, $contractB]);
+
+        $this->em->expects($this->once())->method('flush');
+
+        $linked = $this->service->linkTenantContractsToPromotionPackages([$promoPackage]);
+
+        $this->assertSame(2, $linked);
+        $this->assertTrue($contractA->getPackages()->contains($promoPackage));
+        $this->assertTrue($contractB->getPackages()->contains($promoPackage));
+        // El contrato del tenant sigue cubriendo también el paquete regular — no se reemplaza, se amplía.
+        $this->assertTrue($contractA->getPackages()->contains($regularPackage));
+    }
+
+    public function testLinkTenantContractsIsIdempotentWhenTheContractAlreadyCoversThePromoPackage(): void
+    {
+        $promoPackage = $this->package(1);
+        $regularPackage = $this->package(2);
+        $this->packageRepository->method('findByDestination')->willReturn($regularPackage);
+
+        $tenant = $this->createMock(Account::class);
+        $contract = $this->contract($regularPackage)->setTenant($tenant)->addPackage($promoPackage);
+
+        $this->contractRepository->method('findActiveTenantContractsForPackage')->willReturn([$contract]);
+
+        $this->em->expects($this->never())->method('flush');
+
+        $linked = $this->service->linkTenantContractsToPromotionPackages([$promoPackage]);
+
+        $this->assertSame(0, $linked);
+        $this->assertCount(2, $contract->getPackages());
+    }
+
+    public function testLinkTenantContractsForPromotionDelegatesUsingThePromotionsOwnPackages(): void
+    {
+        $promotion = new CommunicationPromotions();
+        $promoPackage = $this->package(1);
+        $regularPackage = $this->package(2);
+
+        $this->packageRepository->expects($this->once())
+            ->method('findByPromotion')
+            ->with($promotion)
+            ->willReturn([$promoPackage]);
+        $this->packageRepository->method('findByDestination')->willReturn($regularPackage);
+
+        $tenant = $this->createMock(Account::class);
+        $contract = $this->contract($regularPackage)->setTenant($tenant);
+        $this->contractRepository->method('findActiveTenantContractsForPackage')->willReturn([$contract]);
+
+        $this->em->expects($this->once())->method('flush');
+
+        $linked = $this->service->linkTenantContractsForPromotion($promotion);
+
+        $this->assertSame(1, $linked);
     }
 }


### PR DESCRIPTION
## Resumen

**Bug encontrado en staging**: la promoción "Prueba" (activa, bien configurada, con bindings de proveedor completos) no aparecía en el catálogo de Comremit Solutions SL pese a que `communications.catalog.version.default = v2` y la cuenta está correctamente en V2.

**Causa raíz**: `PackageCatalogResolver::catalogFor()` da precedencia ABSOLUTA a los contratos propios del tenant (`tenant_id` NOT NULL) — si existen, el catálogo visible es *exactamente* esos paquetes, sin caer nunca a los contratos "por defecto" (`tenant_id IS NULL`) que `CommunicationPromotionService::createV2()` genera para cada promoción. Cualquier cliente con contrato propio (el caso común de un cliente ya onboardeado) nunca veía promociones nuevas.

**Fix** (sin tocar la precedencia protegida de `catalogFor()`/`offerFor()`): `CommunicationContractService::linkTenantContractsToPromotionPackages()` vincula cada paquete de promoción al MISMO contrato que el tenant ya tiene para su paquete regular equivalente (misma tupla monto/moneda) — no crea contratos nuevos, no toca precio/moneda, solo amplía la colección `ManyToMany` ya existente (mismo mecanismo que `upsertContract()` usa para fusionar paquetes con la misma tupla).

- Se ejecuta automáticamente al final de `createV2()` — toda promoción nueva queda visible de inmediato para clientes con contrato propio.
- Queda disponible como acción manual re-ejecutable: `POST /promotions/{id}/v2/tenant-contracts/link` (mismo patrón que el "refrescar equivalencias" existente) — cubre promociones creadas antes de este fix, o clientes que negocian su contrato propio después.

Verificado además en vivo contra una copia local de la BD de staging: tras aplicar el fix a la promoción real, sus 27 paquetes pasaron a aparecer en `/api/communication/packages` para Comremit con `promotions: ["Prueba"]`.

## Test plan
- [x] `tests/Service/Pricing/CommunicationContractServiceTest.php` — nuevos casos unitarios de `linkTenantContractsToPromotionPackages()`/`linkTenantContractsForPromotion()`
- [x] `tests/Functional/Pricing/CommunicationContractRepositoryTest.php` — `findActiveTenantContractsForPackage()` contra Postgres real
- [x] `tests/Functional/Provider/CommunicationPackagesV2SwitchFunctionalTest.php` — regresión end-to-end: tenant con contrato propio SÍ ve una promoción nueva tras `createV2()`
- [x] `tests/Service/CommunicationPromotionServiceV2Test.php`, `tests/Controller/DashboardPromotionControllerTest.php` — actualizados para el nuevo campo/endpoint
- [x] Suite completa: `php bin/phpunit --no-coverage` (1009 tests, verde) + `vendor/bin/phpstan analyse` (sin errores)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019akFNicpzpVzZSjSVqvGRs