### PR TITLE
Release: fix products en promociones (array vs objeto + vacío en V2)

### DIFF
--- a/src/State/CommunicationPromotionProvider.php
+++ b/src/State/CommunicationPromotionProvider.php
@@ -5,7 +5,10 @@ namespace App\State;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use App\Entity\Account;
+use App\Entity\CommunicationPackage;
 use App\Entity\CommunicationPromotions;
+use App\Repository\CommunicationPackageRepository;
+use Doctrine\Common\Collections\ArrayCollection;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
@@ -15,7 +18,8 @@ class CommunicationPromotionProvider implements ProviderInterface
     public function __construct(
         #[Autowire(service: 'api_platform.doctrine.orm.state.collection_provider')]
         private readonly ProviderInterface $itemProvider,
-        private readonly Security $security
+        private readonly Security $security,
+        private readonly CommunicationPackageRepository $packageRepository,
     ) {
     }
 
@@ -33,17 +37,36 @@ class CommunicationPromotionProvider implements ProviderInterface
             if ($tenant instanceof Account) {
                 $items = iterator_to_array($promotions->getIterator());
                 foreach ($items as $promotion) {
-                    if ($promotion instanceof CommunicationPromotions) {
-                        $products = $promotion->getProducts()->filter(
-                            function (\App\Entity\CommunicationClientPackage $clientPackage) {
-                                $user = $this->security->getUser();
-
-                                return $user instanceof Account && $clientPackage->getTenant()?->getId(
-                                    ) === $user->getId();
-                            }
-                        );
-                        $promotion->setProductsTemp($products);
+                    if (!$promotion instanceof CommunicationPromotions) {
+                        continue;
                     }
+
+                    if ($promotion->isV2()) {
+                        // V2: no genera CommunicationClientPackage por tenant (catálogo
+                        // compartido), así que `products` se puebla desde el
+                        // CommunicationPackage de la promoción vía su FK `promotion`.
+                        $packages = $this->packageRepository->findByPromotion($promotion);
+                        $products = array_map(
+                            static fn (CommunicationPackage $package) => [
+                                'id' => $package->getId(),
+                                'description' => $package->getDescription(),
+                                'name' => $package->getName(),
+                            ],
+                            $packages
+                        );
+                        $promotion->setProductsTemp(new ArrayCollection($products));
+                        continue;
+                    }
+
+                    $products = $promotion->getProducts()->filter(
+                        function (\App\Entity\CommunicationClientPackage $clientPackage) {
+                            $user = $this->security->getUser();
+
+                            return $user instanceof Account && $clientPackage->getTenant()?->getId(
+                                ) === $user->getId();
+                        }
+                    );
+                    $promotion->setProductsTemp(new ArrayCollection($products->getValues()));
                 }
             }
         }


### PR DESCRIPTION
## Summary
- `products` en `GET /communication/promotions` se serializaba como objeto JSON en vez de array cuando `Collection::filter()` (por tenant) dejaba claves no consecutivas; se reindexa con `getValues()` antes de `setProductsTemp()`.
- Las promociones V2 (catálogo compartido) nunca poblaban `products` porque no generan `CommunicationClientPackage` por tenant; ahora se resuelven desde su `CommunicationPackage` vía `CommunicationPackageRepository::findByPromotion()`, manteniendo el mismo shape `{id, description, name}`.

## Test plan
- [x] `phpstan analyse` limpio sobre `CommunicationPromotionProvider.php`
- [x] Contenedor DI compila (nueva dependencia `CommunicationPackageRepository`)
- [x] Suite completa de PHPUnit en verde (1052 tests, 2371 assertions)
- [x] Tests dirigidos de promociones (`CommunicationPromotionServiceV2Test`, `CommunicationPromotionEquivalenceServiceTest`, `CommunicationPromotionBindingServiceTest`) en verde

🤖 Generated with [Claude Code](https://claude.com/claude-code)