### PR TITLE
chore(hooks): corre pre-push vía Docker

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -2,5 +2,5 @@
 set -e
 
 echo "▶ PHPUnit tests..."
-php bin/phpunit --no-coverage
+docker compose exec -e APP_ENV=test worker php bin/phpunit --no-coverage
 echo "✔ Tests OK"


### PR DESCRIPTION
## Resumen
El hook `pre-push` corría `php bin/phpunit` directo en el host. El PHP del host no tiene `pdo_pgsql` instalado y `DATABASE_URL` apunta al hostname interno de Docker (`database`, no resoluble fuera de la red de compose) — el hook fallaba con "could not find driver" en cualquier push, sin importar si los tests realmente pasaban.

Se cambia a `docker compose exec -e APP_ENV=test worker php bin/phpunit --no-coverage`, la misma forma en que ya se corren los tests en el resto del flujo de este repo (ver CLAUDE.md).

## Test plan
- [x] `bash .githooks/pre-push` corre en verde localmente tras el cambio