### PR TITLE
feat(catalog): pagina, filtra por precio y ordena el catálogo V2

### DIFF
--- a/src/Entity/CommunicationPackage.php
+++ b/src/Entity/CommunicationPackage.php
@@ -6,6 +6,8 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\OpenApi\Model\Operation as OpenApiOperation;
+use ApiPlatform\OpenApi\Model\Parameter as OpenApiParameter;
 use App\Repository\CommunicationPackageRepository;
 use App\Service\Pricing\ResolvedPackageOffer;
 use App\State\CommunicationPackageCatalogItemProvider;
@@ -58,11 +60,33 @@ use Symfony\Component\Serializer\Attribute\Groups;
             description: 'Catálogo agnóstico de proveedor (V2) resuelto para el cliente autenticado',
             name: 'CommunicationPackageCatalog',
             provider: CommunicationPackageCatalogProvider::class,
-            paginationEnabled: false,
+            openapi: new OpenApiOperation(
+                parameters: [
+                    new OpenApiParameter(
+                        name: 'orderBy[price]',
+                        in: 'query',
+                        description: 'Ordena por el precio resuelto para el cliente autenticado. Sin este parámetro, se ordena por id ascendente.',
+                        schema: ['type' => 'string', 'enum' => ['asc', 'desc']],
+                    ),
+                    new OpenApiParameter(
+                        name: 'price[gte]',
+                        in: 'query',
+                        description: 'Precio mínimo (inclusive).',
+                        schema: ['type' => 'number'],
+                    ),
+                    new OpenApiParameter(
+                        name: 'price[lte]',
+                        in: 'query',
+                        description: 'Precio máximo (inclusive).',
+                        schema: ['type' => 'number'],
+                    ),
+                ],
+            ),
         ),
     ],
     normalizationContext: ['groups' => ['comPackage:read']],
     security: "is_granted('ROLE_COM_API_USER')",
+    paginationMaximumItemsPerPage: 100,
 )]
 class CommunicationPackage
 {

--- a/src/State/CommunicationPackageCatalogProvider.php
+++ b/src/State/CommunicationPackageCatalogProvider.php
@@ -3,6 +3,7 @@
 namespace App\State;
 
 use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\Pagination\ArrayPaginator;
 use ApiPlatform\State\ProviderInterface;
 use App\Entity\Account;
 use App\Entity\CommunicationPackage;
@@ -11,14 +12,19 @@ use App\Service\Pricing\BenefitOperationResolver;
 use App\Service\Pricing\PackageCatalogResolver;
 use App\Service\Pricing\ResolvedPackageOffer;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Catálogo agnóstico de proveedor (V2) para la app móvil — a diferencia de
  * CommunicationClientPackageProvider (V1), no delega en el provider Doctrine
  * estándar: PackageCatalogResolver::catalogFor() YA decide el conjunto
- * completo de paquetes visibles (no solo su precio), así que no hay nada
- * que "filtrar después" — de ahí que CurrentUserExtension no necesite
- * intervenir en esta operación en absoluto.
+ * completo de paquetes visibles (no solo su precio) — de ahí que
+ * CurrentUserExtension no necesite intervenir en esta operación en
+ * absoluto. Justo por eso, filtro por precio (`price[gte]`/`price[lte]`),
+ * orden (`orderBy[price]`, por defecto id ascendente) y paginación se
+ * aplican A MANO al final de provide() — ninguna extensión estándar de API
+ * Platform (que solo se activa sobre el provider Doctrine) llega a
+ * intervenir aquí.
  *
  * Excepción: un paquete SIN ningún vínculo explícito paquete→producto
  * (CommunicationPackageProviderProduct) no se muestra aquí, aunque
@@ -48,9 +54,9 @@ final class CommunicationPackageCatalogProvider implements ProviderInterface
     }
 
     /**
-     * @return list<CommunicationPackage>
+     * @return iterable<CommunicationPackage>
      */
-    public function provide(Operation $operation, array $uriVariables = [], array $context = []): array
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): iterable
     {
         $tenant = $this->security->getUser();
         if (!$tenant instanceof Account) {
@@ -79,6 +85,112 @@ final class CommunicationPackageCatalogProvider implements ProviderInterface
             $package->setBenefits($this->benefitResolver->resolve($package));
         }
 
-        return $visible;
+        /** @var Request|null $request */
+        $request = $context['request'] ?? null;
+
+        $visible = $this->filterByPriceRange($visible, $request);
+        $visible = $this->sort($visible, $request);
+
+        return $this->paginate($visible, $operation, $request);
+    }
+
+    /**
+     * `price[gte]`/`price[lte]` — el precio es resuelto por
+     * PackageCatalogResolver (no una columna real), así que este filtro se
+     * aplica a mano sobre el array ya visible, no vía #[ApiFilter] (que
+     * necesitaría una columna Doctrine real para generar SQL).
+     *
+     * @param list<CommunicationPackage> $packages
+     * @return list<CommunicationPackage>
+     */
+    private function filterByPriceRange(array $packages, ?Request $request): array
+    {
+        if ($request === null) {
+            return $packages;
+        }
+
+        $priceParams = $request->query->all('price');
+        $gte = isset($priceParams['gte']) && is_numeric($priceParams['gte']) ? (float) $priceParams['gte'] : null;
+        $lte = isset($priceParams['lte']) && is_numeric($priceParams['lte']) ? (float) $priceParams['lte'] : null;
+
+        if ($gte === null && $lte === null) {
+            return $packages;
+        }
+
+        return array_values(array_filter($packages, static function (CommunicationPackage $p) use ($gte, $lte): bool {
+            $price = $p->getAmount();
+            if ($price === null) {
+                return false;
+            }
+            if ($gte !== null && $price < $gte) {
+                return false;
+            }
+
+            return !($lte !== null && $price > $lte);
+        }));
+    }
+
+    /**
+     * `orderBy[price]=asc|desc` — sin este parámetro (o con cualquier otro
+     * valor), se ordena por id ascendente, mismo criterio por defecto que
+     * findActiveCatalog()/findUpcoming() en CommunicationPackageRepository.
+     *
+     * @param list<CommunicationPackage> $packages
+     * @return list<CommunicationPackage>
+     */
+    private function sort(array $packages, ?Request $request): array
+    {
+        $orderBy = $request?->query->all('orderBy') ?? [];
+        $priceDirection = isset($orderBy['price']) && strtoupper((string) $orderBy['price']) === 'DESC' ? 'DESC' : null;
+
+        if (isset($orderBy['price'])) {
+            usort($packages, static function (CommunicationPackage $a, CommunicationPackage $b) use ($priceDirection): int {
+                $cmp = ($a->getAmount() ?? 0.0) <=> ($b->getAmount() ?? 0.0);
+
+                return $priceDirection === 'DESC' ? -$cmp : $cmp;
+            });
+
+            return $packages;
+        }
+
+        usort($packages, static fn (CommunicationPackage $a, CommunicationPackage $b): int => ($a->getId() ?? 0) <=> ($b->getId() ?? 0));
+
+        return $packages;
+    }
+
+    /**
+     * Réplica manual de la paginación estándar de API Platform — este
+     * provider bypasea el provider Doctrine (ver docblock de clase), así
+     * que la extensión de paginación de la Query nunca llega a intervenir;
+     * hay que envolver el resultado en ArrayPaginator (la misma clase que
+     * usa el core) para que la colección salga con metadata Hydra
+     * (hydra:view, totalItems) igual que cualquier otro endpoint paginado.
+     *
+     * @param list<CommunicationPackage> $packages
+     */
+    private function paginate(array $packages, Operation $operation, ?Request $request): iterable
+    {
+        if ($operation->getPaginationEnabled() === false || $request === null) {
+            return $packages;
+        }
+
+        $itemsPerPage = $operation->getPaginationItemsPerPage() ?? 20;
+        if ($operation->getPaginationClientItemsPerPage() === true) {
+            $requested = $request->query->get('itemsPerPage');
+            if (is_numeric($requested)) {
+                $itemsPerPage = (int) $requested;
+            }
+        }
+
+        $maxItemsPerPage = $operation->getPaginationMaximumItemsPerPage();
+        if ($maxItemsPerPage !== null) {
+            $itemsPerPage = min($itemsPerPage, $maxItemsPerPage);
+        }
+        $itemsPerPage = max(1, $itemsPerPage);
+
+        $page = max(1, (int) $request->query->get('page', 1));
+        $firstResult = ($page - 1) * $itemsPerPage;
+
+        return new ArrayPaginator($packages, $firstResult, $itemsPerPage);
     }
 }

--- a/tests/State/CommunicationPackageCatalogProviderTest.php
+++ b/tests/State/CommunicationPackageCatalogProviderTest.php
@@ -3,6 +3,7 @@
 namespace App\Tests\State;
 
 use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\State\Pagination\ArrayPaginator;
 use App\Entity\Account;
 use App\Entity\CommunicationPackage;
 use App\Entity\User;
@@ -15,6 +16,7 @@ use App\State\CommunicationPackageCatalogProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @covers \App\State\CommunicationPackageCatalogProvider
@@ -46,6 +48,25 @@ class CommunicationPackageCatalogProviderTest extends TestCase
         $property->setValue($package, $id);
 
         return $package;
+    }
+
+    /**
+     * ResolvedPackageOffer no setea resolvedOffer en el paquete por sí solo
+     * (lo hace PackageCatalogResolver::catalogFor() de verdad, mockeado
+     * aquí) — sin esto, getAmount() devolvería null y el filtro/orden por
+     * precio no tendría nada que comparar.
+     */
+    private function offer(CommunicationPackage $package, float $price): ResolvedPackageOffer
+    {
+        $offer = new ResolvedPackageOffer($package, $price, 'USD', PackageOfferSourceEnum::PRODUCT_MAX);
+        $package->setResolvedOffer($offer);
+
+        return $offer;
+    }
+
+    private function requestContext(array $query): array
+    {
+        return ['request' => new Request($query)];
     }
 
     public function testReturnsEmptyArrayWhenCurrentUserIsNotAnAccount(): void
@@ -127,5 +148,131 @@ class CommunicationPackageCatalogProviderTest extends TestCase
         $result = $this->provider->provide(new GetCollection());
 
         $this->assertSame([$active], $result);
+    }
+
+    public function testWithoutRequestInContextReturnsAPlainArraySortedById(): void
+    {
+        $account = $this->createMock(Account::class);
+        $this->security->method('getUser')->willReturn($account);
+
+        $p2 = $this->packageWithId(2, 'B');
+        $p1 = $this->packageWithId(1, 'A');
+        $this->catalogResolver->method('catalogFor')->willReturn([$this->offer($p2, 20.0), $this->offer($p1, 10.0)]);
+        $this->bindingRepo->method('findPackageIdsWithBindings')->willReturn([1, 2]);
+
+        $result = $this->provider->provide(new GetCollection());
+
+        $this->assertSame([$p1, $p2], $result);
+    }
+
+    public function testFiltersOutPackagesBelowTheMinimumPrice(): void
+    {
+        $account = $this->createMock(Account::class);
+        $this->security->method('getUser')->willReturn($account);
+
+        $cheap = $this->packageWithId(1, 'Cheap');
+        $expensive = $this->packageWithId(2, 'Expensive');
+        $this->catalogResolver->method('catalogFor')->willReturn([$this->offer($cheap, 10.0), $this->offer($expensive, 50.0)]);
+        $this->bindingRepo->method('findPackageIdsWithBindings')->willReturn([1, 2]);
+
+        $result = iterator_to_array($this->provider->provide(new GetCollection(), context: $this->requestContext(['price' => ['gte' => '20']])));
+
+        $this->assertSame([$expensive], array_values($result));
+    }
+
+    public function testFiltersOutPackagesAboveTheMaximumPrice(): void
+    {
+        $account = $this->createMock(Account::class);
+        $this->security->method('getUser')->willReturn($account);
+
+        $cheap = $this->packageWithId(1, 'Cheap');
+        $expensive = $this->packageWithId(2, 'Expensive');
+        $this->catalogResolver->method('catalogFor')->willReturn([$this->offer($cheap, 10.0), $this->offer($expensive, 50.0)]);
+        $this->bindingRepo->method('findPackageIdsWithBindings')->willReturn([1, 2]);
+
+        $result = iterator_to_array($this->provider->provide(new GetCollection(), context: $this->requestContext(['price' => ['lte' => '20']])));
+
+        $this->assertSame([$cheap], array_values($result));
+    }
+
+    public function testOrdersByPriceAscendingWhenRequested(): void
+    {
+        $account = $this->createMock(Account::class);
+        $this->security->method('getUser')->willReturn($account);
+
+        $expensive = $this->packageWithId(1, 'Expensive');
+        $cheap = $this->packageWithId(2, 'Cheap');
+        $this->catalogResolver->method('catalogFor')->willReturn([$this->offer($expensive, 50.0), $this->offer($cheap, 10.0)]);
+        $this->bindingRepo->method('findPackageIdsWithBindings')->willReturn([1, 2]);
+
+        $result = iterator_to_array($this->provider->provide(new GetCollection(), context: $this->requestContext(['orderBy' => ['price' => 'asc']])));
+
+        $this->assertSame([$cheap, $expensive], array_values($result));
+    }
+
+    public function testOrdersByPriceDescendingWhenRequested(): void
+    {
+        $account = $this->createMock(Account::class);
+        $this->security->method('getUser')->willReturn($account);
+
+        $expensive = $this->packageWithId(1, 'Expensive');
+        $cheap = $this->packageWithId(2, 'Cheap');
+        $this->catalogResolver->method('catalogFor')->willReturn([$this->offer($cheap, 10.0), $this->offer($expensive, 50.0)]);
+        $this->bindingRepo->method('findPackageIdsWithBindings')->willReturn([1, 2]);
+
+        $result = iterator_to_array($this->provider->provide(new GetCollection(), context: $this->requestContext(['orderBy' => ['price' => 'desc']])));
+
+        $this->assertSame([$expensive, $cheap], array_values($result));
+    }
+
+    public function testWithoutOrderByDefaultsToOrderingByIdAscendingEvenWithARequestPresent(): void
+    {
+        $account = $this->createMock(Account::class);
+        $this->security->method('getUser')->willReturn($account);
+
+        $p3 = $this->packageWithId(3, 'C');
+        $p1 = $this->packageWithId(1, 'A');
+        $p2 = $this->packageWithId(2, 'B');
+        $this->catalogResolver->method('catalogFor')->willReturn([$this->offer($p3, 5.0), $this->offer($p1, 50.0), $this->offer($p2, 30.0)]);
+        $this->bindingRepo->method('findPackageIdsWithBindings')->willReturn([1, 2, 3]);
+
+        $result = iterator_to_array($this->provider->provide(new GetCollection(), context: $this->requestContext([])));
+
+        $this->assertSame([$p1, $p2, $p3], array_values($result));
+    }
+
+    public function testPaginatesUsingPageAndItemsPerPage(): void
+    {
+        $account = $this->createMock(Account::class);
+        $this->security->method('getUser')->willReturn($account);
+
+        $packages = [$this->packageWithId(1, 'A'), $this->packageWithId(2, 'B'), $this->packageWithId(3, 'C')];
+        $offers = array_map(fn (CommunicationPackage $p) => $this->offer($p, 10.0), $packages);
+        $this->catalogResolver->method('catalogFor')->willReturn($offers);
+        $this->bindingRepo->method('findPackageIdsWithBindings')->willReturn([1, 2, 3]);
+
+        $operation = (new GetCollection())->withPaginationItemsPerPage(2)->withPaginationClientItemsPerPage(true);
+        $result = $this->provider->provide($operation, context: $this->requestContext(['page' => '2']));
+
+        $this->assertInstanceOf(ArrayPaginator::class, $result);
+        $this->assertSame(3.0, $result->getTotalItems());
+        $this->assertSame([$packages[2]], array_values(iterator_to_array($result)));
+    }
+
+    public function testPaginationClampsItemsPerPageToTheDeclaredMaximum(): void
+    {
+        $account = $this->createMock(Account::class);
+        $this->security->method('getUser')->willReturn($account);
+
+        $packages = [$this->packageWithId(1, 'A'), $this->packageWithId(2, 'B'), $this->packageWithId(3, 'C')];
+        $offers = array_map(fn (CommunicationPackage $p) => $this->offer($p, 10.0), $packages);
+        $this->catalogResolver->method('catalogFor')->willReturn($offers);
+        $this->bindingRepo->method('findPackageIdsWithBindings')->willReturn([1, 2, 3]);
+
+        $operation = (new GetCollection())->withPaginationClientItemsPerPage(true)->withPaginationMaximumItemsPerPage(1);
+        $result = $this->provider->provide($operation, context: $this->requestContext(['itemsPerPage' => '50']));
+
+        $this->assertInstanceOf(ArrayPaginator::class, $result);
+        $this->assertSame(1.0, $result->getItemsPerPage());
     }
 }


### PR DESCRIPTION
## Resumen

`CommunicationPackageCatalogProvider` (catálogo V2) bypasea el provider Doctrine estándar — `PackageCatalogResolver` ya resuelve el conjunto completo de paquetes visibles en memoria, así que ninguna extensión estándar de API Platform (paginación, `OrderFilter`, `RangeFilter`) llega a intervenir. Se implementan a mano sobre el array ya resuelto:

- **`orderBy[price]=asc|desc`** — ordena por el precio resuelto para el cliente autenticado. Sin este parámetro, se ordena por `id` ascendente (igual que el resto del catálogo).
- **`price[gte]`/`price[lte]`** — filtra por rango de precio.
- **Paginación real** (`page`/`itemsPerPage`, respeta `paginationMaximumItemsPerPage: 100`) envolviendo el resultado en `ArrayPaginator` (la misma clase del core de API Platform) — antes el catálogo V2 declaraba `paginationEnabled: false` explícitamente y no traía metadata Hydra (`totalItems`, `hydra:view`).

Aplica tanto a la URL propia de V2 (`/communication/packages/catalog`) como a la URL histórica V1 (`/communication/packages`) para cuentas marcadas V2, porque `CommunicationClientPackageProvider` delega directamente en este mismo provider — **no se toca el switch V1/V2** en absoluto.

Los query params se documentan vía `openapi: new Operation(parameters: [...])` en el `GetCollection`, ya que no hay un `#[ApiFilter]` Doctrine real que pueda declarar esto (el precio no es una columna mapeada).

## Test plan
- [x] 8 tests nuevos: filtro por precio mínimo/máximo, orden asc/desc, default a id ascendente, paginación con `page`/`itemsPerPage`, clamp al máximo declarado
- [x] Suite completa: `php bin/phpunit --no-coverage` (1034 tests, verde) + `vendor/bin/phpstan analyse` (sin errores)
- [x] Verificado en vivo contra el catálogo real corriendo local: orden asc/desc por precio, filtro de rango, paginación con `totalItems` correcto y contenido exacto por página — en ambas URLs (V1 delegada y V2 nativa)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019akFNicpzpVzZSjSVqvGRs