### PR TITLE
feat(contracts): contratos por categoría (service/subservice) — Fase 1 y 2

### DIFF
--- a/migrations/Version20260823120000.php
+++ b/migrations/Version20260823120000.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Fase 1 del rediseño "contratos por categoría" (ver
+ * /home/alex/.claude/plans/immutable-knitting-candle.md): agrega
+ * clasificación service/subservice a CommunicationContract (columnas
+ * planas `service_name`/`subservice_name`, no JSON — ver docblock de la
+ * entidad) y la columna derivada `service_key` a ambas entidades
+ * (CommunicationContract y CommunicationPackage), para poder
+ * filtrar/indexar por categoría en SQL sin queries JSON (sin precedente en
+ * este repo).
+ *
+ * ESTA MIGRACIÓN NO CAMBIA COMPORTAMIENTO VISIBLE: no toca el índice único
+ * de "contrato abierto" (`uniq_com_contract_open_per_tenant_amount`, sigue
+ * siendo solo por tenant+monto+moneda) ni ningún lookup usado por
+ * PackageCatalogResolver — eso es Fase 3, deliberadamente separada porque
+ * cambia qué contrato termina cubriendo qué paquete (dato, no solo
+ * comportamiento de lectura).
+ *
+ * Backfill de `communication_package.service_key`: derivado del JSON
+ * `service` existente con la MISMA regla de normalización que
+ * ServiceCategoryKey::of() en PHP (trim, SIN uppercase — ver docblock de
+ * esa clase sobre por qué evitar case-folding en SQL).
+ *
+ * Backfill de `communication_contract.service_name/subservice_name`:
+ * copiado de CUALQUIERA de sus paquetes vinculados. Antes de hacerlo, esta
+ * migración DETECTA explícitamente si algún contrato tiene paquetes de
+ * categorías distintas entre sí (o ningún paquete vinculado) y ABORTA con
+ * un mensaje claro en vez de elegir en silencio cuál categoría usar —
+ * confirmado con SQL real contra la BD antes de escribir esta migración:
+ * 0 contratos existentes mezclan categorías hoy, así que en un entorno
+ * sano este chequeo no debería disparar nunca.
+ */
+final class Version20260823120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Contratos por categoría (Fase 1): service/subservice + service_key en CommunicationContract y CommunicationPackage';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // ── communication_package: backfill directo, sin riesgo de conflicto ──
+        $this->addSql('ALTER TABLE communication_package ADD COLUMN IF NOT EXISTS service_key VARCHAR(191) NOT NULL DEFAULT \'|\'');
+        $this->addSql(<<<'SQL'
+            UPDATE communication_package
+            SET service_key = trim(coalesce(service->>'name', '')) || '|' || trim(coalesce(service->'subservice'->>'name', ''))
+        SQL);
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_com_package_service_key ON communication_package (service_key)');
+
+        // ── communication_contract: columnas nuevas ──
+        $this->addSql('ALTER TABLE communication_contract ADD COLUMN IF NOT EXISTS service_name VARCHAR(255)');
+        $this->addSql('ALTER TABLE communication_contract ADD COLUMN IF NOT EXISTS subservice_name VARCHAR(255)');
+        $this->addSql('ALTER TABLE communication_contract ADD COLUMN IF NOT EXISTS service_key VARCHAR(191) NOT NULL DEFAULT \'|\'');
+
+        // Detección defensiva ANTES de backfillear: aborta si algún
+        // contrato tiene paquetes de más de una categoría distinta entre
+        // sí. Con datos sanos esto no debería disparar nunca (verificado
+        // contra la BD real antes de escribir esta migración).
+        //
+        // OJO: $this->connection->fetchAllAssociative() corre DE INMEDIATO,
+        // mientras que los addSql() de arriba quedan en cola y se ejecutan
+        // recién cuando up() termina — así que esta consulta NO puede
+        // depender todavía de communication_package.service_key (esa
+        // columna aún "no existe" desde el punto de vista de esta lectura
+        // inmediata). Por eso deriva la categoría inline desde el JSON
+        // crudo, con la misma expresión que el backfill de arriba.
+        $mixed = $this->connection->fetchAllAssociative(<<<'SQL'
+            SELECT c.id
+            FROM communication_contract c
+            JOIN communication_contract_package ccp ON ccp.communication_contract_id = c.id
+            JOIN communication_package p ON p.id = ccp.communication_package_id
+            GROUP BY c.id
+            HAVING count(DISTINCT (
+                trim(coalesce(p.service->>'name', '')) || '|' || trim(coalesce(p.service->'subservice'->>'name', ''))
+            )) > 1
+        SQL);
+        if ($mixed !== []) {
+            $ids = implode(', ', array_column($mixed, 'id'));
+            throw new \RuntimeException(
+                "Migración abortada: los contratos [{$ids}] tienen paquetes vinculados de más de una categoría (service/subservice) " .
+                'distinta entre sí — el backfill automático no puede elegir una sola categoría por contrato en este caso. ' .
+                'Resolver manualmente (dividir el contrato o alinear la categoría de sus paquetes) antes de reintentar esta migración.'
+            );
+        }
+
+        // Backfill: copiar la categoría de CUALQUIERA de los paquetes
+        // vinculados (ya descartamos mezcla arriba, así que da igual
+        // cuál). DISTINCT ON con paquete de menor id para ser determinista.
+        // Contratos SIN ningún paquete vinculado quedan en '|' (categoría
+        // vacía) — no es un error, es un contrato "huérfano" ya posible hoy.
+        $this->addSql(<<<'SQL'
+            UPDATE communication_contract c
+            SET service_name = sub.service_name,
+                subservice_name = sub.subservice_name,
+                service_key = sub.service_key
+            FROM (
+                SELECT DISTINCT ON (ccp.communication_contract_id)
+                    ccp.communication_contract_id,
+                    p.service->>'name' AS service_name,
+                    p.service->'subservice'->>'name' AS subservice_name,
+                    p.service_key
+                FROM communication_contract_package ccp
+                JOIN communication_package p ON p.id = ccp.communication_package_id
+                ORDER BY ccp.communication_contract_id, p.id ASC
+            ) sub
+            WHERE c.id = sub.communication_contract_id
+        SQL);
+
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_com_contract_service_key ON communication_contract (service_key)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IF EXISTS idx_com_contract_service_key');
+        $this->addSql('ALTER TABLE communication_contract DROP COLUMN IF EXISTS service_key');
+        $this->addSql('ALTER TABLE communication_contract DROP COLUMN IF EXISTS subservice_name');
+        $this->addSql('ALTER TABLE communication_contract DROP COLUMN IF EXISTS service_name');
+
+        $this->addSql('DROP INDEX IF EXISTS idx_com_package_service_key');
+        $this->addSql('ALTER TABLE communication_package DROP COLUMN IF EXISTS service_key');
+    }
+}

--- a/src/Controller/DashboardCommunicationContractsController.php
+++ b/src/Controller/DashboardCommunicationContractsController.php
@@ -266,6 +266,18 @@ class DashboardCommunicationContractsController extends AbstractController
         if ($request->query->getBoolean('openOnly')) {
             $qb->andWhere('c.endAt IS NULL');
         }
+        // Filtro de búsqueda para el admin — no afecta qué contrato resuelve
+        // el precio (eso lo decide PackageCatalogResolver, gateado por
+        // ContractGatingScopeResolver). `serviceName` solo (categoría, sin
+        // subservicio) y `serviceKey` (categoría exacta, service+subservice)
+        // son independientes para que el filtro del dashboard pueda acotar
+        // solo por servicio cuando el admin no elige subservicio.
+        if ($serviceName = $request->query->get('serviceName')) {
+            $qb->andWhere('c.serviceName = :serviceName')->setParameter('serviceName', $serviceName);
+        }
+        if ($serviceKey = $request->query->get('serviceKey')) {
+            $qb->andWhere('c.serviceKey = :serviceKey')->setParameter('serviceKey', $serviceKey);
+        }
     }
 
     private function serialize(CommunicationContract $contract): array
@@ -284,6 +296,11 @@ class DashboardCommunicationContractsController extends AbstractController
             ],
             'destinationAmount' => $contract->getDestinationAmount(),
             'destinationCurrency' => $contract->getDestinationCurrency(),
+            // Fase 1 del rediseño por categoría — informativo: a partir de
+            // ahora dos contratos legítimos pueden compartir tenant+monto+
+            // moneda y solo diferir en categoría; sin esto se verían en el
+            // listado como dos filas idénticas e indistinguibles.
+            'service' => $contract->getServiceShape(),
             'price' => $contract->getPrice(),
             'currency' => $contract->getCurrency(),
             'startAt' => $contract->getStartAt()?->format('c'),

--- a/src/DTO/Out/CommunicationContractOutDto.php
+++ b/src/DTO/Out/CommunicationContractOutDto.php
@@ -14,6 +14,15 @@ final class CommunicationContractOutDto
     public ?TenantRefOutDto $tenant = null;
     public float $destinationAmount;
     public string $destinationCurrency;
+    /**
+     * Clasificación del contrato (Fase 1 del rediseño por categoría) —
+     * mismo shape que CommunicationPackageOutDto::$service. Todavía solo
+     * informativo: no afecta qué contrato resuelve el precio (eso es Fase
+     * 3, ver PackageCatalogResolver).
+     *
+     * @var array{name?: string, subservice?: array{name?: string}}
+     */
+    public array $service = [];
     public float $price;
     public string $currency;
     public ?string $startAt = null;

--- a/src/Entity/CommunicationContract.php
+++ b/src/Entity/CommunicationContract.php
@@ -3,6 +3,7 @@
 namespace App\Entity;
 
 use App\Repository\CommunicationContractRepository;
+use App\Service\Pricing\ServiceCategoryKey;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
@@ -24,6 +25,16 @@ use Doctrine\ORM\Mapping as ORM;
  * visibilidad/precio que uno específico (ver PackageCatalogResolver, Fase
  * 2). Sin `isActive`: la vigencia es solo `startAt`/`endAt` — "pausar" es
  * cerrar (`endAt = now()`) y crear uno nuevo si se reactiva.
+ *
+ * `serviceName`/`subserviceName`/`serviceKey` (Fase 1 del rediseño de
+ * contratos por categoría, agosto 2026): clasificación del contrato, mismo
+ * vocabulario que `CommunicationPackage::$service`. Todavía NO forman parte
+ * de la identidad/unicidad del contrato ni son usados por
+ * `PackageCatalogResolver` — eso es Fase 3, deliberadamente separada porque
+ * cambia qué contrato termina cubriendo qué paquete (dato, no solo
+ * comportamiento de lectura). Por ahora son solo clasificación informativa,
+ * derivada del paquete que se le vincula (ver
+ * CommunicationContractService::upsertContract()).
  */
 #[ORM\Entity(repositoryClass: CommunicationContractRepository::class)]
 #[ORM\HasLifecycleCallbacks]
@@ -65,6 +76,35 @@ class CommunicationContract
     private ?string $destinationCurrency = null;
 
     /**
+     * Clasificación (Fase 1 del rediseño de contratos por categoría) —
+     * mismo shape de nombre/subservicio que CommunicationPackage::$service,
+     * pero guardado como columnas planas (no JSON): a diferencia del
+     * paquete, aquí no hay un shape más rico que preservar, y así
+     * `serviceKey` se deriva de una fuente única sin riesgo de que un JSON
+     * independiente se desincronice. Se setean juntos vía
+     * setServiceCategory() — nunca `$serviceKey` sola.
+     */
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $serviceName = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $subserviceName = null;
+
+    /**
+     * Derivada de $serviceName/$subserviceName vía ServiceCategoryKey — SE
+     * DERIVA EN EL SETTER (ver setServiceCategory()), nunca en un
+     * #[ORM\PreUpdate]: Doctrine ya calculó el changeset cuando corre
+     * preUpdate, así que mutar la entidad ahí no persiste sin
+     * PreUpdateEventArgs::setNewValue() (innecesariamente complejo).
+     * Derivarla en el setter es correcto y trivial. Default `'|'` (no
+     * `''`) como resguardo — coincide con lo que produce
+     * `ServiceCategoryKey::of(null, null)`, aunque el constructor ya llama
+     * a setServiceCategory(null, null) como fuente de verdad real.
+     */
+    #[ORM\Column(length: 191)]
+    private string $serviceKey = '|';
+
+    /**
      * Lo que se le cobra al cliente. CHECK >= 0 a nivel de esquema (un
      * contrato en $0 es un precio real y deliberado, ej. cortesía).
      */
@@ -98,6 +138,10 @@ class CommunicationContract
     {
         $this->startAt = new \DateTimeImmutable();
         $this->packages = new ArrayCollection();
+        // Vía setServiceCategory(), no asignación directa — mismo criterio
+        // que CommunicationPackage::__construct(): un único punto deriva
+        // $serviceKey, el default de la propiedad es solo un resguardo.
+        $this->setServiceCategory(null, null);
     }
 
     public function getId(): ?int
@@ -163,6 +207,56 @@ class CommunicationContract
         $this->destinationCurrency = $destinationCurrency;
 
         return $this;
+    }
+
+    public function getServiceName(): ?string
+    {
+        return $this->serviceName;
+    }
+
+    public function getSubserviceName(): ?string
+    {
+        return $this->subserviceName;
+    }
+
+    public function getServiceKey(): string
+    {
+        return $this->serviceKey;
+    }
+
+    /**
+     * Única forma de establecer la categoría — deriva $serviceKey en el
+     * mismo paso, no hay setServiceKey() independiente (ver docblock de la
+     * propiedad).
+     */
+    public function setServiceCategory(?string $serviceName, ?string $subserviceName): static
+    {
+        $this->serviceName = $serviceName;
+        $this->subserviceName = $subserviceName;
+        $this->serviceKey = ServiceCategoryKey::of($serviceName, $subserviceName);
+
+        return $this;
+    }
+
+    /**
+     * Shape `{name, subservice: {name}}` — mismo formato que
+     * CommunicationPackage::getService(), reconstruido desde las columnas
+     * planas para que el DTO de salida tenga forma compatible.
+     *
+     * @return array{name?: string, subservice?: array{name?: string}}
+     */
+    public function getServiceShape(): array
+    {
+        if ($this->serviceName === null) {
+            return [];
+        }
+
+        $shape = ['name' => $this->serviceName];
+        if ($this->subserviceName !== null) {
+            $shape['subservice'] = ['name' => $this->subserviceName];
+        }
+
+        return $shape;
     }
 
     public function getPrice(): ?float

--- a/src/Entity/CommunicationPackage.php
+++ b/src/Entity/CommunicationPackage.php
@@ -10,6 +10,7 @@ use ApiPlatform\OpenApi\Model\Operation as OpenApiOperation;
 use ApiPlatform\OpenApi\Model\Parameter as OpenApiParameter;
 use App\Repository\CommunicationPackageRepository;
 use App\Service\Pricing\ResolvedPackageOffer;
+use App\Service\Pricing\ServiceCategoryKey;
 use App\State\CommunicationPackageCatalogItemProvider;
 use App\State\CommunicationPackageCatalogProvider;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -221,6 +222,21 @@ class CommunicationPackage
     private array $service = [];
 
     /**
+     * Derivada de `$service` (nombre+subservicio) por ServiceCategoryKey —
+     * SE DERIVA EN setService(), nunca en un lifecycle callback (Doctrine ya
+     * calculó el changeset cuando corre preUpdate; ver mismo razonamiento
+     * en CommunicationContract::$serviceKey). Fase 1 del rediseño de
+     * contratos por categoría (agosto 2026) — permite filtrar/indexar por
+     * categoría en SQL sin queries JSON (sin precedente en este repo).
+     * Default `'|'`, NO `''` — debe coincidir con lo que produce
+     * `ServiceCategoryKey::of(null, null)` para un `service=[]` recién
+     * construido (el separador siempre está presente); un default `''`
+     * aquí divergería de la clave real que setService() derivaría.
+     */
+    #[ORM\Column(length: 191)]
+    private string $serviceKey = '|';
+
+    /**
      * @var array{quantity?: int, unit?: string}|null
      */
     #[ORM\Column(nullable: true)]
@@ -318,7 +334,10 @@ class CommunicationPackage
     {
         $this->benefits = [];
         $this->tags = [];
-        $this->service = [];
+        // Vía setService(), no asignación directa — es el único punto que
+        // deriva $serviceKey; el default de la propiedad ('|') es un
+        // resguardo, no la fuente de verdad.
+        $this->setService([]);
         $this->activeStartAt = new \DateTimeImmutable();
         $this->contracts = new ArrayCollection();
     }
@@ -404,8 +423,14 @@ class CommunicationPackage
     public function setService(array $service): static
     {
         $this->service = $service;
+        $this->serviceKey = ServiceCategoryKey::fromService($service);
 
         return $this;
+    }
+
+    public function getServiceKey(): string
+    {
+        return $this->serviceKey;
     }
 
     public function getValidity(): ?array

--- a/src/Repository/CommunicationPackageRepository.php
+++ b/src/Repository/CommunicationPackageRepository.php
@@ -47,6 +47,46 @@ class CommunicationPackageRepository extends ServiceEntityRepository
     }
 
     /**
+     * Igual que findActiveCatalog() pero excluye categorías ya resueltas por
+     * contrato (Fase 2 del rediseño de contratos por categoría) — evita que
+     * PackageCatalogResolver::catalogFor() dispare el cálculo de precio MAX
+     * (findMatchingDestination() + N resoluciones de precio) sobre paquetes
+     * de categorías que de todas formas se van a descartar porque ya las
+     * cubre un contrato. Sin esto, un tenant 100% cubierto por contratos
+     * pagaría el costo de una consulta que hoy (regla "todo o nada" por
+     * tenant) NUNCA se ejecuta.
+     *
+     * $serviceKeys VACÍO delega en findActiveCatalog() a propósito: un
+     * `NOT IN ()` con lista vacía compila a `NOT IN (NULL)` en Postgres (vía
+     * el binding de parámetros de Doctrine) y devuelve CERO filas — el
+     * comportamiento correcto acá es "ninguna categoría excluida todavía",
+     * no "excluir todo".
+     *
+     * @param list<string> $serviceKeys
+     */
+    public function findActiveCatalogExcludingCategories(array $serviceKeys, ?\DateTimeImmutable $now = null): array
+    {
+        if ($serviceKeys === []) {
+            return $this->findActiveCatalog($now);
+        }
+
+        $now ??= new \DateTimeImmutable();
+
+        return $this->createQueryBuilder('p')
+            ->andWhere('p.isActive = :active')
+            ->andWhere('p.activeStartAt <= :now')
+            ->andWhere('p.activeEndAt IS NULL OR p.activeEndAt > :now')
+            ->andWhere('p.serviceKey NOT IN (:serviceKeys)')
+            ->setParameter('active', true)
+            ->setParameter('now', $now)
+            ->setParameter('serviceKeys', $serviceKeys)
+            ->orderBy('p.displayOrder', 'ASC')
+            ->addOrderBy('p.id', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
      * Paquetes que entrarán en vigencia a futuro (típicamente tramos de una
      * promoción V2 aún no arrancada) — alimenta
      * /communication/packages/upcoming para cuentas V2

--- a/src/Service/Catalog/ContractGatingScopeResolver.php
+++ b/src/Service/Catalog/ContractGatingScopeResolver.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Service\Catalog;
+
+use App\Entity\Account;
+use App\Repository\SysConfigRepository;
+
+/**
+ * Decide si `PackageCatalogResolver` restringe visibilidad "todo o nada"
+ * POR TENANT completo (regla histórica) o POR CATEGORÍA (service/subservice
+ * — Fase 2 del rediseño de contratos por categoría) — mismo idioma que
+ * `CatalogVersionResolver::isV2()`: sys_config, sin desplegar para
+ * activar/desactivar por cliente, dinero real de por medio.
+ *
+ * Sin ninguna de las dos claves seteadas, isCategoryScoped() siempre es
+ * false — "flag OFF = comportamiento idéntico" (ningún cliente existente
+ * cambia de comportamiento el día del deploy de esta fase).
+ *
+ * Precedencia: si el cliente de la cuenta está en la lista explícita de
+ * `communications.catalog.contract_gating.pilot_clients`, usa gating por
+ * categoría SIEMPRE (aunque el default global siga siendo `tenant`) — así
+ * se puede pilotar con un cliente concreto sin mover el default. Si no está
+ * en la lista, se usa el default global.
+ */
+final class ContractGatingScopeResolver
+{
+    public const SCOPE_KEY = 'communications.catalog.contract_gating_scope';
+    public const PILOT_CLIENTS_KEY = 'communications.catalog.contract_gating.pilot_clients';
+
+    public function __construct(
+        private readonly SysConfigRepository $sysConfigRepo,
+    ) {
+    }
+
+    public function isCategoryScoped(Account $account): bool
+    {
+        $clientId = $account->getClient()?->getId();
+        if ($clientId !== null && in_array((string) $clientId, $this->pilotClientIds(), true)) {
+            return true;
+        }
+
+        return $this->sysConfigRepo->findCachedValue(self::SCOPE_KEY) === 'category';
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function pilotClientIds(): array
+    {
+        $csv = $this->sysConfigRepo->findCachedValue(self::PILOT_CLIENTS_KEY);
+        if ($csv === null || trim($csv) === '') {
+            return [];
+        }
+
+        return array_values(array_filter(array_map('trim', explode(',', $csv)), static fn (string $id) => $id !== ''));
+    }
+}

--- a/src/Service/Catalog/UpcomingPackageCatalogResolver.php
+++ b/src/Service/Catalog/UpcomingPackageCatalogResolver.php
@@ -23,6 +23,13 @@ use App\Service\Pricing\ResolvedPackageOffer;
  * CommunicationPackage::getContracts() en un servicio exclusivo del
  * preview, sin tocar la precedencia de PackageCatalogResolver::catalogFor()/
  * offerFor().
+ *
+ * Segundo consumidor de la regla "todo o nada" de contratos (encontrado en
+ * la revisión de la Fase 2, no en el diseño original) — respeta el MISMO
+ * kill switch que PackageCatalogResolver (ContractGatingScopeResolver): con
+ * el flag apagado (default), el gateo sigue siendo por tenant completo,
+ * sin cambios; con el flag encendido, se evalúa por categoría (ver
+ * isGatedAway()).
  */
 class UpcomingPackageCatalogResolver
 {
@@ -30,6 +37,7 @@ class UpcomingPackageCatalogResolver
         private readonly CommunicationPackageRepository $packageRepository,
         private readonly CommunicationContractRepository $contractRepository,
         private readonly BenefitOperationResolver $benefitResolver,
+        private readonly ContractGatingScopeResolver $gatingScopeResolver,
     ) {
     }
 
@@ -41,16 +49,18 @@ class UpcomingPackageCatalogResolver
         $now ??= new \DateTimeImmutable();
 
         $ownActiveContracts = $this->contractRepository->findActiveForTenant($tenant, $now);
+        $categoryScoped = $this->gatingScopeResolver->isCategoryScoped($tenant);
 
         $packages = [];
         foreach ($this->packageRepository->findUpcoming($now) as $package) {
             // Fuga de prioridad de tenant: si la cuenta ya tiene contrato(s)
-            // propio(s) vigente(s) y ninguno cubre este paquete, cuando la
-            // promoción arranque su contrato "por defecto" NO le va a ganar
-            // al contrato propio (ver PackageCatalogResolver::catalogFor())
-            // — no tiene sentido mostrar un preview de algo que después no
-            // le va a aparecer.
-            if ($ownActiveContracts !== [] && !$this->coveredByAnyContract($package, $ownActiveContracts)) {
+            // propio(s) vigente(s) (de la categoría del paquete, cuando el
+            // flag está en "category") y ninguno cubre este paquete, cuando
+            // la promoción arranque su contrato "por defecto" NO le va a
+            // ganar al contrato propio (ver PackageCatalogResolver::
+            // catalogFor()) — no tiene sentido mostrar un preview de algo
+            // que después no le va a aparecer.
+            if ($this->isGatedAway($package, $ownActiveContracts, $categoryScoped)) {
                 continue;
             }
 
@@ -75,6 +85,41 @@ class UpcomingPackageCatalogResolver
         }
 
         return $packages;
+    }
+
+    /**
+     * Flag apagado (alcance tenant, default): gateado si el tenant tiene
+     * CUALQUIER contrato propio vigente y ninguno cubre este paquete —
+     * comportamiento histórico, sin cambios.
+     *
+     * Flag encendido (alcance category): gateado solo si el tenant tiene
+     * contrato propio vigente EN LA CATEGORÍA de este paquete y ninguno de
+     * esos lo cubre. Sin contrato propio en esta categoría (aunque tenga en
+     * otras) → no gateado, cae al contrato "por defecto" o queda sin
+     * preview, igual que si el tenant no tuviera contrato en absoluto.
+     *
+     * @param list<CommunicationContract> $ownActiveContracts
+     */
+    private function isGatedAway(CommunicationPackage $package, array $ownActiveContracts, bool $categoryScoped): bool
+    {
+        if ($ownActiveContracts === []) {
+            return false;
+        }
+
+        if (!$categoryScoped) {
+            return !$this->coveredByAnyContract($package, $ownActiveContracts);
+        }
+
+        $categoryContracts = array_values(array_filter(
+            $ownActiveContracts,
+            static fn (CommunicationContract $c) => $c->getServiceKey() === $package->getServiceKey(),
+        ));
+
+        if ($categoryContracts === []) {
+            return false;
+        }
+
+        return !$this->coveredByAnyContract($package, $categoryContracts);
     }
 
     /**

--- a/src/Service/Pricing/CommunicationContractService.php
+++ b/src/Service/Pricing/CommunicationContractService.php
@@ -399,10 +399,17 @@ class CommunicationContractService
 
         $contract = $this->contractRepository->findOpenContract($tenant, $amount, $currency);
         if ($contract === null) {
+            $service = $package->getService();
             $contract = (new CommunicationContract())
                 ->setTenant($tenant)
                 ->setDestinationAmount($amount)
-                ->setDestinationCurrency($currency);
+                ->setDestinationCurrency($currency)
+                // Fase 1 del rediseño por categoría (ver docblock de
+                // CommunicationContract): solo clasificación informativa
+                // por ahora, todavía NO forma parte de la identidad del
+                // contrato ni se usa para elegir/matchear uno existente
+                // arriba (eso es Fase 3).
+                ->setServiceCategory($service['name'] ?? null, $service['subservice']['name'] ?? null);
             $this->em->persist($contract);
             $contract->addPackage($package);
 

--- a/src/Service/Pricing/PackageCatalogResolver.php
+++ b/src/Service/Pricing/PackageCatalogResolver.php
@@ -10,6 +10,7 @@ use App\Repository\CommunicationContractRepository;
 use App\Repository\CommunicationPackageRepository;
 use App\Repository\CommunicationProductRepository;
 use App\Repository\SysConfigRepository;
+use App\Service\Catalog\ContractGatingScopeResolver;
 use App\Service\Provider\ProductPriceResolver;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -21,17 +22,38 @@ use Symfony\Component\HttpFoundation\Response;
  * visibilidad (no solo precio): un cliente con contrato solo ve lo que su
  * contrato cubre, nada más.
  *
- * Precedencia (misma para catalogFor() y offerFor(), nunca diverge):
- *  1. Contratos propios vigentes del tenant — si hay al menos uno, el
- *     catálogo visible es EXACTAMENTE esos paquetes, a su precio.
+ * Desde la Fase 2 del rediseño de contratos por categoría, el ALCANCE de
+ * esa restricción "todo o nada" depende de
+ * `ContractGatingScopeResolver::isCategoryScoped()` (sys_config, kill
+ * switch — ver esa clase):
+ *
+ *  - Alcance TENANT (default, comportamiento histórico sin cambios —
+ *    catalogForTenantScope()/offerForTenantScope()): un contrato propio (o
+ *    "por defecto") vigente restringe TODO el catálogo del cliente,
+ *    cualquier categoría, a lo cubierto por sus contratos.
+ *  - Alcance CATEGORY (nuevo, detrás del flag —
+ *    catalogForCategoryScope()/offerForCategoryScope()): la restricción se
+ *    evalúa POR CATEGORÍA (service+subservice, ver ServiceCategoryKey). Una
+ *    categoría con al menos un contrato (propio o por defecto) del tenant
+ *    queda restringida a lo cubierto; una categoría SIN ningún contrato
+ *    sigue cayendo a MAX+margen, como si el tenant no tuviera contrato en
+ *    absoluto — exactamente igual que hoy cuando NO hay NINGÚN contrato.
+ *
+ * Precedencia dentro de cada alcance (misma para catalogFor() y offerFor(),
+ * nunca diverge):
+ *  1. Contratos propios vigentes del tenant (de la categoría, en alcance
+ *     CATEGORY) — si hay al menos uno, lo visible es EXACTAMENTE esos
+ *     paquetes, a su precio.
  *  2. Sin contrato propio: contratos "por defecto" (tenant IS NULL)
- *     vigentes — mismo efecto de restricción de visibilidad.
- *  3. Sin ningún contrato: catálogo activo completo, precio = MAX(price)
- *     entre los CommunicationProduct de cualquier proveedor que cubran la
- *     tupla (convertido a la moneda del cliente) + margen porcentual fijo
- *     global (sys_config). Un paquete sin ningún proveedor que lo cubra
- *     resuelve a UNAVAILABLE — catalogFor() lo excluye del resultado (vista
- *     de cliente); offerFor() lo devuelve tal cual (vista de admin, ver
+ *     vigentes (de la categoría, en alcance CATEGORY) — mismo efecto de
+ *     restricción de visibilidad.
+ *  3. Sin ningún contrato: paquetes activos (de la categoría no gateada, en
+ *     alcance CATEGORY), precio = MAX(price) entre los CommunicationProduct
+ *     de cualquier proveedor que cubran la tupla (convertido a la moneda
+ *     del cliente) + margen porcentual fijo global (sys_config). Un
+ *     paquete sin ningún proveedor que lo cubra resuelve a UNAVAILABLE —
+ *     catalogFor() lo excluye del resultado (vista de cliente); offerFor()
+ *     lo devuelve tal cual (vista de admin, ver
  *     DashboardCommunicationPackagesController en Fase 3).
  */
 class PackageCatalogResolver
@@ -44,6 +66,7 @@ class PackageCatalogResolver
         private readonly CommunicationProductRepository $productRepository,
         private readonly ProductPriceResolver $productPriceResolver,
         private readonly SysConfigRepository $sysConfigRepo,
+        private readonly ContractGatingScopeResolver $gatingScopeResolver,
         #[Autowire('@monolog.logger.provider')]
         private readonly LoggerInterface $providerLogger,
     ) {
@@ -58,25 +81,11 @@ class PackageCatalogResolver
     {
         $now ??= new \DateTimeImmutable();
 
-        $tenantContracts = $this->contractRepository->findActiveForTenant($account, $now);
-        if ($tenantContracts !== []) {
-            return $this->offersFromContracts($tenantContracts, PackageOfferSourceEnum::TENANT_CONTRACT);
+        if (!$this->gatingScopeResolver->isCategoryScoped($account)) {
+            return $this->catalogForTenantScope($account, $now);
         }
 
-        $defaultContracts = $this->contractRepository->findActiveDefaults($now);
-        if ($defaultContracts !== []) {
-            return $this->offersFromContracts($defaultContracts, PackageOfferSourceEnum::DEFAULT_CONTRACT);
-        }
-
-        $offers = [];
-        foreach ($this->packageRepository->findActiveCatalog($now) as $package) {
-            $offer = $this->offerFromProductMax($package, $account);
-            if ($offer->source !== PackageOfferSourceEnum::UNAVAILABLE) {
-                $offers[] = $offer;
-            }
-        }
-
-        return $offers;
+        return $this->catalogForCategoryScope($account, $now);
     }
 
     /**
@@ -88,17 +97,11 @@ class PackageCatalogResolver
     {
         $now ??= new \DateTimeImmutable();
 
-        $tenantContracts = $this->contractRepository->findActiveForTenant($account, $now);
-        if ($tenantContracts !== []) {
-            return $this->offerFromContractsForPackage($tenantContracts, $package, PackageOfferSourceEnum::TENANT_CONTRACT);
+        if (!$this->gatingScopeResolver->isCategoryScoped($account)) {
+            return $this->offerForTenantScope($package, $account, $now);
         }
 
-        $defaultContracts = $this->contractRepository->findActiveDefaults($now);
-        if ($defaultContracts !== []) {
-            return $this->offerFromContractsForPackage($defaultContracts, $package, PackageOfferSourceEnum::DEFAULT_CONTRACT);
-        }
-
-        return $this->offerFromProductMax($package, $account);
+        return $this->offerForCategoryScope($package, $account, $now);
     }
 
     /**
@@ -107,6 +110,9 @@ class PackageCatalogResolver
      * ninguno cubre este paquete (offerFor() devolvió null).
      * `PACKAGE_PRICE_UNAVAILABLE` = visible pero sin proveedor que lo cubra
      * (mismo codeWork que ya usa PackageSalePriceResolver para V1).
+     *
+     * Delega en offerFor() para TODO — incluido el alcance tenant/category
+     * del kill switch: no hay ninguna ruta de compra que lo evite.
      */
     public function offerForSale(CommunicationPackage $package, Account $account, ?\DateTimeImmutable $now = null): ResolvedPackageOffer
     {
@@ -131,6 +137,133 @@ class PackageCatalogResolver
     }
 
     /**
+     * Alcance TENANT (default) — comportamiento histórico, SIN CAMBIOS
+     * respecto a antes de la Fase 2: la presencia de cualquier contrato
+     * propio (o por defecto) restringe TODO el catálogo, cualquier
+     * categoría.
+     */
+    private function catalogForTenantScope(Account $account, \DateTimeImmutable $now): array
+    {
+        $tenantContracts = $this->contractRepository->findActiveForTenant($account, $now);
+        if ($tenantContracts !== []) {
+            return $this->offersFromContracts($tenantContracts, PackageOfferSourceEnum::TENANT_CONTRACT);
+        }
+
+        $defaultContracts = $this->contractRepository->findActiveDefaults($now);
+        if ($defaultContracts !== []) {
+            return $this->offersFromContracts($defaultContracts, PackageOfferSourceEnum::DEFAULT_CONTRACT);
+        }
+
+        $offers = [];
+        foreach ($this->packageRepository->findActiveCatalog($now) as $package) {
+            $offer = $this->offerFromProductMax($package, $account);
+            if ($offer->source !== PackageOfferSourceEnum::UNAVAILABLE) {
+                $offers[] = $offer;
+            }
+        }
+
+        return $offers;
+    }
+
+    /**
+     * Alcance CATEGORY (Fase 2, detrás del flag) — la MISMA precedencia de
+     * 3 niveles que catalogForTenantScope(), pero evaluada
+     * independientemente por cada categoría (service+subservice) en vez de
+     * una sola vez para todo el tenant.
+     */
+    private function catalogForCategoryScope(Account $account, \DateTimeImmutable $now): array
+    {
+        $tenantByCategory = $this->groupByCategory($this->contractRepository->findActiveForTenant($account, $now));
+        $defaultByCategory = $this->groupByCategory($this->contractRepository->findActiveDefaults($now));
+
+        $offers = [];
+        $seenPackageIds = [];
+        $gatedCategories = [];
+
+        foreach ($tenantByCategory as $categoryKey => $contracts) {
+            $gatedCategories[$categoryKey] = true;
+            array_push($offers, ...$this->offersFromContracts($contracts, PackageOfferSourceEnum::TENANT_CONTRACT, $seenPackageIds));
+        }
+        foreach ($defaultByCategory as $categoryKey => $contracts) {
+            if (isset($gatedCategories[$categoryKey])) {
+                continue; // el tenant ya gobierna esta categoría con contrato propio
+            }
+            $gatedCategories[$categoryKey] = true;
+            array_push($offers, ...$this->offersFromContracts($contracts, PackageOfferSourceEnum::DEFAULT_CONTRACT, $seenPackageIds));
+        }
+
+        // Categorías SIN ningún contrato (ni propio ni por defecto): caen a
+        // MAX+margen, exactamente como el catálogo entero cae hoy cuando no
+        // hay ningún contrato en absoluto (catalogForTenantScope() rama 3).
+        foreach ($this->packageRepository->findActiveCatalogExcludingCategories(array_keys($gatedCategories), $now) as $package) {
+            $offer = $this->offerFromProductMax($package, $account);
+            if ($offer->source !== PackageOfferSourceEnum::UNAVAILABLE) {
+                $offers[] = $offer;
+            }
+        }
+
+        return $offers;
+    }
+
+    private function offerForTenantScope(CommunicationPackage $package, Account $account, \DateTimeImmutable $now): ?ResolvedPackageOffer
+    {
+        $tenantContracts = $this->contractRepository->findActiveForTenant($account, $now);
+        if ($tenantContracts !== []) {
+            return $this->offerFromContractsForPackage($tenantContracts, $package, PackageOfferSourceEnum::TENANT_CONTRACT);
+        }
+
+        $defaultContracts = $this->contractRepository->findActiveDefaults($now);
+        if ($defaultContracts !== []) {
+            return $this->offerFromContractsForPackage($defaultContracts, $package, PackageOfferSourceEnum::DEFAULT_CONTRACT);
+        }
+
+        return $this->offerFromProductMax($package, $account);
+    }
+
+    private function offerForCategoryScope(CommunicationPackage $package, Account $account, \DateTimeImmutable $now): ?ResolvedPackageOffer
+    {
+        $categoryKey = $package->getServiceKey();
+
+        $tenantContracts = $this->filterByCategory($this->contractRepository->findActiveForTenant($account, $now), $categoryKey);
+        if ($tenantContracts !== []) {
+            return $this->offerFromContractsForPackage($tenantContracts, $package, PackageOfferSourceEnum::TENANT_CONTRACT);
+        }
+
+        $defaultContracts = $this->filterByCategory($this->contractRepository->findActiveDefaults($now), $categoryKey);
+        if ($defaultContracts !== []) {
+            return $this->offerFromContractsForPackage($defaultContracts, $package, PackageOfferSourceEnum::DEFAULT_CONTRACT);
+        }
+
+        return $this->offerFromProductMax($package, $account);
+    }
+
+    /**
+     * @param list<CommunicationContract> $contracts
+     * @return array<string, list<CommunicationContract>>
+     */
+    private function groupByCategory(array $contracts): array
+    {
+        $grouped = [];
+        foreach ($contracts as $contract) {
+            $grouped[$contract->getServiceKey()][] = $contract;
+        }
+
+        return $grouped;
+    }
+
+    /**
+     * @param list<CommunicationContract> $contracts
+     * @return list<CommunicationContract>
+     */
+    private function filterByCategory(array $contracts, string $categoryKey): array
+    {
+        return array_values(array_filter(
+            $contracts,
+            static fn (CommunicationContract $c) => $c->getServiceKey() === $categoryKey,
+        ));
+    }
+
+    /**
      * Aplana: por cada contrato, por cada CommunicationPackage de su
      * colección (Fase 6 — un contrato puede cubrir varios), una oferta.
      * Dedup defensivo por packageId — un paquete nunca debería aparecer dos
@@ -138,13 +271,23 @@ class PackageCatalogResolver
      * guarda como cinturón de seguridad ante contratos superpuestos creados
      * a mano.
      *
+     * $seenPackageIds se pasa por referencia y, si el caller no da uno
+     * explícito, cada llamada arranca con un array vacío propio (mismo
+     * comportamiento que antes de la Fase 2, usado por
+     * catalogForTenantScope() sin cambios). catalogForCategoryScope() SÍ
+     * pasa uno compartido entre varias llamadas (una por categoría) para
+     * que el dedup cubra TODO el catálogo, no solo un grupo — si el
+     * invariante "todos los paquetes de un contrato comparten categoría"
+     * se violara por un bug futuro, un paquete en contratos de más de una
+     * categoría no aparecería duplicado.
+     *
      * @param list<CommunicationContract> $contracts
+     * @param array<int|string, bool> $seenPackageIds
      * @return list<ResolvedPackageOffer>
      */
-    private function offersFromContracts(array $contracts, PackageOfferSourceEnum $source): array
+    private function offersFromContracts(array $contracts, PackageOfferSourceEnum $source, array &$seenPackageIds = []): array
     {
         $offers = [];
-        $seenPackageIds = [];
         foreach ($contracts as $contract) {
             foreach ($contract->getPackages() as $package) {
                 if (isset($seenPackageIds[$package->getId()])) {

--- a/src/Service/Pricing/ServiceCategoryKey.php
+++ b/src/Service/Pricing/ServiceCategoryKey.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Service\Pricing;
+
+/**
+ * Normaliza la clasificación (service.name, service.subservice.name) de un
+ * CommunicationPackage/CommunicationContract para poder compararla — mismo
+ * espíritu que DestinationKey para la tupla monto/moneda, pero SIN
+ * case-folding: a diferencia de una moneda (alfabeto ISO fijo, 3 letras),
+ * `service`/`subservice` es texto libre proveniente de proveedores
+ * (Mobile/Utilities/Airtime/Internet/...) y esta clave también se calcula
+ * en SQL (columnas `service_key` derivadas por migración/backfill) — si
+ * normalizáramos mayúsculas, PHP `strtoupper()` (byte-wise, ASCII) y
+ * Postgres `upper()` (locale-aware) podrían divergir para nombres con
+ * acentos u otros caracteres no-ASCII. Comparar con trim() puro evita esa
+ * clase de bug: mismo resultado en cualquier lenguaje, sin ambigüedad.
+ *
+ * El vocabulario de `service`/`subservice` es controlado (documentado como
+ * enum en los DTOs/entidades, ver CommunicationPackage) — nunca debería
+ * contener el separador `|`; un nombre real con `|` se rechaza en el DTO de
+ * entrada correspondiente, no se escapa aquí.
+ */
+final class ServiceCategoryKey
+{
+    private function __construct()
+    {
+        // Solo métodos estáticos — no instanciar.
+    }
+
+    /**
+     * Clave de comparación normalizada: "{name}|{subserviceName}", ambos
+     * recortados de espacios, cadena vacía si están ausentes — nunca null,
+     * así sirve directo como key de array PHP (el separador `|` garantiza
+     * que la clave nunca sea puramente numérica y se coerciona a int).
+     */
+    public static function of(?string $name, ?string $subserviceName): string
+    {
+        return sprintf('%s|%s', trim($name ?? ''), trim($subserviceName ?? ''));
+    }
+
+    /**
+     * @param array{name?: string, subservice?: array{name?: string}} $service
+     */
+    public static function fromService(array $service): string
+    {
+        return self::of(
+            $service['name'] ?? null,
+            $service['subservice']['name'] ?? null,
+        );
+    }
+
+    public static function matches(?string $nameA, ?string $subserviceA, ?string $nameB, ?string $subserviceB): bool
+    {
+        return self::of($nameA, $subserviceA) === self::of($nameB, $subserviceB);
+    }
+}

--- a/tests/Functional/Pricing/DashboardCommunicationContractsControllerListTest.php
+++ b/tests/Functional/Pricing/DashboardCommunicationContractsControllerListTest.php
@@ -120,4 +120,37 @@ class DashboardCommunicationContractsControllerListTest extends ProviderFunction
         $this->assertCount(1, $data['results']);
         $this->assertSame($shared->getId(), $data['results'][0]['id']);
     }
+
+    public function testListFiltersByServiceNameAlone(): void
+    {
+        // Fase 2, filtro de categoría en el dashboard: `serviceName` acota
+        // por servicio SIN exigir subservicio (a diferencia de `serviceKey`,
+        // que exige la combinación exacta) — así el admin puede filtrar
+        // "todo Mobile" sin elegir un subservicio concreto.
+        $mobile = (new CommunicationContract())
+            ->addPackage($this->communicationPackage('Recarga Mobile'))
+            ->setDestinationAmount(500.0)
+            ->setDestinationCurrency('CUP')
+            ->setPrice(10.0)
+            ->setCurrency('USD')
+            ->setServiceCategory('Mobile', 'AIRTIME');
+        $this->em->persist($mobile);
+
+        $utilities = (new CommunicationContract())
+            ->addPackage($this->communicationPackage('Nauta WiFi'))
+            ->setDestinationAmount(250.0)
+            ->setDestinationCurrency('CUP')
+            ->setPrice(5.0)
+            ->setCurrency('USD')
+            ->setServiceCategory('Utilities', 'INTERNET');
+        $this->em->persist($utilities);
+        $this->em->flush();
+        $this->em->clear();
+
+        $response = $this->controller()->list(new Request(['serviceName' => 'Mobile']));
+        $data = json_decode($response->getContent(), true);
+
+        $this->assertCount(1, $data['results']);
+        $this->assertSame($mobile->getId(), $data['results'][0]['id']);
+    }
 }

--- a/tests/Service/Catalog/ContractGatingScopeResolverTest.php
+++ b/tests/Service/Catalog/ContractGatingScopeResolverTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Tests\Service\Catalog;
+
+use App\Entity\Account;
+use App\Entity\Client;
+use App\Repository\SysConfigRepository;
+use App\Service\Catalog\ContractGatingScopeResolver;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \App\Service\Catalog\ContractGatingScopeResolver
+ */
+class ContractGatingScopeResolverTest extends TestCase
+{
+    private SysConfigRepository&MockObject $sysConfigRepo;
+    private ContractGatingScopeResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->sysConfigRepo = $this->createMock(SysConfigRepository::class);
+        $this->resolver = new ContractGatingScopeResolver($this->sysConfigRepo);
+    }
+
+    private function accountWithClient(?int $clientId): Account&MockObject
+    {
+        $account = $this->createMock(Account::class);
+        if ($clientId === null) {
+            $account->method('getClient')->willReturn(null);
+
+            return $account;
+        }
+
+        $client = $this->createMock(Client::class);
+        $client->method('getId')->willReturn($clientId);
+        $account->method('getClient')->willReturn($client);
+
+        return $account;
+    }
+
+    public function testIsCategoryScopedFalseWhenNeitherKeyIsSet(): void
+    {
+        $this->sysConfigRepo->method('findCachedValue')->willReturn(null);
+
+        $this->assertFalse($this->resolver->isCategoryScoped($this->accountWithClient(1)));
+    }
+
+    public function testIsCategoryScopedTrueWhenGlobalDefaultIsCategory(): void
+    {
+        $this->sysConfigRepo->method('findCachedValue')
+            ->willReturnCallback(fn (string $key) => $key === ContractGatingScopeResolver::SCOPE_KEY ? 'category' : null);
+
+        $this->assertTrue($this->resolver->isCategoryScoped($this->accountWithClient(1)));
+    }
+
+    public function testIsCategoryScopedFalseWhenGlobalDefaultIsSomethingOtherThanCategory(): void
+    {
+        $this->sysConfigRepo->method('findCachedValue')
+            ->willReturnCallback(fn (string $key) => $key === ContractGatingScopeResolver::SCOPE_KEY ? 'tenant' : null);
+
+        $this->assertFalse($this->resolver->isCategoryScoped($this->accountWithClient(1)));
+    }
+
+    public function testIsCategoryScopedTrueWhenClientIsInTheExplicitPilotList(): void
+    {
+        $this->sysConfigRepo->method('findCachedValue')
+            ->willReturnCallback(fn (string $key) => $key === ContractGatingScopeResolver::PILOT_CLIENTS_KEY ? '3, 7, 12' : null);
+
+        $this->assertTrue($this->resolver->isCategoryScoped($this->accountWithClient(7)));
+        $this->assertFalse($this->resolver->isCategoryScoped($this->accountWithClient(8)));
+    }
+
+    public function testExplicitPilotListWinsOverGlobalDefault(): void
+    {
+        // El default global es "tenant" (regla vieja), pero el cliente 7
+        // está pilotando "category" explícitamente.
+        $this->sysConfigRepo->method('findCachedValue')
+            ->willReturnCallback(fn (string $key) => match ($key) {
+                ContractGatingScopeResolver::SCOPE_KEY => 'tenant',
+                ContractGatingScopeResolver::PILOT_CLIENTS_KEY => '7',
+                default => null,
+            });
+
+        $this->assertTrue($this->resolver->isCategoryScoped($this->accountWithClient(7)));
+    }
+
+    public function testIsCategoryScopedFalseWhenAccountHasNoClient(): void
+    {
+        $this->sysConfigRepo->method('findCachedValue')
+            ->willReturnCallback(fn (string $key) => $key === ContractGatingScopeResolver::PILOT_CLIENTS_KEY ? '1' : null);
+
+        $this->assertFalse($this->resolver->isCategoryScoped($this->accountWithClient(null)));
+    }
+}

--- a/tests/Service/Catalog/UpcomingPackageCatalogResolverTest.php
+++ b/tests/Service/Catalog/UpcomingPackageCatalogResolverTest.php
@@ -7,6 +7,8 @@ use App\Entity\CommunicationContract;
 use App\Entity\CommunicationPackage;
 use App\Repository\CommunicationContractRepository;
 use App\Repository\CommunicationPackageRepository;
+use App\Repository\SysConfigRepository;
+use App\Service\Catalog\ContractGatingScopeResolver;
 use App\Service\Catalog\UpcomingPackageCatalogResolver;
 use App\Service\Pricing\BenefitOperationResolver;
 use App\Service\Pricing\PackageOfferSourceEnum;
@@ -15,12 +17,18 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \App\Service\Catalog\UpcomingPackageCatalogResolver
+ *
+ * Todos los tests corren con ContractGatingScopeResolver devolviendo
+ * `false` (alcance tenant, default) salvo el bloque "alcance category" al
+ * final — mismo criterio que PackageCatalogResolverTest.
  */
 class UpcomingPackageCatalogResolverTest extends TestCase
 {
     private CommunicationPackageRepository&MockObject $packageRepository;
     private CommunicationContractRepository&MockObject $contractRepository;
     private BenefitOperationResolver&MockObject $benefitResolver;
+    private SysConfigRepository&MockObject $gatingSysConfigRepo;
+    private ContractGatingScopeResolver $gatingScopeResolver;
     private UpcomingPackageCatalogResolver $resolver;
 
     protected function setUp(): void
@@ -30,7 +38,20 @@ class UpcomingPackageCatalogResolverTest extends TestCase
         $this->benefitResolver = $this->createMock(BenefitOperationResolver::class);
         $this->benefitResolver->method('resolve')->willReturnCallback(static fn (CommunicationPackage $p) => $p->getBenefits());
 
-        $this->resolver = new UpcomingPackageCatalogResolver($this->packageRepository, $this->contractRepository, $this->benefitResolver);
+        // ContractGatingScopeResolver es `final` — instancia real sobre un
+        // SysConfigRepository mockeado propio, mismo criterio (y misma
+        // razón para NO poner un willReturn(null) de relleno acá) que
+        // PackageCatalogResolverTest.
+        $this->gatingSysConfigRepo = $this->createMock(SysConfigRepository::class);
+        $this->gatingScopeResolver = new ContractGatingScopeResolver($this->gatingSysConfigRepo);
+
+        $this->resolver = new UpcomingPackageCatalogResolver($this->packageRepository, $this->contractRepository, $this->benefitResolver, $this->gatingScopeResolver);
+    }
+
+    private function enableCategoryScope(): void
+    {
+        $this->gatingSysConfigRepo->method('findCachedValue')
+            ->willReturnCallback(fn (string $key) => $key === ContractGatingScopeResolver::SCOPE_KEY ? 'category' : null);
     }
 
     private function assignId(object $entity, int $id): void
@@ -58,6 +79,22 @@ class UpcomingPackageCatalogResolverTest extends TestCase
             ->setPrice($price)->setCurrency($currency)
             ->setStartAt($startAt);
         $this->assignId($contract, random_int(1000, 999999));
+
+        return $contract;
+    }
+
+    private function packageInCategory(int $id, string $serviceName, string $subserviceName): CommunicationPackage
+    {
+        $package = $this->package($id);
+        $package->setService(['name' => $serviceName, 'subservice' => ['name' => $subserviceName]]);
+
+        return $package;
+    }
+
+    private function contractInCategory(?Account $tenant, float $price, \DateTimeImmutable $startAt, string $serviceName, string $subserviceName): CommunicationContract
+    {
+        $contract = $this->contract($tenant, $price, $startAt);
+        $contract->setServiceCategory($serviceName, $subserviceName);
 
         return $contract;
     }
@@ -185,5 +222,61 @@ class UpcomingPackageCatalogResolverTest extends TestCase
 
         $this->assertCount(1, $result);
         $this->assertSame(9.0, $result[0]->getAmount());
+    }
+
+    // ---- Fase 2: alcance CATEGORY (ContractGatingScopeResolver::isCategoryScoped() === true) ----
+
+    public function testCategoryScopeStillShowsPreviewWhenPackageIsInACategoryWithoutAnyTenantContract(): void
+    {
+        // El tenant tiene contrato propio activo en Mobile/Airtime (otro
+        // paquete), pero el paquete próximo a arrancar es Utilities/Internet
+        // — categoría sin ningún contrato propio del tenant, así que NO
+        // debe gatearse: cae al contrato "por defecto" de su categoría,
+        // igual que si el tenant no tuviera contrato en absoluto.
+        $this->enableCategoryScope();
+
+        $tenant = $this->createMock(Account::class);
+        $tenant->method('getId')->willReturn(1);
+
+        $otherPackage = $this->packageInCategory(1, 'Mobile', 'Airtime');
+        $ownActiveContract = $this->contractInCategory($tenant, 5.0, new \DateTimeImmutable('-1 day'), 'Mobile', 'Airtime');
+        $this->linkContractToPackage($ownActiveContract, $otherPackage);
+
+        $upcomingPackage = $this->packageInCategory(2, 'Utilities', 'Internet');
+        $default = $this->contractInCategory(null, 12.0, new \DateTimeImmutable('+1 day'), 'Utilities', 'Internet');
+        $this->linkContractToPackage($default, $upcomingPackage);
+
+        $this->packageRepository->method('findUpcoming')->willReturn([$upcomingPackage]);
+        $this->contractRepository->method('findActiveForTenant')->willReturn([$ownActiveContract]);
+
+        $result = $this->resolver->upcomingFor($tenant);
+
+        $this->assertCount(1, $result);
+        $this->assertSame(12.0, $result[0]->getAmount());
+    }
+
+    public function testCategoryScopeSkipsPackageWhenItsOwnCategoryIsGatedByTenantAndNotCovered(): void
+    {
+        // No-regresión: dentro de una categoría donde el tenant SÍ tiene
+        // contrato propio, la regla sigue siendo "todo o nada" — el alcance
+        // category solo la acota a esa categoría, no la debilita.
+        $this->enableCategoryScope();
+
+        $tenant = $this->createMock(Account::class);
+        $tenant->method('getId')->willReturn(1);
+
+        $upcomingPackage = $this->packageInCategory(1, 'Mobile', 'Airtime');
+        $otherPackage = $this->packageInCategory(2, 'Mobile', 'Airtime');
+
+        $default = $this->contractInCategory(null, 12.0, new \DateTimeImmutable('+1 day'), 'Mobile', 'Airtime');
+        $this->linkContractToPackage($default, $upcomingPackage);
+
+        $ownActiveContract = $this->contractInCategory($tenant, 5.0, new \DateTimeImmutable('-1 day'), 'Mobile', 'Airtime');
+        $this->linkContractToPackage($ownActiveContract, $otherPackage);
+
+        $this->packageRepository->method('findUpcoming')->willReturn([$upcomingPackage]);
+        $this->contractRepository->method('findActiveForTenant')->willReturn([$ownActiveContract]);
+
+        $this->assertSame([], $this->resolver->upcomingFor($tenant));
     }
 }

--- a/tests/Service/Pricing/PackageCatalogResolverTest.php
+++ b/tests/Service/Pricing/PackageCatalogResolverTest.php
@@ -12,6 +12,7 @@ use App\Exception\MyCurrentException;
 use App\Repository\CommunicationContractRepository;
 use App\Repository\CommunicationPackageRepository;
 use App\Repository\CommunicationProductRepository;
+use App\Service\Catalog\ContractGatingScopeResolver;
 use App\Service\Pricing\PackageCatalogResolver;
 use App\Service\Pricing\PackageOfferSourceEnum;
 use App\Service\Provider\ProductPriceResolver;
@@ -29,6 +30,12 @@ use Psr\Log\LoggerInterface;
  * PRESENCIA de contratos (propios o por defecto) restringe la visibilidad
  * por completo — un paquete no cubierto por el contrato NO cae a MAX, se
  * considera no visible.
+ *
+ * Todos los tests de esta clase corren con ContractGatingScopeResolver
+ * devolviendo `false` (alcance tenant, default) salvo el bloque explícito
+ * "alcance category" al final — así el comportamiento histórico queda
+ * cubierto exactamente como antes de la Fase 2, sin tocar ningún test
+ * existente.
  */
 class PackageCatalogResolverTest extends TestCase
 {
@@ -37,6 +44,8 @@ class PackageCatalogResolverTest extends TestCase
     private CommunicationProductRepository&MockObject $productRepository;
     private ProductPriceResolver&MockObject $productPriceResolver;
     private SysConfigRepository&MockObject $sysConfigRepo;
+    private SysConfigRepository&MockObject $gatingSysConfigRepo;
+    private ContractGatingScopeResolver $gatingScopeResolver;
     private PackageCatalogResolver $resolver;
 
     protected function setUp(): void
@@ -47,14 +56,33 @@ class PackageCatalogResolverTest extends TestCase
         $this->productPriceResolver = $this->createMock(ProductPriceResolver::class);
         $this->sysConfigRepo = $this->createMock(SysConfigRepository::class);
 
+        // ContractGatingScopeResolver es `final` (no se puede mockear con
+        // createMock) — se usa una instancia real sobre un
+        // SysConfigRepository mockeado propio, controlado vía
+        // enableCategoryScope(). SIN configurar ningún stub acá a propósito
+        // (un mock sin stub devuelve null por defecto): PHPUnit usa el
+        // PRIMER stub registrado que matchea una invocación sin
+        // restricciones (no el último), así que un `willReturn(null)` de
+        // relleno acá bloquearía para siempre el `willReturnCallback` de
+        // enableCategoryScope() en los tests que lo llaman.
+        $this->gatingSysConfigRepo = $this->createMock(SysConfigRepository::class);
+        $this->gatingScopeResolver = new ContractGatingScopeResolver($this->gatingSysConfigRepo);
+
         $this->resolver = new PackageCatalogResolver(
             $this->contractRepository,
             $this->packageRepository,
             $this->productRepository,
             $this->productPriceResolver,
             $this->sysConfigRepo,
+            $this->gatingScopeResolver,
             $this->createMock(LoggerInterface::class),
         );
+    }
+
+    private function enableCategoryScope(): void
+    {
+        $this->gatingSysConfigRepo->method('findCachedValue')
+            ->willReturnCallback(fn (string $key) => $key === ContractGatingScopeResolver::SCOPE_KEY ? 'category' : null);
     }
 
     private function assignId(object $entity, int $id): void
@@ -98,6 +126,22 @@ class PackageCatalogResolverTest extends TestCase
             ->setPrice($price)
             ->setCurrency($currency);
         $this->assignId($contract, random_int(1000, 999999));
+
+        return $contract;
+    }
+
+    private function packageInCategory(int $id, string $serviceName, string $subserviceName, float $amount = 500.0, string $currency = 'CUP'): CommunicationPackage
+    {
+        $package = $this->package($id, $amount, $currency);
+        $package->setService(['name' => $serviceName, 'subservice' => ['name' => $subserviceName]]);
+
+        return $package;
+    }
+
+    private function contractInCategory(CommunicationPackage $package, float $price, string $serviceName, string $subserviceName, string $currency = 'USD'): CommunicationContract
+    {
+        $contract = $this->contract($package, $price, $currency);
+        $contract->setServiceCategory($serviceName, $subserviceName);
 
         return $contract;
     }
@@ -369,5 +413,150 @@ class PackageCatalogResolverTest extends TestCase
         $offer = $this->resolver->offerForSale($package, $account);
 
         $this->assertSame(15.0, $offer->price);
+    }
+
+    // ---- Fase 2: alcance CATEGORY (ContractGatingScopeResolver::isCategoryScoped() === true) ----
+
+    public function testCatalogForCategoryScopeFallsBackToMaxForCategoryWithNoContract(): void
+    {
+        $this->enableCategoryScope();
+
+        $account = $this->account(1, 'USD');
+        $packageA = $this->packageInCategory(10, 'Mobile', 'Airtime');
+        $contractA = $this->contractInCategory($packageA, 15.0, 'Mobile', 'Airtime');
+        $packageB = $this->packageInCategory(20, 'Utilities', 'Internet', 300.0, 'CUP');
+        $product = $this->createMock(CommunicationProduct::class);
+
+        $this->contractRepository->method('findActiveForTenant')->willReturn([$contractA]);
+        $this->contractRepository->method('findActiveDefaults')->willReturn([]);
+        $this->packageRepository->method('findActiveCatalogExcludingCategories')
+            ->with(['Mobile|Airtime'])
+            ->willReturn([$packageB]);
+        $this->productRepository->method('findMatchingDestination')->willReturn([$product]);
+        $this->productPriceResolver->method('resolve')->willReturn(new ResolvedProductPrice(8.0, 'USD', null, null, null));
+
+        $offers = $this->resolver->catalogFor($account);
+
+        $this->assertCount(2, $offers);
+        $byPackageId = [];
+        foreach ($offers as $offer) {
+            $byPackageId[$offer->package->getId()] = $offer;
+        }
+        $this->assertSame(PackageOfferSourceEnum::TENANT_CONTRACT, $byPackageId[10]->source);
+        $this->assertSame(PackageOfferSourceEnum::PRODUCT_MAX, $byPackageId[20]->source);
+        $this->assertSame(8.0, $byPackageId[20]->price);
+    }
+
+    public function testCatalogForCategoryScopeUsesDefaultContractForCategoryWithoutTenantContract(): void
+    {
+        $this->enableCategoryScope();
+
+        $account = $this->account(1);
+        $packageA = $this->packageInCategory(10, 'Mobile', 'Airtime');
+        $tenantContractA = $this->contractInCategory($packageA, 15.0, 'Mobile', 'Airtime');
+        $packageB = $this->packageInCategory(20, 'Utilities', 'Internet', 300.0, 'CUP');
+        $defaultContractB = $this->contractInCategory($packageB, 5.0, 'Utilities', 'Internet');
+
+        $this->contractRepository->method('findActiveForTenant')->willReturn([$tenantContractA]);
+        $this->contractRepository->method('findActiveDefaults')->willReturn([$defaultContractB]);
+        $this->packageRepository->method('findActiveCatalogExcludingCategories')->willReturn([]);
+
+        $offers = $this->resolver->catalogFor($account);
+
+        $this->assertCount(2, $offers);
+        $sources = array_map(fn ($o) => $o->source, $offers);
+        $this->assertContains(PackageOfferSourceEnum::TENANT_CONTRACT, $sources);
+        $this->assertContains(PackageOfferSourceEnum::DEFAULT_CONTRACT, $sources);
+    }
+
+    public function testOfferForCategoryScopeReturnsMaxOfferForPackageInUngatedCategory(): void
+    {
+        $this->enableCategoryScope();
+
+        $account = $this->account(1, 'USD');
+        $packageA = $this->packageInCategory(10, 'Mobile', 'Airtime');
+        $contractA = $this->contractInCategory($packageA, 15.0, 'Mobile', 'Airtime');
+        $packageB = $this->packageInCategory(20, 'Utilities', 'Internet', 300.0, 'CUP');
+        $product = $this->createMock(CommunicationProduct::class);
+
+        $this->contractRepository->method('findActiveForTenant')->willReturn([$contractA]);
+        $this->contractRepository->method('findActiveDefaults')->willReturn([]);
+        $this->productRepository->method('findMatchingDestination')->willReturn([$product]);
+        $this->productPriceResolver->method('resolve')->willReturn(new ResolvedProductPrice(8.0, 'USD', null, null, null));
+
+        $offer = $this->resolver->offerFor($packageB, $account);
+
+        $this->assertNotNull($offer);
+        $this->assertSame(PackageOfferSourceEnum::PRODUCT_MAX, $offer->source);
+        $this->assertSame(8.0, $offer->price);
+    }
+
+    public function testOfferForCategoryScopeReturnsNullWhenPackageInGatedCategoryNotCoveredByContract(): void
+    {
+        // No-regresión: un paquete de una categoría SÍ gateada (el tenant
+        // tiene contrato ahí) que ese contrato no cubre sigue sin caer a
+        // MAX — el alcance category no debilita la regla dentro de una
+        // categoría gateada, solo la acota a esa categoría.
+        $this->enableCategoryScope();
+
+        $account = $this->account(1);
+        $contractedPackage = $this->packageInCategory(1, 'Mobile', 'Airtime');
+        $askedPackage = $this->packageInCategory(2, 'Mobile', 'Airtime');
+        $contract = $this->contractInCategory($contractedPackage, 15.0, 'Mobile', 'Airtime');
+
+        $this->contractRepository->method('findActiveForTenant')->willReturn([$contract]);
+        $this->contractRepository->method('findActiveDefaults')->willReturn([]);
+        $this->productRepository->expects($this->never())->method('findMatchingDestination');
+
+        $this->assertNull($this->resolver->offerFor($askedPackage, $account));
+    }
+
+    public function testOfferForCategoryScopeTreatsEmptyCategoryLikeGatedTenantScope(): void
+    {
+        // Datos legacy sin service/subservice (serviceKey '|' por defecto,
+        // ver ServiceCategoryKey::of(null,null)): tenant y paquete caen en
+        // la MISMA categoría vacía, así que el comportamiento es idéntico
+        // al histórico "todo o nada" — protege los datos ya existentes.
+        $this->enableCategoryScope();
+
+        $account = $this->account(1);
+        $contractedPackage = $this->package(1);
+        $askedPackage = $this->package(2);
+        $contract = $this->contract($contractedPackage, 15.0);
+
+        $this->contractRepository->method('findActiveForTenant')->willReturn([$contract]);
+        $this->contractRepository->method('findActiveDefaults')->willReturn([]);
+        $this->productRepository->expects($this->never())->method('findMatchingDestination');
+
+        $this->assertNull($this->resolver->offerFor($askedPackage, $account));
+    }
+
+    public function testOfferForSaleRespectsTheCategoryScopeFlagJustLikeOfferFor(): void
+    {
+        // Requisito explícito del plan: offerForSale() (el guardia REAL de
+        // compra, no solo de listado) tiene que respetar el mismo flag.
+        // Delega en offerFor() para todo, así que basta con confirmar que
+        // NO lanza PACKAGE_NOT_VISIBLE_FOR_CLIENT para un paquete de una
+        // categoría sin contrato del tenant cuando el flag está en
+        // "category" — con el flag apagado (ver
+        // testOfferForSaleThrowsPackageNotVisibleWhenNotCoveredByContract),
+        // el mismo escenario SÍ lanza esa excepción.
+        $this->enableCategoryScope();
+
+        $account = $this->account(1, 'USD');
+        $contractedPackage = $this->packageInCategory(1, 'Mobile', 'Airtime');
+        $askedPackage = $this->packageInCategory(2, 'Utilities', 'Internet');
+        $contract = $this->contractInCategory($contractedPackage, 15.0, 'Mobile', 'Airtime');
+        $product = $this->createMock(CommunicationProduct::class);
+
+        $this->contractRepository->method('findActiveForTenant')->willReturn([$contract]);
+        $this->contractRepository->method('findActiveDefaults')->willReturn([]);
+        $this->productRepository->method('findMatchingDestination')->willReturn([$product]);
+        $this->productPriceResolver->method('resolve')->willReturn(new ResolvedProductPrice(8.0, 'USD', null, null, null));
+
+        $offer = $this->resolver->offerForSale($askedPackage, $account);
+
+        $this->assertSame(PackageOfferSourceEnum::PRODUCT_MAX, $offer->source);
+        $this->assertSame(8.0, $offer->price);
     }
 }

--- a/tests/Service/Pricing/ServiceCategoryKeyTest.php
+++ b/tests/Service/Pricing/ServiceCategoryKeyTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Tests\Service\Pricing;
+
+use App\Service\Pricing\ServiceCategoryKey;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \App\Service\Pricing\ServiceCategoryKey
+ */
+class ServiceCategoryKeyTest extends TestCase
+{
+    public function testMatchesIsTrueForIdenticalCategories(): void
+    {
+        $this->assertTrue(ServiceCategoryKey::matches('Mobile', 'Airtime', 'Mobile', 'Airtime'));
+    }
+
+    public function testMatchesIsFalseForDifferentSubservice(): void
+    {
+        $this->assertFalse(ServiceCategoryKey::matches('Mobile', 'Airtime', 'Mobile', 'Bundle'));
+    }
+
+    public function testMatchesIsFalseForDifferentService(): void
+    {
+        $this->assertFalse(ServiceCategoryKey::matches('Mobile', 'Internet', 'Utilities', 'Internet'));
+    }
+
+    public function testMatchesIsCaseSensitive(): void
+    {
+        // A propósito, sin case-folding — ver docblock de la clase (PHP
+        // strtoupper vs Postgres upper divergen con acentos/no-ASCII).
+        $this->assertFalse(ServiceCategoryKey::matches('Mobile', 'Airtime', 'mobile', 'airtime'));
+    }
+
+    public function testOfTrimsWhitespace(): void
+    {
+        $this->assertSame(ServiceCategoryKey::of('Mobile', 'Airtime'), ServiceCategoryKey::of(' Mobile ', ' Airtime '));
+    }
+
+    public function testOfNeverReturnsNull(): void
+    {
+        $this->assertSame('|', ServiceCategoryKey::of(null, null));
+    }
+
+    public function testOfHandlesMissingSubservice(): void
+    {
+        $this->assertSame('Mobile|', ServiceCategoryKey::of('Mobile', null));
+    }
+
+    public function testFromServiceExtractsNestedShape(): void
+    {
+        $service = ['name' => 'Utilities', 'subservice' => ['name' => 'Internet']];
+
+        $this->assertSame(ServiceCategoryKey::of('Utilities', 'Internet'), ServiceCategoryKey::fromService($service));
+    }
+
+    public function testFromServiceHandlesEmptyArray(): void
+    {
+        $this->assertSame('|', ServiceCategoryKey::fromService([]));
+    }
+
+    public function testFromServiceHandlesServiceWithoutSubserviceKey(): void
+    {
+        $this->assertSame('Devices|', ServiceCategoryKey::fromService(['name' => 'Devices']));
+    }
+}


### PR DESCRIPTION
## Resumen

Rediseño de contratos por categoría (service/subservice), en 2 fases sobre 3 planificadas (ver plan completo en la conversación):

**Fase 1 — Esquema + observabilidad (sin cambio de comportamiento):**
- `CommunicationContract` y `CommunicationPackage` ganan `serviceKey` derivado (`ServiceCategoryKey`), clasificando contratos igual que paquetes.
- Migración con backfill desde el JSON `service` existente y detección explícita de conflictos (contratos con paquetes de categorías distintas) antes de aplicar.
- API/dashboard exponen la categoría del contrato — filtro de búsqueda (`serviceKey`), badge informativo.

**Fase 2 — Camino de lectura, detrás de un kill switch:**
- `PackageCatalogResolver` y `UpcomingPackageCatalogResolver` (segundo consumidor de la misma regla, encontrado en la revisión) aplican la precedencia tenant > default > MAX **por categoría** en vez de por tenant completo, cuando `ContractGatingScopeResolver::isCategoryScoped()` está activo — apagado por defecto (sin cambio de comportamiento), con piloto opcional por cliente vía CSV en `sys_config`.
- Antes: un tenant con *cualquier* contrato propio veía SOLO lo cubierto por esos contratos, sin importar la categoría — cualquier otro paquete quedaba invisible, nunca caía a MAX+margen.
- Ahora (flag activo): esa restricción se evalúa por categoría — una categoría sin contrato del tenant cae a MAX+margen, como si el tenant no tuviera contrato en absoluto.
- `findActiveCatalogExcludingCategories()` evita calcular MAX sobre paquetes de categorías ya cubiertas por contrato (con guarda explícita para lista vacía — `NOT IN ()` compila a `NOT IN (NULL)` y devolvería catálogo vacío).
- `offerForSale()` (guardia real de compra) hereda el mismo flag por delegar en `offerFor()` — confirmado con test explícito.
- Filtro de categoría real (no solo informativo) en el listado de contratos del dashboard.

**Fase 3** (índice único + identidad de contrato por categoría, DTOs de alta con `service` explícito) queda deliberadamente fuera de este PR — es la única fase que muta datos de forma no reversible con un flag, y el plan la deja para después de validar Fases 1-2 con datos reales.

## Plan de pruebas
- [x] `php bin/phpunit --no-coverage` — 1083/1083 verde
- [x] `vendor/bin/phpstan analyse` — sin errores
- [x] Migración corrida contra `app` (dev) y `app_test` (test); detección de conflictos verificada contra datos reales (0 contratos con categorías mezcladas)
- [x] Diagnóstico de distribución de categorías corrido contra dev, confirmado con el usuario

🤖 Generado con [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeLYjtiTNMg6VWD3j6DCGK