### PR TITLE
fix(dtone): getPlatformBalance() nunca leía el saldo real

### DIFF
--- a/src/Provider/DTOne/DTOneCommunicationProvider.php
+++ b/src/Provider/DTOne/DTOneCommunicationProvider.php
@@ -216,17 +216,33 @@ final class DTOneCommunicationProvider implements
         return $this->statusMapper->mapStatusQuery($raw);
     }
 
+    /**
+     * GET /v1/balances devuelve un array plano de cuentas, NO un objeto con
+     * `data`/`balances` (confirmado en vivo el 2026-08-20 contra el sandbox
+     * TEST real): `[{"available":99907.81,"credit_limit":0,"holding":0,
+     * "id":16679,"unit":"EUR","unit_type":"CURRENCY"}]`. La moneda es
+     * `unit` (no `currency`) y el saldo disponible es `available` (no
+     * `amount`) — `holding` es saldo retenido/pendiente, no usable, y
+     * `credit_limit` es una línea de crédito, no saldo propio; ninguno de
+     * los dos debe sumarse aquí. Se descartan entradas con `unit_type`
+     * distinto de CURRENCY (p. ej. una futura cuenta de crédito no
+     * monetaria) — hoy DTOne solo devuelve CURRENCY, pero el campo existe
+     * explícitamente para distinguirlas.
+     */
     public function getPlatformBalance(ProviderContext $context): ProviderBalanceResult
     {
         $raw = $this->client->getBalances($context);
         $amounts = [];
 
-        foreach ((array) ($raw['data'] ?? $raw['balances'] ?? []) as $entry) {
-            if (!is_array($entry) || !isset($entry['currency'])) {
+        foreach ($raw as $entry) {
+            if (!isset($entry['unit'], $entry['available'])) {
+                continue;
+            }
+            if (($entry['unit_type'] ?? 'CURRENCY') !== 'CURRENCY') {
                 continue;
             }
 
-            $amounts[(string) $entry['currency']] = (float) ($entry['amount'] ?? 0.0);
+            $amounts[(string) $entry['unit']] = (float) $entry['available'];
         }
 
         return new ProviderBalanceResult(amounts: $amounts, fetchedAt: new \DateTimeImmutable('now'));

--- a/src/Provider/DTOne/DTOneHttpClient.php
+++ b/src/Provider/DTOne/DTOneHttpClient.php
@@ -154,12 +154,15 @@ class DTOneHttpClient
     }
 
     /**
-     * GET /v1/balances — nuestro saldo con DTOne, multi-moneda.
+     * GET /v1/balances — nuestro saldo con DTOne, multi-moneda. La
+     * respuesta es un array plano de cuentas (no un objeto envoltorio) —
+     * ver el docblock de DTOneCommunicationProvider::getPlatformBalance().
      *
-     * @return array<string, mixed>
+     * @return list<array<string, mixed>>
      */
     public function getBalances(ProviderContext $context): array
     {
+        /** @var list<array<string, mixed>> */
         return $this->request($context, 'GET', '/v1/balances');
     }
 

--- a/tests/Provider/DTOne/DTOneCommunicationProviderTest.php
+++ b/tests/Provider/DTOne/DTOneCommunicationProviderTest.php
@@ -209,18 +209,45 @@ class DTOneCommunicationProviderTest extends TestCase
         $this->assertSame(ProviderOutcomeEnum::UNKNOWN, $result->outcome);
     }
 
-    public function testGetPlatformBalanceParsesDataArray(): void
+    /**
+     * Forma real confirmada en vivo el 2026-08-20 contra el sandbox TEST:
+     * un array plano de cuentas, `unit`/`available` (no `data`/`currency`/
+     * `amount`, que es lo que el código asumía antes de este fix — por
+     * eso "probar conexión" siempre mostraba el saldo vacío para DTOne).
+     */
+    public function testGetPlatformBalanceParsesFlatAccountsArray(): void
     {
         $this->client->method('getBalances')->willReturn([
-            'data' => [
-                ['currency' => 'USD', 'amount' => 123.45],
-                ['currency' => 'EUR', 'amount' => 10],
-            ],
+            ['available' => 123.45, 'credit_limit' => 0, 'holding' => 0, 'id' => 1, 'unit' => 'USD', 'unit_type' => 'CURRENCY'],
+            ['available' => 10.0, 'credit_limit' => 0, 'holding' => 0, 'id' => 2, 'unit' => 'EUR', 'unit_type' => 'CURRENCY'],
         ]);
 
         $result = $this->provider->getPlatformBalance($this->context());
 
         $this->assertSame(['USD' => 123.45, 'EUR' => 10.0], $result->amounts);
+    }
+
+    public function testGetPlatformBalanceIgnoresHoldingAndCreditLimit(): void
+    {
+        $this->client->method('getBalances')->willReturn([
+            ['available' => 99907.81, 'credit_limit' => 500.0, 'holding' => 250.0, 'id' => 1, 'unit' => 'EUR', 'unit_type' => 'CURRENCY'],
+        ]);
+
+        $result = $this->provider->getPlatformBalance($this->context());
+
+        $this->assertSame(['EUR' => 99907.81], $result->amounts);
+    }
+
+    public function testGetPlatformBalanceSkipsNonCurrencyEntries(): void
+    {
+        $this->client->method('getBalances')->willReturn([
+            ['available' => 5000.0, 'id' => 1, 'unit' => 'CREDIT', 'unit_type' => 'CREDIT_LINE'],
+            ['available' => 123.45, 'id' => 2, 'unit' => 'USD', 'unit_type' => 'CURRENCY'],
+        ]);
+
+        $result = $this->provider->getPlatformBalance($this->context());
+
+        $this->assertSame(['USD' => 123.45], $result->amounts);
     }
 
     public function testFetchProductsFiltersByCubaCountryIsoCode(): void


### PR DESCRIPTION
## Resumen
Reportado por el usuario: en la pantalla de configuración de proveedores, "Probar conexión" contra DTOne (TEST y PROD) siempre mostraba "Conexión exitosa. Saldo de plataforma:" **vacío**, a diferencia de CSQ/ETECSA que sí muestran el monto.

## Causa
`DTOneCommunicationProvider::getPlatformBalance()` asumía la forma `{"data":[{"currency":...,"amount":...}]}`. La respuesta real de `GET /v1/balances` (confirmada en vivo contra el sandbox TEST) es un array plano de cuentas:
```json
[{"available":99907.81,"credit_limit":0,"holding":0,"id":16679,"unit":"EUR","unit_type":"CURRENCY"}]
```
La clave `data` nunca existió, así que el `foreach` nunca iteraba nada — `amounts` quedaba siempre en `[]`, sin lanzar ningún error (por eso "conexión exitosa" con saldo vacío, en vez de un fallo visible).

## Cambio
Parsea la forma real: `unit` (no `currency`), `available` (no `amount`) — descartando explícitamente `holding` (retenido, no usable) y `credit_limit` (línea de crédito, no saldo propio), y cualquier entrada con `unit_type` distinto de `CURRENCY`.

## Test plan
- [x] PHPStan limpio
- [x] Suite completa: 1052/1052 verdes
- [x] Tests actualizados/nuevos en `DTOneCommunicationProviderTest` (forma real, exclusión de holding/credit_limit, exclusión de unit_type no-CURRENCY)
- [x] Verificado en vivo contra DTOne TEST local: `{"success":true,"amounts":{"EUR":99907.81},...}`