### PR TITLE
Release: botón "probar conexión" de proveedores siempre consulta balance

### DIFF
--- a/src/Service/Provider/ProviderConnectionTestService.php
+++ b/src/Service/Provider/ProviderConnectionTestService.php
@@ -6,9 +6,13 @@ use App\Enums\CommunicationProviderEnum;
 
 /**
  * Prueba en vivo, bajo demanda, si las credenciales configuradas para un
- * proveedor/entorno funcionan. Delega el sondeo en ProviderPingService (la
- * misma ruta que usa el ping periódico — un solo comportamiento) y adapta su
- * ProviderPingResult a la forma de retorno histórica de este servicio.
+ * proveedor/entorno funcionan. Delega el sondeo en ProviderPingService con
+ * `preferBalance: true` — a diferencia del ping periódico automático (que
+ * prioriza un health-check barato para no golpear a cada proveedor con una
+ * consulta de saldo cada 15 minutos), este botón manual SIEMPRE debe
+ * consultar el balance real cuando el proveedor lo soporta (confirmado con
+ * el usuario), no solo verificar que responde. Adapta el ProviderPingResult
+ * resultante a la forma de retorno histórica de este servicio.
  * No hay circuit breaker ni estado persistido: es una señal honesta del
  * instante en que se pulsa el botón, no un histórico de fiabilidad.
  */
@@ -24,7 +28,7 @@ class ProviderConnectionTestService
      */
     public function test(CommunicationProviderEnum $provider, string $environmentType): array
     {
-        $result = $this->pingService->ping($provider, $environmentType);
+        $result = $this->pingService->ping($provider, $environmentType, preferBalance: true);
 
         if ($result->available) {
             return [

--- a/src/Service/Provider/ProviderPingService.php
+++ b/src/Service/Provider/ProviderPingService.php
@@ -4,6 +4,7 @@ namespace App\Service\Provider;
 
 use App\Enums\CommunicationProviderEnum;
 use App\Provider\Contract\ProviderBalanceInterface;
+use App\Provider\Contract\ProviderContext;
 use App\Provider\Contract\ProviderHealthCheckInterface;
 use App\Provider\Contract\ProviderPingResult;
 use App\Provider\ProviderContextFactory;
@@ -14,11 +15,18 @@ use App\Provider\ProviderRegistry;
  * Sondeo único de disponibilidad de un proveedor, usado tanto por el ping
  * periódico (App\Schedule\Task\PingProvidersTask) como por el botón de
  * "probar conexión" del dashboard (App\Service\Provider\ProviderConnectionTestService).
- * Una sola ruta de sondeo, un solo comportamiento.
  *
- * Orden de preferencia: si el adaptador tiene un ping dedicado
- * (ProviderHealthCheckInterface) se usa ese; si no, getPlatformBalance() como
- * prueba de vida barata; si tampoco, inconclusive (no hay forma de sondear).
+ * Orden de preferencia por defecto (ping periódico, cada 15 min — no debe
+ * generar consultas de saldo constantes a cada proveedor): si el adaptador
+ * tiene un ping dedicado (ProviderHealthCheckInterface) se usa ese; si no,
+ * getPlatformBalance() como prueba de vida barata; si tampoco, inconclusive
+ * (no hay forma de sondear).
+ *
+ * `$preferBalance` invierte esa prioridad — lo usa exclusivamente el botón
+ * manual "probar conexión" del dashboard (confirmado con el usuario:
+ * ahí SIEMPRE debe consultarse el balance real, no solo un ping barato,
+ * aunque el proveedor tenga su propio health-check; el ping automático de
+ * 15 min sigue sin tocarse).
  */
 class ProviderPingService
 {
@@ -29,7 +37,7 @@ class ProviderPingService
     ) {
     }
 
-    public function ping(CommunicationProviderEnum $provider, string $environmentType): ProviderPingResult
+    public function ping(CommunicationProviderEnum $provider, string $environmentType, bool $preferBalance = false): ProviderPingResult
     {
         try {
             if (!$this->credentialsResolver->isFullyConfigured($provider, $environmentType)) {
@@ -39,23 +47,32 @@ class ProviderPingService
             $adapter = $this->registry->get($provider);
             $context = $this->contextFactory->forEnvironmentType($provider, $environmentType);
 
+            if ($preferBalance && $adapter instanceof ProviderBalanceInterface) {
+                return $this->pingViaBalance($adapter, $context);
+            }
+
             if ($adapter instanceof ProviderHealthCheckInterface) {
                 return $adapter->checkHealth($context);
             }
 
             if ($adapter instanceof ProviderBalanceInterface) {
-                $start = microtime(true);
-                $balance = $adapter->getPlatformBalance($context);
-
-                return ProviderPingResult::available(
-                    (int) round((microtime(true) - $start) * 1000),
-                    ['amounts' => $balance->amounts, 'fetchedAt' => $balance->fetchedAt->format(DATE_ATOM)],
-                );
+                return $this->pingViaBalance($adapter, $context);
             }
         } catch (\Throwable $e) {
             return ProviderPingResult::unavailable($e->getMessage());
         }
 
         return ProviderPingResult::inconclusive('Proveedor sin ping ni prueba de saldo disponibles');
+    }
+
+    private function pingViaBalance(ProviderBalanceInterface $adapter, ProviderContext $context): ProviderPingResult
+    {
+        $start = microtime(true);
+        $balance = $adapter->getPlatformBalance($context);
+
+        return ProviderPingResult::available(
+            (int) round((microtime(true) - $start) * 1000),
+            ['amounts' => $balance->amounts, 'fetchedAt' => $balance->fetchedAt->format(DATE_ATOM)],
+        );
     }
 }

--- a/tests/Service/Provider/ProviderConnectionTestServiceTest.php
+++ b/tests/Service/Provider/ProviderConnectionTestServiceTest.php
@@ -8,6 +8,8 @@ use App\Exception\MyCurrentException;
 use App\Provider\Contract\ProviderBalanceInterface;
 use App\Provider\Contract\ProviderBalanceResult;
 use App\Provider\Contract\ProviderContext;
+use App\Provider\Contract\ProviderHealthCheckInterface;
+use App\Provider\Contract\ProviderPingResult;
 use App\Provider\ProviderContextFactory;
 use App\Provider\ProviderCredentialsResolver;
 use App\Provider\ProviderRegistry;
@@ -115,6 +117,53 @@ class ProviderConnectionTestServiceTest extends TestCase
 
         $this->assertFalse($result['success']);
         $this->assertSame('faltan credenciales', $result['message']);
+    }
+
+    /**
+     * El botón "probar conexión" del dashboard debe consultar SIEMPRE el
+     * balance real cuando el proveedor lo soporta — aunque el adaptador
+     * tenga también su propio health-check (como CSQ/ETECSA), que es lo
+     * que usa el ping automático de 15 min en su lugar. Confirmado con el
+     * usuario: antes de este fix, CSQ mostraba `amounts: []` en el botón
+     * manual porque checkHealth() (un ping vacío, sin datos de saldo)
+     * tenía prioridad.
+     */
+    public function testPrefersBalanceOverHealthCheckEvenWhenAdapterSupportsBoth(): void
+    {
+        $adapter = new class implements ProviderHealthCheckInterface, ProviderBalanceInterface {
+            public function getCode(): CommunicationProviderEnum
+            {
+                return CommunicationProviderEnum::CSQ;
+            }
+
+            /** @return list<ProviderCapabilityEnum> */
+            public function getCapabilities(): array
+            {
+                return [ProviderCapabilityEnum::BALANCE];
+            }
+
+            public function getConfigSchema(): array
+            {
+                return [];
+            }
+
+            public function checkHealth(ProviderContext $context): ProviderPingResult
+            {
+                throw new \LogicException('checkHealth() no debía llamarse: el botón manual prefiere balance');
+            }
+
+            public function getPlatformBalance(ProviderContext $context): ProviderBalanceResult
+            {
+                return new ProviderBalanceResult(['USD' => 374.0], new \DateTimeImmutable('2026-08-20T00:00:00+00:00'));
+            }
+        };
+
+        $service = $this->service(new ProviderRegistry([$adapter]));
+
+        $result = $service->test(CommunicationProviderEnum::CSQ, 'TEST');
+
+        $this->assertTrue($result['success']);
+        $this->assertSame(['USD' => 374.0], $result['amounts']);
     }
 
     public function testReturnsFailureWhenProviderNotRegistered(): void

--- a/tests/Service/Provider/ProviderPingServiceTest.php
+++ b/tests/Service/Provider/ProviderPingServiceTest.php
@@ -205,6 +205,81 @@ class ProviderPingServiceTest extends TestCase
         $this->assertSame('timeout', $result->error);
     }
 
+    public function testPreferBalancePrefersBalanceOverHealthCheckWhenAdapterSupportsBoth(): void
+    {
+        $adapter = new class implements ProviderHealthCheckInterface, ProviderBalanceInterface {
+            public function getCode(): CommunicationProviderEnum
+            {
+                return CommunicationProviderEnum::DTONE;
+            }
+
+            public function getCapabilities(): array
+            {
+                return [];
+            }
+
+            public function getConfigSchema(): array
+            {
+                return [];
+            }
+
+            public function checkHealth(ProviderContext $context): ProviderPingResult
+            {
+                // El botón manual "probar conexión" (preferBalance: true) nunca
+                // debe llegar aquí cuando el adaptador también soporta balance
+                // — si este método se invoca, el test debe fallar de forma
+                // visible en vez de devolver un resultado que enmascare el bug.
+                throw new \LogicException('checkHealth() no debía llamarse con preferBalance: true');
+            }
+
+            public function getPlatformBalance(ProviderContext $context): ProviderBalanceResult
+            {
+                return new ProviderBalanceResult(['USD' => 374.0], new \DateTimeImmutable('2026-08-20T00:00:00+00:00'));
+            }
+        };
+        $registry = new ProviderRegistry([$adapter]);
+
+        $service = new ProviderPingService($registry, $this->credentialsResolver($registry, 'x'), $this->contextFactory());
+
+        $result = $service->ping(CommunicationProviderEnum::DTONE, 'TEST', preferBalance: true);
+
+        $this->assertTrue($result->available);
+        $this->assertSame(['USD' => 374.0], $result->details['amounts']);
+    }
+
+    public function testPreferBalanceFallsBackToHealthCheckWhenAdapterHasNoBalance(): void
+    {
+        $adapter = new class implements ProviderHealthCheckInterface {
+            public function getCode(): CommunicationProviderEnum
+            {
+                return CommunicationProviderEnum::DTONE;
+            }
+
+            public function getCapabilities(): array
+            {
+                return [];
+            }
+
+            public function getConfigSchema(): array
+            {
+                return [];
+            }
+
+            public function checkHealth(ProviderContext $context): ProviderPingResult
+            {
+                return ProviderPingResult::available(7);
+            }
+        };
+        $registry = new ProviderRegistry([$adapter]);
+
+        $service = new ProviderPingService($registry, $this->credentialsResolver($registry, 'x'), $this->contextFactory());
+
+        $result = $service->ping(CommunicationProviderEnum::DTONE, 'TEST', preferBalance: true);
+
+        $this->assertTrue($result->available);
+        $this->assertSame(7, $result->latencyMs);
+    }
+
     public function testPingReturnsUnavailableWhenProviderNotRegistered(): void
     {
         $registry = new ProviderRegistry([]);


### PR DESCRIPTION
## Resumen
fix(providers): "probar conexión" siempre consulta balance (#114) — el botón manual de la pantalla de configuración de proveedores mostraba `amounts: []` para CSQ aunque las credenciales y el saldo real funcionaran, porque priorizaba el health-check propio del proveedor (un ping vacío para CSQ) sobre la consulta de saldo real. El ping automático cada 15 minutos (pantalla de Disponibilidad de proveedores) no se toca — sigue usando el health-check barato.

## Test plan
- [x] CI verde en #114
- [x] Verificado en vivo contra CSQ TEST local: saldo real de 374 USD