### PR TITLE
fix(sale): soporta reserva de promociones V2 (Fase 5)

### DIFF
--- a/src/Repository/CommunicationPackageRepository.php
+++ b/src/Repository/CommunicationPackageRepository.php
@@ -119,6 +119,33 @@ class CommunicationPackageRepository extends ServiceEntityRepository
     }
 
     /**
+     * Paquete de una promoción V2 aún no vigente, para
+     * CommunicationSaleService::processReserve() (Fase 5) — equivalente V2
+     * de CommunicationPromotionsRepository::getFuturePromotionById(), que
+     * solo cubre CommunicationClientPackage (V1) vía
+     * CommunicationPromotions::$products, un ManyToMany que nunca incluye
+     * CommunicationPackage (aquí la relación es el ManyToOne directo
+     * CommunicationPackage::$promotion). Mismo criterio "futuro":
+     * promo.startAt > $now.
+     */
+    public function findFutureForReserve(int $packageId, int $promotionId, ?\DateTimeImmutable $now = null): ?CommunicationPackage
+    {
+        $now ??= new \DateTimeImmutable();
+
+        return $this->createQueryBuilder('p')
+            ->innerJoin('p.promotion', 'promo')
+            ->andWhere('p.id = :packageId')
+            ->andWhere('promo.id = :promotionId')
+            ->andWhere('promo.startAt > :now')
+            ->setParameter('packageId', $packageId)
+            ->setParameter('promotionId', $promotionId)
+            ->setParameter('now', $now)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
+    /**
      * Variante de findByDestination() acotada a los paquetes generados por
      * UNA promoción concreta (Fase 5B) — misma tolerancia de coma flotante,
      * pero nunca puede devolver un paquete del catálogo regular ni de otra

--- a/src/Service/CommunicationSaleService.php
+++ b/src/Service/CommunicationSaleService.php
@@ -206,18 +206,33 @@ class CommunicationSaleService extends CommonService
             $reserveDto->getPromotionId(),
             $reserveDto->getPackageId()
         );
+
+        // getFuturePromotionById() solo cubre CommunicationClientPackage
+        // (V1, ver su JOIN con CommunicationPromotions::$products) — una
+        // promoción V2 nunca la resuelve así, sus paquetes son
+        // CommunicationPackage con ManyToOne directo a la promoción (Fase
+        // 5, ver CommunicationPackageRepository::findFutureForReserve()).
+        $catalogPackage = null;
+        if ($promotion === null) {
+            /** @var \App\Repository\CommunicationPackageRepository $packageRepo */
+            $packageRepo = $this->em->getRepository(CommunicationPackage::class);
+            $catalogPackage = $packageRepo->findFutureForReserve(
+                $reserveDto->getPackageId(),
+                $reserveDto->getPromotionId(),
+            );
+            $promotion = $catalogPackage?->getPromotion();
+        }
+
         if (is_null($promotion)) {
             throw new MyCurrentException('COM007', 'The promotion is not active to reserves');
         }
 
-        // Reserve siempre trae promoción hoy (el DTO la exige) y las
-        // promociones V2 todavía no existen (ver Fase 5 del plan) — pasar
-        // $promotion fuerza la rama legacy en admit() sin importar
-        // CatalogVersionResolver::isV2(). El proveedor se resuelve por
-        // prioridad de cliente + vínculo promoción→producto (ver
-        // PromotionProviderDispatchResolver) y se congela ANTES de
-        // construir la venta.
-        $admission = $this->admit($user, $reserveDto->getPackageId(), 'recharge', forReserve: true, promotion: $promotion);
+        // El proveedor se resuelve por prioridad de cliente + vínculo
+        // promoción→producto (ver PromotionProviderDispatchResolver,
+        // agnóstico V1/V2) y se congela ANTES de construir la venta.
+        $admission = $catalogPackage !== null
+            ? $this->admitV2ForReserve($user, $catalogPackage, $promotion)
+            : $this->admit($user, $reserveDto->getPackageId(), 'recharge', forReserve: true, promotion: $promotion);
 
         $recharge = new CommunicationSaleRecharge();
         $recharge->setTenant($user);
@@ -474,10 +489,9 @@ class CommunicationSaleService extends CommonService
                     return;
                 }
                 if ($isV2Sale) {
-                    // Snapshot ya persistido en admit() (ver admitV2()) —
-                    // nunca se re-deriva, y V2 todavía no soporta
-                    // promociones (Fase 5), así que no hay sustitución de
-                    // productCode que aplicar aquí.
+                    // Snapshot ya persistido en admisión (admitV2() para
+                    // compra directa, admitV2ForReserve() para reserva de
+                    // promoción V2 — Fase 5) — nunca se re-deriva aquí.
                     $productCode = $saleRecharge->getDispatchExternalRef();
                     $destination = (object) [
                         'amount' => $saleRecharge->getDestinationAmount(),
@@ -931,11 +945,10 @@ class CommunicationSaleService extends CommonService
      * ProviderDispatchResolver::select(), devolviendo el snapshot que
      * applyAdmission() persistirá en la venta.
      *
-     * $promotion no nulo fuerza SIEMPRE la rama legacy, sin importar
-     * isV2(): las promociones V2 no existen todavía (Fase 5) y
-     * processReserve() hoy exige promoción en el 100% de los casos (el DTO
-     * la hace obligatoria) — este parámetro es lo que mantiene su rama V2
-     * inerte hasta que Fase 5 dé de alta el equivalente.
+     * $promotion no nulo fuerza SIEMPRE la rama legacy: esto es exclusivo
+     * del reserve V1. processReserve() resuelve el reserve V2 aparte, vía
+     * admitV2ForReserve() (Fase 5), sin pasar por aquí en absoluto — ver
+     * su propio docblock.
      *
      * @throws MyCurrentException
      */
@@ -1023,6 +1036,38 @@ class CommunicationSaleService extends CommonService
         // si ningún proveedor disponible de la prioridad del cliente cubre
         // la tupla — ver ProviderDispatchResolver.
         $dispatch = $this->dispatchResolver->select($user, $package, $saleType);
+
+        return new CommunicationSaleAdmission(
+            provider: $dispatch->provider->value,
+            amount: $offer->price,
+            currency: $offer->currency,
+            catalogPackage: $package,
+            dispatchProduct: $dispatch->product,
+            dispatchExternalRef: $dispatch->externalRef,
+            destinationAmount: $package->getDestinationAmount(),
+            destinationCurrency: $package->getDestinationCurrency(),
+        );
+    }
+
+    /**
+     * V2 Fase 5 — equivalente de admitLegacy() cuando processReserve()
+     * resuelve un CommunicationPackage de una promoción V2 aún futura (ver
+     * CommunicationPackageRepository::findFutureForReserve()). A diferencia
+     * de admitV2(), NO exige isPackageWithinActiveWindow(): el paquete
+     * todavía no está vigente por diseño, es justo lo que se está
+     * reservando. El precio se resuelve igual (offerForSale() solo mira el
+     * contrato, nunca la ventana activa del paquete — ver el docblock de
+     * PackageCatalogResolver), y el proveedor se resuelve a nivel de
+     * PROMOCIÓN (no de paquete) con el mismo mecanismo que ya usa el
+     * reserve legacy — PromotionProviderDispatchResolver es agnóstico de
+     * V1/V2.
+     *
+     * @throws MyCurrentException
+     */
+    private function admitV2ForReserve(Account $user, CommunicationPackage $package, CommunicationPromotions $promotion): CommunicationSaleAdmission
+    {
+        $offer = $this->packageCatalogResolver->offerForSale($package, $user);
+        $dispatch = $this->promotionDispatchResolver->select($user, $promotion);
 
         return new CommunicationSaleAdmission(
             provider: $dispatch->provider->value,

--- a/tests/Functional/Pricing/CommunicationPackageRepositoryTest.php
+++ b/tests/Functional/Pricing/CommunicationPackageRepositoryTest.php
@@ -3,6 +3,7 @@
 namespace App\Tests\Functional\Pricing;
 
 use App\Entity\CommunicationPackage;
+use App\Entity\CommunicationPromotions;
 use App\Repository\CommunicationPackageRepository;
 use App\Tests\Functional\FunctionalTestCase;
 
@@ -154,5 +155,63 @@ class CommunicationPackageRepositoryTest extends FunctionalTestCase
             [$first->getId(), $second->getId(), $later->getId()],
             array_map(static fn (CommunicationPackage $p) => $p->getId(), $result),
         );
+    }
+
+    private function promotion(\DateTimeImmutable $startAt, \DateTimeImmutable $endAt): CommunicationPromotions
+    {
+        self::$counter++;
+        $promotion = (new CommunicationPromotions())
+            ->setName("Promo {$this::$counter}")
+            ->setDescription("Promo {$this::$counter}")
+            ->setStartAt($startAt)
+            ->setEndAt($endAt);
+
+        $this->em->persist($promotion);
+
+        return $promotion;
+    }
+
+    public function testFindFutureForReserveReturnsPackageWhenPromotionHasNotStarted(): void
+    {
+        $now = new \DateTimeImmutable();
+        $promotion = $this->promotion($now->modify('+1 day'), $now->modify('+30 days'));
+        $package = $this->package(activeStartAt: $now->modify('+1 day'))->setPromotion($promotion);
+        $this->em->flush();
+
+        $result = $this->repository()->findFutureForReserve($package->getId(), $promotion->getId(), $now);
+
+        $this->assertNotNull($result);
+        $this->assertSame($package->getId(), $result->getId());
+    }
+
+    public function testFindFutureForReserveReturnsNullWhenPromotionAlreadyStarted(): void
+    {
+        $now = new \DateTimeImmutable();
+        $promotion = $this->promotion($now->modify('-1 day'), $now->modify('+30 days'));
+        $package = $this->package(activeStartAt: $now->modify('-1 day'))->setPromotion($promotion);
+        $this->em->flush();
+
+        $this->assertNull($this->repository()->findFutureForReserve($package->getId(), $promotion->getId(), $now));
+    }
+
+    public function testFindFutureForReserveReturnsNullWhenPackageBelongsToAnotherPromotion(): void
+    {
+        $now = new \DateTimeImmutable();
+        $promotion = $this->promotion($now->modify('+1 day'), $now->modify('+30 days'));
+        $otherPromotion = $this->promotion($now->modify('+1 day'), $now->modify('+30 days'));
+        $package = $this->package(activeStartAt: $now->modify('+1 day'))->setPromotion($promotion);
+        $this->em->flush();
+
+        $this->assertNull($this->repository()->findFutureForReserve($package->getId(), $otherPromotion->getId(), $now));
+    }
+
+    public function testFindFutureForReserveReturnsNullWhenPackageHasNoPromotion(): void
+    {
+        $now = new \DateTimeImmutable();
+        $promotion = $this->promotion($now->modify('+1 day'), $now->modify('+30 days'));
+        $package = $this->package(activeStartAt: $now->modify('+1 day'));
+        $this->em->flush();
+
+        $this->assertNull($this->repository()->findFutureForReserve($package->getId(), $promotion->getId(), $now));
     }
 }

--- a/tests/Service/CommunicationSaleServiceV2AdmissionTest.php
+++ b/tests/Service/CommunicationSaleServiceV2AdmissionTest.php
@@ -359,10 +359,10 @@ class CommunicationSaleServiceV2AdmissionTest extends TestCase
         $this->assertNull($result->getPackage());
     }
 
-    public function testProcessReserveAlwaysUsesLegacyEvenWhenClientIsInV2(): void
+    public function testProcessReserveUsesLegacyWhenV1PromotionIsFound(): void
     {
-        // hasPromotion=true fuerza legacy en admit() sin importar
-        // CatalogVersionResolver::isV2() — ver docblock de admit().
+        // getFuturePromotionById() (V1) resuelve directo → nunca se llega a
+        // intentar la resolución V2 (ver docblock de processReserve()).
         $account = $this->account(1);
         $this->security->method('getUser')->willReturn($account);
 
@@ -410,5 +410,85 @@ class CommunicationSaleServiceV2AdmissionTest extends TestCase
         $this->assertSame('ETECSA', $result->getProvider());
         $this->assertNull($result->getCatalogPackage());
         $this->assertSame('etecsa-ext-ref', $result->getDispatchExternalRef());
+    }
+
+    public function testProcessReserveUsesV2WhenV1LookupFailsButV2PackageIsFuture(): void
+    {
+        // getFuturePromotionById() (V1) no encuentra nada — es una
+        // promoción V2 (CommunicationPackage::$promotion, ManyToOne
+        // directo, nunca cubierto por esa consulta) — ver
+        // CommunicationPackageRepository::findFutureForReserve() (Fase 5).
+        $account = $this->account(1);
+        $this->security->method('getUser')->willReturn($account);
+
+        $promotionRepo = $this->createMock(CommunicationPromotionsRepository::class);
+        $promotionRepo->method('getFuturePromotionById')->willReturn(null);
+
+        $promotion = $this->createMock(CommunicationPromotions::class);
+        $package = $this->catalogPackage()->setPromotion($promotion);
+
+        $catalogPackageRepo = $this->createMock(\App\Repository\CommunicationPackageRepository::class);
+        $catalogPackageRepo->expects($this->once())
+            ->method('findFutureForReserve')
+            ->with(42, 93)
+            ->willReturn($package);
+
+        $this->em->method('getRepository')->willReturnMap([
+            [CommunicationPromotions::class, $promotionRepo],
+            [CommunicationPackage::class, $catalogPackageRepo],
+        ]);
+
+        $product = $this->createMock(CommunicationProduct::class);
+
+        $this->packageCatalogResolver->expects($this->once())
+            ->method('offerForSale')
+            ->with($package, $account)
+            ->willReturn(new ResolvedPackageOffer($package, 8.5, 'USD', PackageOfferSourceEnum::PRODUCT_MAX));
+        $this->promotionDispatchResolver->expects($this->once())
+            ->method('select')
+            ->with($account, $promotion)
+            ->willReturn(new SelectedDispatch(CommunicationProviderEnum::CSQ, $product, '7854-250'));
+        // Reserve resuelve el proveedor a nivel de PROMOCIÓN — el dispatch
+        // por paquete (usado en la compra V2 directa, admitV2()) nunca se
+        // toca aquí.
+        $this->dispatchResolver->expects($this->never())->method('select');
+
+        $this->balanceService->method('hasAvailableBalance')->willReturn(true);
+
+        $reserve = new ReserveRecharge('5550001234', 93, 42, 'reserve-ctx-v2-future');
+
+        $result = $this->service->processReserve($reserve);
+
+        $this->assertSame('CSQ', $result->getProvider());
+        $this->assertSame($package, $result->getCatalogPackage());
+        $this->assertSame(8.5, $result->getAmount());
+        $this->assertSame('USD', $result->getCurrency());
+        $this->assertSame('7854-250', $result->getDispatchExternalRef());
+        $this->assertSame(500.0, $result->getDestinationAmount());
+        $this->assertSame('CUP', $result->getDestinationCurrency());
+    }
+
+    public function testProcessReserveThrowsCom007WhenNeitherV1NorV2ResolvesTheFuturePromotion(): void
+    {
+        $account = $this->account(1);
+        $this->security->method('getUser')->willReturn($account);
+
+        $promotionRepo = $this->createMock(CommunicationPromotionsRepository::class);
+        $promotionRepo->method('getFuturePromotionById')->willReturn(null);
+
+        $catalogPackageRepo = $this->createMock(\App\Repository\CommunicationPackageRepository::class);
+        $catalogPackageRepo->method('findFutureForReserve')->willReturn(null);
+
+        $this->em->method('getRepository')->willReturnMap([
+            [CommunicationPromotions::class, $promotionRepo],
+            [CommunicationPackage::class, $catalogPackageRepo],
+        ]);
+
+        $this->expectException(MyCurrentException::class);
+        $this->expectExceptionMessage('The promotion is not active to reserves');
+
+        $reserve = new ReserveRecharge('5550001234', 93, 42, 'reserve-ctx-v2-missing');
+
+        $this->service->processReserve($reserve);
     }
 }


### PR DESCRIPTION
## Resumen
- `processReserve()` solo resolvía la promoción futura vía `CommunicationPromotions::$products` (ManyToMany exclusivo de `CommunicationClientPackage`, V1) — cualquier reserva sobre un paquete de una promoción V2 devolvía `COM007 "The promotion is not active to reserves"`.
- Se agrega `CommunicationPackageRepository::findFutureForReserve()` como fallback cuando la resolución V1 no encuentra nada.
- Se agrega `admitV2ForReserve()`: precio vía `PackageCatalogResolver::offerForSale()` (no exige ventana activa del paquete, correcto para un paquete todavía futuro), proveedor vía `PromotionProviderDispatchResolver` (ya agnóstico V1/V2, mismo mecanismo que usa el reserve legacy).

## Contexto
Detectado en producción: intento real de reserva sobre la promoción "Cubacel {monto} CUP" (V2, arranca 2026-08-20) devolvió COM007.

## Test plan
- [x] `vendor/bin/phpstan analyse` limpio
- [x] Suite completa (`docker compose exec -e APP_ENV=test worker php bin/phpunit --no-coverage`): 1040/1040 verdes
- [x] Nuevos tests: 4 en `CommunicationPackageRepositoryTest` (findFutureForReserve), 2 en `CommunicationSaleServiceV2AdmissionTest` (V2 reserve happy path + COM007 cuando ninguna versión resuelve)