### PR TITLE
feat(packages): extiende tags/service para Nauta Hogar y PLUS

### DIFF
--- a/src/DTO/CreateClientPackageDto.php
+++ b/src/DTO/CreateClientPackageDto.php
@@ -82,7 +82,7 @@ class CreateClientPackageDto implements IInput
     #[OAProperty(schema: [
         'type' => 'array',
         'nullable' => true,
-        'items' => ['type' => 'string', 'enum' => ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET']],
+        'items' => ['type' => 'string', 'enum' => ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET', 'LANDLINE', 'UNLIMITED']],
     ])]
     protected ?array $tags;
 
@@ -90,9 +90,9 @@ class CreateClientPackageDto implements IInput
         'type' => 'object',
         'nullable' => true,
         'properties' => [
-            'name'       => ['type' => 'string', 'enum' => ['Mobile', 'uSIM', 'Devices']],
+            'name'       => ['type' => 'string', 'enum' => ['Mobile', 'uSIM', 'Devices', 'Utilities']],
             'subservice' => ['type' => 'object', 'properties' => [
-                'name' => ['type' => 'string', 'enum' => ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET', 'uSIM']],
+                'name' => ['type' => 'string', 'enum' => ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET', 'LANDLINE', 'uSIM']],
             ]],
         ],
     ])]

--- a/src/DTO/CreateCommunicationPackageBatchDto.php
+++ b/src/DTO/CreateCommunicationPackageBatchDto.php
@@ -86,7 +86,7 @@ class CreateCommunicationPackageBatchDto implements IInput
     #[OAProperty(schema: [
         'type' => 'array',
         'nullable' => true,
-        'items' => ['type' => 'string', 'enum' => ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET']],
+        'items' => ['type' => 'string', 'enum' => ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET', 'LANDLINE', 'UNLIMITED']],
     ])]
     protected ?array $tags;
 
@@ -94,9 +94,9 @@ class CreateCommunicationPackageBatchDto implements IInput
         'type' => 'object',
         'nullable' => true,
         'properties' => [
-            'name' => ['type' => 'string', 'enum' => ['Mobile', 'uSIM', 'Devices']],
+            'name' => ['type' => 'string', 'enum' => ['Mobile', 'uSIM', 'Devices', 'Utilities']],
             'subservice' => ['type' => 'object', 'properties' => [
-                'name' => ['type' => 'string', 'enum' => ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET', 'uSIM']],
+                'name' => ['type' => 'string', 'enum' => ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET', 'LANDLINE', 'uSIM']],
             ]],
         ],
     ])]

--- a/src/DTO/CreateCommunicationPackageDto.php
+++ b/src/DTO/CreateCommunicationPackageDto.php
@@ -68,7 +68,7 @@ class CreateCommunicationPackageDto implements IInput
     #[OAProperty(schema: [
         'type' => 'array',
         'nullable' => true,
-        'items' => ['type' => 'string', 'enum' => ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET']],
+        'items' => ['type' => 'string', 'enum' => ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET', 'LANDLINE', 'UNLIMITED']],
     ])]
     protected ?array $tags;
 
@@ -76,9 +76,9 @@ class CreateCommunicationPackageDto implements IInput
         'type' => 'object',
         'nullable' => true,
         'properties' => [
-            'name'       => ['type' => 'string', 'enum' => ['Mobile', 'uSIM', 'Devices']],
+            'name'       => ['type' => 'string', 'enum' => ['Mobile', 'uSIM', 'Devices', 'Utilities']],
             'subservice' => ['type' => 'object', 'properties' => [
-                'name' => ['type' => 'string', 'enum' => ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET', 'uSIM']],
+                'name' => ['type' => 'string', 'enum' => ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET', 'LANDLINE', 'uSIM']],
             ]],
         ],
     ])]

--- a/src/DTO/CreatePromotionV2Dto.php
+++ b/src/DTO/CreatePromotionV2Dto.php
@@ -121,7 +121,7 @@ class CreatePromotionV2Dto implements IInput
     #[OAProperty(schema: [
         'type' => 'array',
         'nullable' => true,
-        'items' => ['type' => 'string', 'enum' => ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET']],
+        'items' => ['type' => 'string', 'enum' => ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET', 'LANDLINE', 'UNLIMITED']],
     ])]
     protected ?array $tags;
 
@@ -129,9 +129,9 @@ class CreatePromotionV2Dto implements IInput
         'type' => 'object',
         'nullable' => true,
         'properties' => [
-            'name' => ['type' => 'string', 'enum' => ['Mobile', 'uSIM', 'Devices']],
+            'name' => ['type' => 'string', 'enum' => ['Mobile', 'uSIM', 'Devices', 'Utilities']],
             'subservice' => ['type' => 'object', 'properties' => [
-                'name' => ['type' => 'string', 'enum' => ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET', 'uSIM']],
+                'name' => ['type' => 'string', 'enum' => ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET', 'LANDLINE', 'uSIM']],
             ]],
         ],
     ])]

--- a/src/DTO/Out/ClientPackageDetailOutDto.php
+++ b/src/DTO/Out/ClientPackageDetailOutDto.php
@@ -38,7 +38,7 @@ final class ClientPackageDetailOutDto extends ClientPackageOutDto
         schema: [
             'type' => 'array',
             'nullable' => true,
-            'items' => ['type' => 'string', 'enum' => ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET']],
+            'items' => ['type' => 'string', 'enum' => ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET', 'LANDLINE', 'UNLIMITED']],
         ],
         description: 'Categorías del paquete',
     )]
@@ -49,9 +49,9 @@ final class ClientPackageDetailOutDto extends ClientPackageOutDto
             'type' => 'object',
             'nullable' => true,
             'properties' => [
-                'name'       => ['type' => 'string', 'enum' => ['Mobile', 'uSIM', 'Devices']],
+                'name'       => ['type' => 'string', 'enum' => ['Mobile', 'uSIM', 'Devices', 'Utilities']],
                 'subservice' => ['type' => 'object', 'properties' => [
-                    'name' => ['type' => 'string', 'enum' => ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET', 'uSIM']],
+                    'name' => ['type' => 'string', 'enum' => ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET', 'LANDLINE', 'uSIM']],
                 ]],
             ],
         ],

--- a/src/DTO/OutputPaginationPackage.php
+++ b/src/DTO/OutputPaginationPackage.php
@@ -130,7 +130,7 @@ class OutputPaginationPackage
                         'type' => 'array',
                         'items' => [
                             'type' => 'string',
-                            'enum' => ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET']
+                            'enum' => ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET', 'LANDLINE', 'UNLIMITED']
                         ],
                     ],
                     'service' => [
@@ -138,14 +138,14 @@ class OutputPaginationPackage
                         'properties' => [
                             'name' => [
                                 'type' => 'string',
-                                'enum' => ['Mobile', 'uSIM', 'Devices']
+                                'enum' => ['Mobile', 'uSIM', 'Devices', 'Utilities']
                             ],
                             'subservice' => [
                                 'type' => 'object',
                                 'properties' => [
                                     'name' => [
                                         'type' => 'string',
-                                        'enum' => ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET', 'uSIM']
+                                        'enum' => ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET', 'LANDLINE', 'uSIM']
                                     ]
                                 ]
                             ]

--- a/src/Entity/CommunicationClientPackage.php
+++ b/src/Entity/CommunicationClientPackage.php
@@ -170,7 +170,7 @@ class CommunicationClientPackage
             'type' => 'array',
             'items' => [
                 'type' => 'string',
-                'enum' => ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET'],
+                'enum' => ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET', 'LANDLINE', 'UNLIMITED'],
             ],
         ]
     )]
@@ -184,14 +184,14 @@ class CommunicationClientPackage
             'properties' => [
                 'name' => [
                     'type' => 'string',
-                    'enum' => ['Mobile', 'uSIM', 'Devices'],
+                    'enum' => ['Mobile', 'uSIM', 'Devices', 'Utilities'],
                 ],
                 'subservice' => [
                     'type' => 'object',
                     'properties' => [
                         'name' => [
                             'type' => 'string',
-                            'enum' => ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET', 'uSIM'],
+                            'enum' => ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET', 'LANDLINE', 'uSIM'],
                         ],
                     ],
                 ],

--- a/src/Entity/CommunicationPackage.php
+++ b/src/Entity/CommunicationPackage.php
@@ -186,7 +186,7 @@ class CommunicationPackage
             'type' => 'array',
             'items' => [
                 'type' => 'string',
-                'enum' => ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET'],
+                'enum' => ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET', 'LANDLINE', 'UNLIMITED'],
             ],
         ]
     )]
@@ -203,14 +203,14 @@ class CommunicationPackage
             'properties' => [
                 'name' => [
                     'type' => 'string',
-                    'enum' => ['Mobile', 'uSIM', 'Devices'],
+                    'enum' => ['Mobile', 'uSIM', 'Devices', 'Utilities'],
                 ],
                 'subservice' => [
                     'type' => 'object',
                     'properties' => [
                         'name' => [
                             'type' => 'string',
-                            'enum' => ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET', 'uSIM'],
+                            'enum' => ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET', 'LANDLINE', 'uSIM'],
                         ],
                     ],
                 ],

--- a/src/Service/Provider/ClientCatalogImportService.php
+++ b/src/Service/Provider/ClientCatalogImportService.php
@@ -200,19 +200,45 @@ class ClientCatalogImportService
     }
 
     /**
+     * Deriva tags a partir del `subservice` crudo del proveedor, más un tag
+     * `UNLIMITED` adicional cuando el primer benefit es de datos ilimitados
+     * (`type=DATA` con `amount.base` negativo — convención de DTOne para
+     * "sin límite", ver Nauta PLUS). Necesario porque Nauta WIFI Recharge y
+     * Nauta PLUS comparten el mismo `subservice=Internet` pero son productos
+     * distintos (recarga de saldo vs. plan de datos ilimitado por días) —
+     * sin este tag extra quedarían indistinguibles en el catálogo.
+     *
      * @return list<string>
      */
     private function deriveTags(?CommunicationProduct $product): array
     {
-        $allowedTags = ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET'];
+        $allowedTags = ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET', 'LANDLINE'];
         $subservice = $product?->getService()['subservice']['name'] ?? null;
-        if ($subservice === null) {
-            return [];
+
+        $tags = [];
+        if ($subservice !== null) {
+            $normalized = strtoupper($subservice);
+            if (in_array($normalized, $allowedTags, true)) {
+                $tags[] = $normalized;
+            }
         }
 
-        $normalized = strtoupper($subservice);
+        if ($this->hasUnlimitedDataBenefit($product)) {
+            $tags[] = 'UNLIMITED';
+        }
 
-        return in_array($normalized, $allowedTags, true) ? [$normalized] : [];
+        return $tags;
+    }
+
+    private function hasUnlimitedDataBenefit(?CommunicationProduct $product): bool
+    {
+        $firstBenefit = ($product?->getBenefits() ?? [])[0] ?? null;
+        if (!is_array($firstBenefit)) {
+            return false;
+        }
+
+        return ($firstBenefit['type'] ?? null) === 'DATA'
+            && (float) ($firstBenefit['amount']['base'] ?? 0) < 0;
     }
 
     /**

--- a/tests/Service/Provider/ClientCatalogImportServiceTest.php
+++ b/tests/Service/Provider/ClientCatalogImportServiceTest.php
@@ -424,4 +424,107 @@ class ClientCatalogImportServiceTest extends TestCase
 
         $this->service->importForRouting($routing);
     }
+
+    // ---- deriveTags() — Nauta WiFi vs. Nauta PLUS vs. Nauta Hogar ----
+
+    private function productWithServiceAndBenefits(int $id, array $service, array $benefits): CommunicationProduct&MockObject
+    {
+        $product = $this->createMock(CommunicationProduct::class);
+        $product->method('getId')->willReturn($id);
+        $product->method('getDescription')->willReturn('Producto de prueba');
+        $product->method('getExternalRef')->willReturn('ext-1');
+        $product->method('getService')->willReturn($service);
+        $product->method('getBenefits')->willReturn($benefits);
+
+        return $product;
+    }
+
+    /**
+     * @param array<string, mixed> $service
+     * @param array<int, array<string, mixed>> $benefits
+     */
+    private function importSingleProductAndCaptureTags(array $service, array $benefits): array
+    {
+        $client = (new Client())->setCurrency('USD');
+        $environment = $this->createMock(Environment::class);
+        $environment->method('getId')->willReturn(10);
+
+        $routing = new ClientProviderRouting();
+        $routing->setClient($client);
+        $routing->setEnvironment($environment);
+        $routing->setProvider(CommunicationProviderEnum::DTONE->value);
+
+        $this->catalogSyncService->method('syncProducts')->willReturn(new SyncResult());
+
+        $product = $this->productWithServiceAndBenefits(1, $service, $benefits);
+        $account = $this->accountWithId(101, $client, $environment);
+
+        $productRepo = $this->createMock(CommunicationProductRepository::class);
+        $productRepo->method('findBy')->willReturn([$product]);
+        $accountRepo = $this->createMock(AccountRepository::class);
+        $accountRepo->method('findBy')->willReturn([$account]);
+
+        $this->em->method('getRepository')->willReturnMap([
+            [CommunicationProduct::class, $productRepo],
+            [Account::class, $accountRepo],
+            [CommunicationClientPackage::class, $this->clientPackageRepo(null)],
+        ]);
+
+        $this->materializationService->method('materializeForTenant')->willReturn(new CommunicationClientPackage());
+
+        $persisted = [];
+        $this->em->method('persist')->willReturnCallback(function ($entity) use (&$persisted) {
+            $persisted[] = $entity;
+        });
+
+        $this->service->importForRouting($routing);
+
+        return $persisted;
+    }
+
+    public function testDerivesInternetTagForNautaWifiRecharge(): void
+    {
+        $persisted = $this->importSingleProductAndCaptureTags(
+            ['name' => 'Utilities', 'subservice' => ['name' => 'Internet']],
+            [['type' => 'CREDITS', 'unit' => 'CUP', 'unit_type' => 'CURRENCY', 'amount' => ['base' => 250]]],
+        );
+
+        $this->assertSame(['INTERNET'], $persisted[0]->getTags());
+    }
+
+    /**
+     * Nauta PLUS comparte subservice=Internet con Nauta WIFI Recharge, pero
+     * su benefit es de datos ilimitados (type=DATA, amount.base=-1) — debe
+     * quedar distinguible con un tag extra, no confundirse con la recarga
+     * simple (ver conversación sobre cómo diferenciar ambos productos).
+     */
+    public function testDerivesInternetAndUnlimitedTagsForNautaPlus(): void
+    {
+        $persisted = $this->importSingleProductAndCaptureTags(
+            ['name' => 'Utilities', 'subservice' => ['name' => 'Internet']],
+            [['type' => 'DATA', 'unit' => 'MB', 'unit_type' => 'DATA', 'amount' => ['base' => -1]]],
+        );
+
+        $this->assertSame(['INTERNET', 'UNLIMITED'], $persisted[0]->getTags());
+    }
+
+    public function testDerivesLandlineTagForNautaHogar(): void
+    {
+        $persisted = $this->importSingleProductAndCaptureTags(
+            ['name' => 'Utilities', 'subservice' => ['name' => 'Landline']],
+            [['type' => 'CREDITS', 'unit' => 'CUP', 'unit_type' => 'CURRENCY', 'amount' => ['base' => 480]]],
+        );
+
+        $this->assertSame(['LANDLINE'], $persisted[0]->getTags());
+    }
+
+    public function testDerivesNoTagForUnrecognizedSubservice(): void
+    {
+        $persisted = $this->importSingleProductAndCaptureTags(
+            ['name' => 'Utilities', 'subservice' => null],
+            [['type' => 'CREDITS', 'unit' => 'CUP', 'unit_type' => 'CURRENCY', 'amount' => ['base' => 1000]]],
+        );
+
+        $this->assertSame([], $persisted[0]->getTags());
+    }
 }


### PR DESCRIPTION
## Resumen

- Extiende el enum de `tags` de paquete (`CommunicationClientPackage`/`CommunicationPackage`) con `LANDLINE` y `UNLIMITED`, y el de `service.name` con `Utilities` (valores reales de DTOne, ausentes hasta ahora del enum documentado en los DTOs de entrada/salida).
- `ClientCatalogImportService::deriveTags()` ahora deriva `LANDLINE` desde el subservice y agrega `UNLIMITED` cuando el primer benefit es de datos ilimitados (`type=DATA`, `amount.base` negativo) — necesario porque Nauta WIFI Recharge y Nauta PLUS comparten `subservice=Internet` pero son productos distintos (recarga de saldo vs. plan de datos ilimitado por días); sin este tag quedaban indistinguibles en el catálogo.
- Tests nuevos en `ClientCatalogImportServiceTest` cubriendo las 3 variantes de Nauta (WiFi Recharge, PLUS, Hogar) + un caso de subservicio no reconocido.

## Contexto

Verificado contra datos reales de staging (DTOne, `provider=DTONE`, `service=Utilities`): 43 productos Nauta WiFi/PLUS bajo `subservice=Internet` y 5 de Nauta Hogar bajo `subservice=Landline`, hoy sin forma de diferenciarse en el catálogo interno.

## Test plan

- [x] `php bin/phpunit --no-coverage` — 1058 tests, verde (corrido por el pre-push hook)
- [x] `vendor/bin/phpstan analyse` — sin errores (corrido por el pre-commit hook)
- [x] e2e de dashboard-cm (PR asociado) verificado end-to-end contra el catálogo V2, creando paquetes de las 3 variantes con estos tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeLYjtiTNMg6VWD3j6DCGK