### PR TITLE
feat(promotions): descripción detallada V2 + quita precio/ambiente del alta

### DIFF
--- a/src/Controller/DashboardPromotionController.php
+++ b/src/Controller/DashboardPromotionController.php
@@ -142,11 +142,7 @@ class DashboardPromotionController extends AbstractController
                 'destinationAmount' => $p->getDestinationAmount(),
                 'destinationCurrency' => $p->getDestinationCurrency(),
             ], $result->packages),
-            'contracts' => [
-                'created' => $result->contracts->created,
-                'updated' => $result->contracts->updated,
-                'tenantContractsLinked' => $result->tenantContractsLinked,
-            ],
+            'tenantContractsLinked' => $result->tenantContractsLinked,
             'equivalences' => $this->serializeEquivalenceResult($result->equivalences),
         ], Response::HTTP_CREATED);
     }

--- a/src/DTO/CreatePromotionV2Dto.php
+++ b/src/DTO/CreatePromotionV2Dto.php
@@ -14,11 +14,18 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
  * [amountFrom, amountTo] saltando de amountStep en amountStep (ambos
  * extremos incluidos, así que amountFrom == amountTo es válido para una
  * promoción de un solo producto), marcado con esta promoción — catálogo
- * compartido, vigente solo durante [startAt, endAt] — más un
- * CommunicationContract "por defecto" por cada uno, con el precio
- * interpolado linealmente entre priceFrom/priceTo. NO tiene productId: las
- * equivalencias por proveedor se resuelven aparte (Fase 5C/5D) — sin
- * equivalencia explícita, ningún proveedor despacha ese tramo.
+ * compartido, vigente solo durante [startAt, endAt]. NO tiene precio: el
+ * precio vive en CommunicationContract, un concepto aparte que se gestiona
+ * por su propio flujo administrativo (createSingle()/createBatch()/
+ * createByRange() en CommunicationContractService) — createV2() solo se
+ * encarga de generar los paquetes y sus beneficios; sin contrato propio de
+ * un tenant que ya cubra el paquete regular equivalente (ver
+ * linkTenantContractsToPromotionPackages()), el paquete recién creado
+ * queda visible al precio derivado del catálogo (PackageCatalogResolver,
+ * MAX de producto + margen) hasta que se le cree un contrato. Tampoco
+ * tiene productId: las equivalencias por proveedor se resuelven aparte
+ * (Fase 5C/5D) — sin equivalencia explícita, ningún proveedor despacha ese
+ * tramo.
  */
 class CreatePromotionV2Dto implements IInput
 {
@@ -29,6 +36,8 @@ class CreatePromotionV2Dto implements IInput
     #[Assert\NotBlank]
     #[Assert\Length(max: 255)]
     protected ?string $description;
+
+    protected ?string $infoDescription;
 
     #[Assert\NotBlank]
     #[Assert\Length(max: 255)]
@@ -67,18 +76,6 @@ class CreatePromotionV2Dto implements IInput
     #[Assert\Positive]
     protected ?float $amountStep;
 
-    #[Assert\NotNull]
-    #[Assert\PositiveOrZero]
-    protected ?float $priceFrom;
-
-    #[Assert\NotNull]
-    #[Assert\PositiveOrZero]
-    protected ?float $priceTo;
-
-    #[Assert\NotBlank]
-    #[Assert\Length(exactly: 3)]
-    protected ?string $priceCurrency;
-
     #[Assert\PositiveOrZero]
     protected ?int $displayOrder;
 
@@ -99,11 +96,12 @@ class CreatePromotionV2Dto implements IInput
                 // Cálculo en vivo contra la línea base (destinationAmount
                 // para CREDITS/CURRENCY; el beneficio del mismo type/unit
                 // en el paquete regular equivalente para el resto) — ver
-                // CommunicationPackageAdminService::applyBenefitOperations().
-                // Sin operation, amount.base/promotion_bonus se usan tal
-                // cual (comportamiento previo). Con operation, `value` es
-                // obligatorio y amount.base/promotion_bonus se recalculan,
-                // sobrescribiendo lo que se haya enviado.
+                // BenefitOperationResolver. Sin operation, amount.base/
+                // promotion_bonus se usan tal cual (comportamiento previo).
+                // Con operation, `value` es obligatorio y amount.base/
+                // promotion_bonus se recalculan EN VIVO al servir el
+                // catálogo (no al crear), sobrescribiendo lo que se haya
+                // enviado.
                 'operation' => ['type' => 'string', 'nullable' => true, 'enum' => ['MULTIPLY', 'ADD', 'SET']],
                 'value' => ['type' => 'number', 'nullable' => true, 'example' => 6],
                 // Franja horaria diaria de vigencia de este beneficio (uso
@@ -153,6 +151,7 @@ class CreatePromotionV2Dto implements IInput
     public function __construct(
         ?string $name = null,
         ?string $description = null,
+        ?string $infoDescription = null,
         ?string $packageNameTemplate = null,
         ?string $packageDescriptionTemplate = null,
         ?string $knowMore = null,
@@ -163,9 +162,6 @@ class CreatePromotionV2Dto implements IInput
         ?float $amountFrom = null,
         ?float $amountTo = null,
         ?float $amountStep = null,
-        ?float $priceFrom = null,
-        ?float $priceTo = null,
-        ?string $priceCurrency = null,
         ?int $displayOrder = null,
         ?array $benefits = null,
         ?array $tags = null,
@@ -174,6 +170,7 @@ class CreatePromotionV2Dto implements IInput
     ) {
         $this->name = $name;
         $this->description = $description;
+        $this->infoDescription = $infoDescription;
         $this->packageNameTemplate = $packageNameTemplate;
         $this->packageDescriptionTemplate = $packageDescriptionTemplate;
         $this->knowMore = $knowMore;
@@ -184,9 +181,6 @@ class CreatePromotionV2Dto implements IInput
         $this->amountFrom = $amountFrom;
         $this->amountTo = $amountTo;
         $this->amountStep = $amountStep;
-        $this->priceFrom = $priceFrom;
-        $this->priceTo = $priceTo;
-        $this->priceCurrency = $priceCurrency;
         $this->displayOrder = $displayOrder;
         $this->benefits = $benefits;
         $this->tags = $tags;
@@ -266,6 +260,9 @@ class CreatePromotionV2Dto implements IInput
     public function getDescription(): ?string { return $this->description; }
     public function setDescription(?string $v): void { $this->description = $v; }
 
+    public function getInfoDescription(): ?string { return $this->infoDescription; }
+    public function setInfoDescription(?string $v): void { $this->infoDescription = $v; }
+
     public function getPackageNameTemplate(): ?string { return $this->packageNameTemplate; }
     public function setPackageNameTemplate(?string $v): void { $this->packageNameTemplate = $v; }
 
@@ -295,15 +292,6 @@ class CreatePromotionV2Dto implements IInput
 
     public function getAmountStep(): ?float { return $this->amountStep; }
     public function setAmountStep(?float $v): void { $this->amountStep = $v; }
-
-    public function getPriceFrom(): ?float { return $this->priceFrom; }
-    public function setPriceFrom(?float $v): void { $this->priceFrom = $v; }
-
-    public function getPriceTo(): ?float { return $this->priceTo; }
-    public function setPriceTo(?float $v): void { $this->priceTo = $v; }
-
-    public function getPriceCurrency(): ?string { return $this->priceCurrency; }
-    public function setPriceCurrency(?string $v): void { $this->priceCurrency = $v; }
 
     public function getDisplayOrder(): ?int { return $this->displayOrder; }
     public function setDisplayOrder(?int $v): void { $this->displayOrder = $v; }

--- a/src/Service/CommunicationPromotionService.php
+++ b/src/Service/CommunicationPromotionService.php
@@ -409,11 +409,20 @@ class CommunicationPromotionService extends CommonService
      * Alta de promoción V2 (Fase 5B, catálogo compartido) — genera un
      * CommunicationPackage por cada monto de [amountFrom, amountTo] (paso
      * amountStep), marcado con esta promoción y vigente SOLO durante
-     * [startAt, endAt], más un CommunicationContract "por defecto" por
-     * cada uno con el precio interpolado entre priceFrom/priceTo. A
-     * diferencia de createPackagesForPromotion() (legacy), no depende de
-     * un producto de origen ni genera nada por cliente — la visibilidad la
-     * decide PackageCatalogResolver como a cualquier paquete V2.
+     * [startAt, endAt]. A diferencia de createPackagesForPromotion()
+     * (legacy), no depende de un producto de origen ni genera nada por
+     * cliente — la visibilidad la decide PackageCatalogResolver como a
+     * cualquier paquete V2.
+     *
+     * NO crea contrato: el precio es responsabilidad exclusiva del flujo
+     * de CommunicationContract (aparte, ver CommunicationContractService)
+     * — createV2() solo vincula los contratos propios que un tenant YA
+     * tenga sobre el paquete regular equivalente (linkTenantContracts
+     * ToPromotionPackages()), para que la promoción no quede oculta para
+     * quien ya compraba ese paquete (ver PackageCatalogResolver::
+     * catalogFor()). Un paquete sin ningún contrato propio vinculado
+     * queda visible igual, al precio derivado del catálogo (MAX de
+     * producto + margen), hasta que se le cree un contrato a mano.
      *
      * Las equivalencias por proveedor (quién despacha cada tramo) se
      * auto-pueblan al final vía CommunicationPromotionEquivalenceService
@@ -449,6 +458,9 @@ class CommunicationPromotionService extends CommonService
         if ($dto->getKnowMore() !== null) {
             $promotion->setKnowMore($dto->getKnowMore());
         }
+        if ($dto->getInfoDescription() !== null) {
+            $promotion->setInfoDescription($dto->getInfoDescription());
+        }
 
         $this->em->persist($promotion);
         $this->em->flush();
@@ -478,19 +490,10 @@ class CommunicationPromotionService extends CommonService
         }
         $this->em->flush();
 
-        $contractResult = $this->contractService->createForPromotionPackages(
-            $packages,
-            (float) $dto->getPriceFrom(),
-            (float) $dto->getPriceTo(),
-            (string) $dto->getPriceCurrency(),
-            $dto->getStartAt(),
-            $dto->getEndAt(),
-        );
-
         $tenantContractsLinked = $this->contractService->linkTenantContractsToPromotionPackages($packages);
 
         $equivalences = $this->equivalenceService->populateEquivalences($promotion, $packages);
 
-        return new CreatePromotionV2Result($promotion, $packages, $contractResult, $tenantContractsLinked, $equivalences);
+        return new CreatePromotionV2Result($promotion, $packages, $tenantContractsLinked, $equivalences);
     }
 }

--- a/src/Service/CreatePromotionV2Result.php
+++ b/src/Service/CreatePromotionV2Result.php
@@ -4,15 +4,14 @@ namespace App\Service;
 
 use App\Entity\CommunicationPackage;
 use App\Entity\CommunicationPromotions;
-use App\Service\Pricing\ContractRangeResult;
 use App\Service\Pricing\PromotionEquivalenceResult;
 
 /**
  * Resultado de CommunicationPromotionService::createV2() — la promoción,
  * los CommunicationPackage generados por rango (todos marcados con esta
- * promoción), el resultado de los CommunicationContract "por defecto"
- * creados para ellos, cuántos contratos propios de tenants existentes se
- * vincularon a esos paquetes (ver CommunicationContractService::
+ * promoción, SIN contrato/precio propio — eso es responsabilidad aparte
+ * de CommunicationContractService), cuántos contratos propios de tenants
+ * existentes se vincularon a esos paquetes (ver CommunicationContractService::
  * linkTenantContractsToPromotionPackages()), y el reporte del
  * auto-poblado de equivalencias por proveedor (Fase 5D) — qué
  * proveedores cubrieron cuántos tramos, y qué huecos quedaron (ver
@@ -26,7 +25,6 @@ final readonly class CreatePromotionV2Result
     public function __construct(
         public CommunicationPromotions $promotion,
         public array $packages,
-        public ContractRangeResult $contracts,
         public int $tenantContractsLinked,
         public PromotionEquivalenceResult $equivalences,
     ) {

--- a/src/Service/Pricing/CommunicationContractService.php
+++ b/src/Service/Pricing/CommunicationContractService.php
@@ -169,69 +169,15 @@ class CommunicationContractService
     }
 
     /**
-     * Variante de createByRange() para promociones V2 (Fase 5B): en vez de
-     * resolver cada paquete por (monto, moneda) contra el catálogo regular
-     * (findByDestination() excluye a propósito los paquetes promocionales,
-     * ver su docblock), recibe DIRECTAMENTE la lista ya generada por
-     * CommunicationPackageAdminService::createBatch() — un contrato "por
-     * defecto" (tenant=null, catálogo compartido) por cada paquete, con el
-     * precio interpolado linealmente entre priceFrom (el de menor
-     * destinationAmount) y priceTo (el de mayor).
-     *
-     * @param list<CommunicationPackage> $packages
-     */
-    public function createForPromotionPackages(
-        array $packages,
-        float $priceFrom,
-        float $priceTo,
-        string $currency,
-        ?string $startAt,
-        ?string $endAt,
-    ): ContractRangeResult {
-        if ($packages === []) {
-            return new ContractRangeResult(0, 0, 0, [], []);
-        }
-
-        $amounts = array_map(static fn (CommunicationPackage $p) => (float) $p->getDestinationAmount(), $packages);
-        $from = min($amounts);
-        $to = max($amounts);
-        $span = $to - $from;
-        $priceCurrency = strtoupper($currency);
-
-        $created = 0;
-        $updated = 0;
-        $contracts = [];
-
-        foreach ($packages as $package) {
-            $amount = (float) $package->getDestinationAmount();
-            $price = $span > 0
-                ? round($priceFrom + ($priceTo - $priceFrom) * ($amount - $from) / $span, 2)
-                : round($priceFrom, 2);
-
-            $result = $this->upsertContract($package, null);
-            $this->applyPricing($result->contract, $price, $priceCurrency, $startAt, $endAt, $result->contractIsNew);
-            $this->stampCreatedBy($result->contract);
-
-            $result->isNew ? $created++ : $updated++;
-            $contracts[] = $result->contract;
-        }
-
-        $this->em->flush();
-
-        $contractIds = array_map(static fn (CommunicationContract $c) => $c->getId(), $contracts);
-
-        return new ContractRangeResult($created, $updated, 0, $contractIds, []);
-    }
-
-    /**
      * Vincula, a cada paquete de promoción recién creado, los contratos
      * propios que un tenant YA tenga sobre su paquete regular equivalente
      * (misma tupla monto/moneda, sin promoción) — sin esto, un cliente con
      * contrato propio nunca ve la promoción: PackageCatalogResolver::
      * catalogFor() solo mira los contratos propios del tenant cuando
-     * existen (precedencia #1), y los contratos "por defecto" (tenant IS
-     * NULL) que createForPromotionPackages() genera quedan fuera de esa
-     * rama por completo.
+     * existen (precedencia #1), y un paquete de promoción sin contrato
+     * propio vinculado queda fuera de esa rama por completo (createV2()
+     * ya no crea contrato alguno — el precio es responsabilidad aparte de
+     * este servicio, ver createSingle()/createBatch()/createByRange()).
      *
      * No crea contratos nuevos ni toca precio/moneda/fechas: reutiliza el
      * MISMO contrato que el tenant ya tiene para el paquete regular (misma
@@ -294,8 +240,8 @@ class CommunicationContractService
      * mueve su colección de `CommunicationPackage` (los paquetes que ya
      * cubría siguen ahí, aunque ahora el contrato diga otro monto). Para
      * "mover" paquetes de un contrato a otro, usar los flujos de creación
-     * (createSingle/createBatch/createByRange/createForPromotionPackages) —
-     * convergen solos al contrato correcto vía upsertContract().
+     * (createSingle/createBatch/createByRange) — convergen solos al
+     * contrato correcto vía upsertContract().
      *
      * @throws MyCurrentException si ya existe OTRO contrato abierto para la
      *   tupla (tenant, nuevo monto, nueva moneda)

--- a/tests/Controller/DashboardPromotionControllerTest.php
+++ b/tests/Controller/DashboardPromotionControllerTest.php
@@ -16,7 +16,6 @@ use App\Service\CreatePromotionV2Result;
 use App\Service\Pricing\CommunicationContractService;
 use App\Service\Pricing\CommunicationPromotionBindingService;
 use App\Service\Pricing\CommunicationPromotionEquivalenceService;
-use App\Service\Pricing\ContractRangeResult;
 use App\Service\Pricing\PromotionEquivalenceResult;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -179,9 +178,6 @@ class DashboardPromotionControllerTest extends TestCase
             amountFrom: 500.0,
             amountTo: 525.0,
             amountStep: 25.0,
-            priceFrom: 19.7,
-            priceTo: 20.71,
-            priceCurrency: 'USD',
         );
     }
 
@@ -196,7 +192,7 @@ class DashboardPromotionControllerTest extends TestCase
             [['provider' => 'DTONE', 'matched' => 2, 'error' => null]],
             [],
         );
-        $result = new CreatePromotionV2Result($promotion, $packages, new ContractRangeResult(2, 0, 0, [1, 2], []), 3, $equivalences);
+        $result = new CreatePromotionV2Result($promotion, $packages, 3, $equivalences);
         $this->promotionService->expects($this->once())->method('createV2')->willReturn($result);
 
         $response = $this->controller->createV2($this->v2Dto());
@@ -206,8 +202,7 @@ class DashboardPromotionControllerTest extends TestCase
         $this->assertSame(2, $data['packagesCreated']);
         $this->assertCount(2, $data['packages']);
         $this->assertEquals(500.0, $data['packages'][0]['destinationAmount']);
-        $this->assertSame(2, $data['contracts']['created']);
-        $this->assertSame(3, $data['contracts']['tenantContractsLinked']);
+        $this->assertSame(3, $data['tenantContractsLinked']);
         $this->assertSame('DTONE', $data['equivalences']['providers'][0]['provider']);
         $this->assertSame([], $data['equivalences']['gaps']);
     }

--- a/tests/DTO/CreatePromotionV2DtoTest.php
+++ b/tests/DTO/CreatePromotionV2DtoTest.php
@@ -40,9 +40,6 @@ class CreatePromotionV2DtoTest extends TestCase
             amountFrom: 500.0,
             amountTo: 500.0,
             amountStep: 1.0,
-            priceFrom: 10.0,
-            priceTo: 10.0,
-            priceCurrency: 'USD',
             benefits: $benefits,
         );
     }

--- a/tests/Functional/Provider/CommunicationPackagesV2SwitchFunctionalTest.php
+++ b/tests/Functional/Provider/CommunicationPackagesV2SwitchFunctionalTest.php
@@ -391,9 +391,6 @@ class CommunicationPackagesV2SwitchFunctionalTest extends ProviderFunctionalTest
             amountFrom: (float) $regularPackage->getDestinationAmount(),
             amountTo: (float) $regularPackage->getDestinationAmount(),
             amountStep: 1.0,
-            priceFrom: 25.0,
-            priceTo: 25.0,
-            priceCurrency: 'USD',
         );
 
         $result = $promotionService->createV2($dto);
@@ -437,9 +434,6 @@ class CommunicationPackagesV2SwitchFunctionalTest extends ProviderFunctionalTest
             amountFrom: 600.0,
             amountTo: 600.0,
             amountStep: 1.0,
-            priceFrom: 25.0,
-            priceTo: 25.0,
-            priceCurrency: 'USD',
             benefits: [[
                 'type' => 'CREDITS',
                 'unit' => 'CUP',
@@ -453,6 +447,10 @@ class CommunicationPackagesV2SwitchFunctionalTest extends ProviderFunctionalTest
         $promotionService = self::getContainer()->get(CommunicationPromotionService::class);
         $result = $promotionService->createV2($dto);
         $promoPackage = $result->packages[0];
+        // createV2() ya NO crea contrato (el precio es responsabilidad
+        // aparte de CommunicationContractService) — sin uno, el paquete
+        // no sería visible para este tenant sin contratos propios.
+        $this->defaultContractFor($promoPackage, 25.0);
         $this->bindProvider($promoPackage, $environment);
         $this->em->flush();
 
@@ -489,7 +487,7 @@ class CommunicationPackagesV2SwitchFunctionalTest extends ProviderFunctionalTest
             'type' => 'DATA', 'unit' => 'GB', 'unit_type' => 'DATA',
             'amount' => ['base' => 5, 'promotion_bonus' => 0, 'total_excluding_tax' => 5, 'total_including_tax' => 5],
         ]]);
-        $this->defaultContractFor($regularPackage, 10.0, new \DateTimeImmutable('-30 days'));
+        $regularContract = $this->defaultContractFor($regularPackage, 10.0, new \DateTimeImmutable('-30 days'));
         $this->bindProvider($regularPackage, $environment);
         $this->em->flush();
 
@@ -505,9 +503,6 @@ class CommunicationPackagesV2SwitchFunctionalTest extends ProviderFunctionalTest
             amountFrom: 600.0,
             amountTo: 600.0,
             amountStep: 1.0,
-            priceFrom: 25.0,
-            priceTo: 25.0,
-            priceCurrency: 'USD',
             benefits: [[
                 'type' => 'DATA',
                 'unit' => 'GB',
@@ -521,6 +516,10 @@ class CommunicationPackagesV2SwitchFunctionalTest extends ProviderFunctionalTest
         $promotionService = self::getContainer()->get(CommunicationPromotionService::class);
         $result = $promotionService->createV2($dto);
         $promoPackage = $result->packages[0];
+        // createV2() ya NO crea/extiende contrato — antes de este rediseño,
+        // el mismo tuple (600 CUP) hacía que se fusionara solo en el
+        // contrato "por defecto" de arriba; ahora es un paso manual aparte.
+        $regularContract->addPackage($promoPackage);
         $this->bindProvider($promoPackage, $environment);
         $this->em->flush();
 

--- a/tests/Service/CommunicationPromotionServiceV2Test.php
+++ b/tests/Service/CommunicationPromotionServiceV2Test.php
@@ -13,7 +13,6 @@ use App\Service\CommunicationPromotionService;
 use App\Service\Pricing\CommunicationContractService;
 use App\Service\Pricing\CommunicationPackageAdminService;
 use App\Service\Pricing\CommunicationPromotionEquivalenceService;
-use App\Service\Pricing\ContractRangeResult;
 use App\Service\Pricing\PromotionEquivalenceResult;
 use App\Service\Pricing\TargetAccountResolver;
 use Doctrine\ORM\EntityManagerInterface;
@@ -82,9 +81,6 @@ class CommunicationPromotionServiceV2Test extends TestCase
             amountFrom: 500.0,
             amountTo: 1250.0,
             amountStep: 25.0,
-            priceFrom: 19.7,
-            priceTo: 49.25,
-            priceCurrency: 'USD',
         );
     }
 
@@ -122,12 +118,6 @@ class CommunicationPromotionServiceV2Test extends TestCase
             }))
             ->willReturn($packages);
 
-        $contractResult = new ContractRangeResult(2, 0, 0, [10, 11], []);
-        $this->contractService->expects($this->once())
-            ->method('createForPromotionPackages')
-            ->with($packages, 19.7, 49.25, 'USD', '2026-08-18T00:00:00+00:00', '2026-08-25T23:59:00+00:00')
-            ->willReturn($contractResult);
-
         $this->contractService->expects($this->once())
             ->method('linkTenantContractsToPromotionPackages')
             ->with($packages)
@@ -142,7 +132,6 @@ class CommunicationPromotionServiceV2Test extends TestCase
         $result = $this->service->createV2($this->dto());
 
         $this->assertSame($packages, $result->packages);
-        $this->assertSame($contractResult, $result->contracts);
         $this->assertSame(3, $result->tenantContractsLinked);
         $this->assertSame($equivalencesResult, $result->equivalences);
         foreach ($result->packages as $package) {
@@ -162,7 +151,6 @@ class CommunicationPromotionServiceV2Test extends TestCase
         $single = [(new CommunicationPackage())->setName('p')->setDescription('p')->setDestinationAmount(500.0)->setDestinationCurrency('CUP')];
 
         $this->packageAdminService->method('createBatch')->willReturn($single);
-        $this->contractService->method('createForPromotionPackages')->willReturn(new ContractRangeResult(1, 0, 0, [1], []));
         $this->contractService->method('linkTenantContractsToPromotionPackages')->willReturn(0);
         $this->equivalenceService->method('populateEquivalences')->willReturn(new PromotionEquivalenceResult([], []));
 
@@ -178,13 +166,59 @@ class CommunicationPromotionServiceV2Test extends TestCase
             amountFrom: 500.0,
             amountTo: 500.0,
             amountStep: 1.0,
-            priceFrom: 19.7,
-            priceTo: 19.7,
-            priceCurrency: 'USD',
         );
 
         $result = $this->service->createV2($dto);
 
         $this->assertCount(1, $result->packages);
+    }
+
+    public function testSetsInfoDescriptionWhenProvided(): void
+    {
+        $environment = $this->createMock(Environment::class);
+        $envRepo = $this->createMock(EntityRepository::class);
+        $envRepo->method('find')->willReturn($environment);
+        $this->em->method('getRepository')->with(Environment::class)->willReturn($envRepo);
+
+        $single = [(new CommunicationPackage())->setName('p')->setDescription('p')->setDestinationAmount(500.0)->setDestinationCurrency('CUP')];
+        $this->packageAdminService->method('createBatch')->willReturn($single);
+        $this->contractService->method('linkTenantContractsToPromotionPackages')->willReturn(0);
+        $this->equivalenceService->method('populateEquivalences')->willReturn(new PromotionEquivalenceResult([], []));
+
+        $dto = new CreatePromotionV2Dto(
+            name: 'Con detalle',
+            description: 'Con detalle',
+            infoDescription: '<p>Detalle completo de la promoción</p>',
+            packageNameTemplate: 'Bono {monto} CUP',
+            packageDescriptionTemplate: 'Bono {monto} CUP',
+            startAt: '2026-08-18T00:00:00+00:00',
+            endAt: '2026-08-25T23:59:00+00:00',
+            environmentId: 4,
+            destinationCurrency: 'CUP',
+            amountFrom: 500.0,
+            amountTo: 500.0,
+            amountStep: 1.0,
+        );
+
+        $result = $this->service->createV2($dto);
+
+        $this->assertSame('<p>Detalle completo de la promoción</p>', $result->promotion->getInfoDescription());
+    }
+
+    public function testInfoDescriptionStaysNullWhenNotProvided(): void
+    {
+        $environment = $this->createMock(Environment::class);
+        $envRepo = $this->createMock(EntityRepository::class);
+        $envRepo->method('find')->willReturn($environment);
+        $this->em->method('getRepository')->with(Environment::class)->willReturn($envRepo);
+
+        $single = [(new CommunicationPackage())->setName('p')->setDescription('p')->setDestinationAmount(500.0)->setDestinationCurrency('CUP')];
+        $this->packageAdminService->method('createBatch')->willReturn($single);
+        $this->contractService->method('linkTenantContractsToPromotionPackages')->willReturn(0);
+        $this->equivalenceService->method('populateEquivalences')->willReturn(new PromotionEquivalenceResult([], []));
+
+        $result = $this->service->createV2($this->dto());
+
+        $this->assertNull($result->promotion->getInfoDescription());
     }
 }


### PR DESCRIPTION
## Resumen

Tres cambios pedidos tras revisión del formulario de promoción V2:

1. **Descripción detallada**: `CreatePromotionV2Dto`/`createV2()` ganan `infoDescription` — el campo ya existía en la entidad (`CommunicationPromotions::$infoDescription`, usado en V1) pero nunca estaba conectado al flujo V2.
2. **Sin precio en la creación**: se elimina `priceFrom`/`priceTo`/`priceCurrency` de `CreatePromotionV2Dto` — el precio es responsabilidad de `CommunicationContract`, gestionado aparte (`createSingle`/`createBatch`/`createByRange`), no de `createV2()`. Se elimina `CommunicationContractService::createForPromotionPackages()` (quedó sin ningún llamador tras el cambio). Un paquete nuevo sin contrato propio de tenant vinculado (la feature de `linkTenantContractsToPromotionPackages()` del PR #104 sigue funcionando igual) queda visible al precio derivado del catálogo hasta que se le cree contrato a mano.
3. **Sin ambiente manual**: el dashboard ya toma el ambiente del selector activo de la barra lateral, sin pedirlo en el formulario (ver PR hermano en dashboard-cm).

## Test plan
- [x] Tests actualizados (DTO, servicio, controlador, funcional end-to-end) — se quitaron referencias a precio/`ContractRangeResult` y se agregó cobertura de `infoDescription`
- [x] Suite completa: `php bin/phpunit --no-coverage` (1026 tests, verde) + `vendor/bin/phpstan analyse` (sin errores)
- [x] Verificado en vivo vía UI: promoción real creada con `environment_id`/`info_description` correctos, sin precio ni ambiente manual

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019akFNicpzpVzZSjSVqvGRs