### PR TITLE
feat(contracts): contratos por categoría — Fase 3 (identidad y camino de escritura)

### DIFF
--- a/migrations/Version20260823130000.php
+++ b/migrations/Version20260823130000.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Fase 3 del rediseño "contratos por categoría" (ver
+ * /home/alex/.claude/plans/immutable-knitting-candle.md): `service_key`
+ * pasa a formar parte de la IDENTIDAD del contrato — el índice único
+ * `uniq_com_contract_open_per_tenant_amount` (tenant, monto, moneda) gana
+ * `service_key` como cuarta columna, así que dos paquetes que comparten
+ * tupla monto/moneda pero difieren en categoría ahora producen DOS
+ * contratos abiertos, no uno solo mezclado (`CommunicationContractService::
+ * upsertContract()`/`findOpenContract()` y `CommunicationContract::
+ * addPackage()`, este último ya actualizados en código para exigirlo).
+ *
+ * SEGURA por construcción, sin backfill ni detección de conflictos: el
+ * índice viejo (tenant, monto, moneda) YA garantizaba unicidad sobre un
+ * subconjunto estricto de estas columnas — agregar una columna más a un
+ * índice único NUNCA puede introducir una violación donde antes no la
+ * había (el nuevo índice es estrictamente MENOS restrictivo en cuántas
+ * filas pueden coincidir, no más). Si por algún motivo la hipótesis
+ * estuviera mal, `CREATE UNIQUE INDEX` fallaría igual y la migración
+ * abortaría (transactional: true en doctrine_migrations.yaml).
+ */
+final class Version20260823130000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Contratos por categoría (Fase 3): service_key pasa a formar parte del índice único de contrato abierto';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IF EXISTS uniq_com_contract_open_per_tenant_amount');
+        $this->addSql(<<<'SQL'
+            CREATE UNIQUE INDEX IF NOT EXISTS uniq_com_contract_open_per_tenant_amount
+                ON communication_contract (tenant_id, destination_amount, destination_currency, service_key)
+                NULLS NOT DISTINCT
+                WHERE end_at IS NULL
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IF EXISTS uniq_com_contract_open_per_tenant_amount');
+        $this->addSql(<<<'SQL'
+            CREATE UNIQUE INDEX IF NOT EXISTS uniq_com_contract_open_per_tenant_amount
+                ON communication_contract (tenant_id, destination_amount, destination_currency)
+                NULLS NOT DISTINCT
+                WHERE end_at IS NULL
+        SQL);
+    }
+}

--- a/src/DTO/CreateCommunicationContractBatchDto.php
+++ b/src/DTO/CreateCommunicationContractBatchDto.php
@@ -2,13 +2,18 @@
 
 namespace App\DTO;
 
+use App\OpenApi\Attribute\OAProperty;
 use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 /**
  * Alta en lote de CommunicationContract (V2) — mismo precio para varios
  * clientes a la vez. Reutiliza TargetAccountResolver tal cual: `clients`
  * vacío/ausente = todas las cuentas activas de `environmentId` (mismo
  * criterio que CreateRateContractDto/promociones).
+ *
+ * `service` (Fase 3) obligatorio, validado contra la categoría real de
+ * `communicationPackageId` — ver docblock de CreateCommunicationContractDto.
  */
 class CreateCommunicationContractBatchDto implements IInput
 {
@@ -35,6 +40,18 @@ class CreateCommunicationContractBatchDto implements IInput
 
     protected ?string $endAt;
 
+    #[Assert\NotNull]
+    #[OAProperty(schema: [
+        'type' => 'object',
+        'properties' => [
+            'name'       => ['type' => 'string', 'enum' => ['Mobile', 'uSIM', 'Devices', 'Utilities']],
+            'subservice' => ['type' => 'object', 'properties' => [
+                'name' => ['type' => 'string', 'enum' => ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET', 'LANDLINE', 'uSIM']],
+            ]],
+        ],
+    ])]
+    protected ?array $service;
+
     public function __construct(
         ?int $communicationPackageId = null,
         ?int $environmentId = null,
@@ -43,6 +60,7 @@ class CreateCommunicationContractBatchDto implements IInput
         ?string $currency = null,
         ?string $startAt = null,
         ?string $endAt = null,
+        ?array $service = null,
     ) {
         $this->communicationPackageId = $communicationPackageId;
         $this->environmentId = $environmentId;
@@ -51,6 +69,15 @@ class CreateCommunicationContractBatchDto implements IInput
         $this->currency = $currency;
         $this->startAt = $startAt;
         $this->endAt = $endAt;
+        $this->service = $service;
+    }
+
+    #[Assert\Callback]
+    public function validateService(ExecutionContextInterface $context): void
+    {
+        if (empty($this->service['name'] ?? null)) {
+            $context->buildViolation('service.name es requerido')->atPath('service')->addViolation();
+        }
     }
 
     public function getCommunicationPackageId(): ?int { return $this->communicationPackageId; }
@@ -75,4 +102,7 @@ class CreateCommunicationContractBatchDto implements IInput
 
     public function getEndAt(): ?string { return $this->endAt; }
     public function setEndAt(?string $v): void { $this->endAt = $v; }
+
+    public function getService(): ?array { return $this->service; }
+    public function setService(?array $v): void { $this->service = $v; }
 }

--- a/src/DTO/CreateCommunicationContractDto.php
+++ b/src/DTO/CreateCommunicationContractDto.php
@@ -2,7 +2,9 @@
 
 namespace App\DTO;
 
+use App\OpenApi\Attribute\OAProperty;
 use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 /**
  * Alta de UN CommunicationContract (V2) — CommunicationContractService::createSingle().
@@ -16,6 +18,13 @@ use Symfony\Component\Validator\Constraints as Assert;
  * resuelve a la cuenta ACTIVA de ese cliente en `environmentId` vía
  * TargetAccountResolver, igual que el alta en lote. `environmentId` es
  * obligatorio cuando se da `tenantId`.
+ *
+ * `service` (Fase 3 del rediseño de contratos por categoría) es
+ * obligatorio y debe coincidir con la categoría real de
+ * `communicationPackageId` — CommunicationContractService lo valida contra
+ * el paquete elegido (422 si no coincide). Exigirlo explícito, en vez de
+ * derivarlo en silencio del paquete, es una decisión deliberada: atrapa el
+ * caso de elegir el paquete equivocado en vez de propagarlo en silencio.
  */
 class CreateCommunicationContractDto implements IInput
 {
@@ -41,6 +50,18 @@ class CreateCommunicationContractDto implements IInput
 
     protected ?string $endAt;
 
+    #[Assert\NotNull]
+    #[OAProperty(schema: [
+        'type' => 'object',
+        'properties' => [
+            'name'       => ['type' => 'string', 'enum' => ['Mobile', 'uSIM', 'Devices', 'Utilities']],
+            'subservice' => ['type' => 'object', 'properties' => [
+                'name' => ['type' => 'string', 'enum' => ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET', 'LANDLINE', 'uSIM']],
+            ]],
+        ],
+    ])]
+    protected ?array $service;
+
     public function __construct(
         ?int $communicationPackageId = null,
         ?int $tenantId = null,
@@ -49,6 +70,7 @@ class CreateCommunicationContractDto implements IInput
         ?string $currency = null,
         ?string $startAt = null,
         ?string $endAt = null,
+        ?array $service = null,
     ) {
         $this->communicationPackageId = $communicationPackageId;
         $this->tenantId = $tenantId;
@@ -57,6 +79,15 @@ class CreateCommunicationContractDto implements IInput
         $this->currency = $currency;
         $this->startAt = $startAt;
         $this->endAt = $endAt;
+        $this->service = $service;
+    }
+
+    #[Assert\Callback]
+    public function validateService(ExecutionContextInterface $context): void
+    {
+        if (empty($this->service['name'] ?? null)) {
+            $context->buildViolation('service.name es requerido')->atPath('service')->addViolation();
+        }
     }
 
     public function getCommunicationPackageId(): ?int { return $this->communicationPackageId; }
@@ -79,4 +110,7 @@ class CreateCommunicationContractDto implements IInput
 
     public function getEndAt(): ?string { return $this->endAt; }
     public function setEndAt(?string $v): void { $this->endAt = $v; }
+
+    public function getService(): ?array { return $this->service; }
+    public function setService(?array $v): void { $this->service = $v; }
 }

--- a/src/DTO/CreateCommunicationContractRangeDto.php
+++ b/src/DTO/CreateCommunicationContractRangeDto.php
@@ -2,6 +2,7 @@
 
 namespace App\DTO;
 
+use App\OpenApi\Attribute\OAProperty;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
@@ -11,9 +12,16 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
  * CommunicationPackage cuyo destino caiga en [fromAmount, toAmount]
  * saltando de `step` en `step`, con el precio interpolado linealmente entre
  * `priceFrom` (para fromAmount) y `priceTo` (para toAmount). Un monto del
- * rango sin CommunicationPackage correspondiente se omite (no aborta el
- * alta) y se reporta en la respuesta — ver
- * CommunicationContractService::createByRange().
+ * rango sin CommunicationPackage correspondiente (de la categoría pedida —
+ * ver `service` abajo) se omite (no aborta el alta) y se reporta en la
+ * respuesta — ver CommunicationContractService::createByRange().
+ *
+ * `service` (Fase 3) es obligatorio y, a diferencia de
+ * CreateCommunicationContractDto/Batch (que lo validan contra un paquete ya
+ * elegido), aquí es la ÚNICA forma de decidir a qué categoría pertenecen
+ * los paquetes que matchean cada monto del rango — sin esto, dos paquetes
+ * de categorías distintas que comparten tupla (monto, moneda) eran
+ * indistinguibles para este flujo.
  */
 class CreateCommunicationContractRangeDto implements IInput
 {
@@ -63,6 +71,18 @@ class CreateCommunicationContractRangeDto implements IInput
 
     protected ?string $endAt;
 
+    #[Assert\NotNull]
+    #[OAProperty(schema: [
+        'type' => 'object',
+        'properties' => [
+            'name'       => ['type' => 'string', 'enum' => ['Mobile', 'uSIM', 'Devices', 'Utilities']],
+            'subservice' => ['type' => 'object', 'properties' => [
+                'name' => ['type' => 'string', 'enum' => ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET', 'LANDLINE', 'uSIM']],
+            ]],
+        ],
+    ])]
+    protected ?array $service;
+
     public function __construct(
         ?float $fromAmount = null,
         ?float $toAmount = null,
@@ -75,6 +95,7 @@ class CreateCommunicationContractRangeDto implements IInput
         ?int $environmentId = null,
         ?string $startAt = null,
         ?string $endAt = null,
+        ?array $service = null,
     ) {
         $this->fromAmount = $fromAmount;
         $this->toAmount = $toAmount;
@@ -87,6 +108,7 @@ class CreateCommunicationContractRangeDto implements IInput
         $this->environmentId = $environmentId;
         $this->startAt = $startAt;
         $this->endAt = $endAt;
+        $this->service = $service;
     }
 
     #[Assert\Callback]
@@ -96,6 +118,14 @@ class CreateCommunicationContractRangeDto implements IInput
             $context->buildViolation('El monto final debe ser mayor o igual al monto inicial')
                 ->atPath('toAmount')
                 ->addViolation();
+        }
+    }
+
+    #[Assert\Callback]
+    public function validateService(ExecutionContextInterface $context): void
+    {
+        if (empty($this->service['name'] ?? null)) {
+            $context->buildViolation('service.name es requerido')->atPath('service')->addViolation();
         }
     }
 
@@ -131,4 +161,7 @@ class CreateCommunicationContractRangeDto implements IInput
 
     public function getEndAt(): ?string { return $this->endAt; }
     public function setEndAt(?string $v): void { $this->endAt = $v; }
+
+    public function getService(): ?array { return $this->service; }
+    public function setService(?array $v): void { $this->service = $v; }
 }

--- a/src/Entity/CommunicationContract.php
+++ b/src/Entity/CommunicationContract.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use App\Exception\MyCurrentException;
 use App\Repository\CommunicationContractRepository;
 use App\Service\Pricing\ServiceCategoryKey;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -157,11 +158,32 @@ class CommunicationContract
         return $this->packages;
     }
 
+    /**
+     * Fase 3 del rediseño por categoría: rechaza un paquete de categoría
+     * distinta a la que ya cubre este contrato — la guarda solo se evalúa
+     * al agregar el SEGUNDO paquete en adelante (colección no vacía), nunca
+     * el primero, porque en ese momento la categoría del contrato puede
+     * todavía no estar seteada (ver upsertContract(), que persiste el
+     * contrato con setServiceCategory() antes de la primera addPackage(),
+     * pero otros constructores de test agregan el paquete antes de fijar
+     * la categoría — mismo criterio en ambos casos: el primer paquete
+     * nunca se rechaza a sí mismo).
+     */
     public function addPackage(CommunicationPackage $package): static
     {
-        if (!$this->packages->contains($package)) {
-            $this->packages->add($package);
+        if ($this->packages->contains($package)) {
+            return $this;
         }
+
+        if (!$this->packages->isEmpty() && $package->getServiceKey() !== $this->serviceKey) {
+            throw new MyCurrentException(
+                'COMMUNICATION_CONTRACT_CATEGORY_MISMATCH',
+                'El paquete pertenece a una categoría distinta a la de este contrato',
+                409,
+            );
+        }
+
+        $this->packages->add($package);
 
         return $this;
     }

--- a/src/Repository/CommunicationContractRepository.php
+++ b/src/Repository/CommunicationContractRepository.php
@@ -96,21 +96,29 @@ class CommunicationContractRepository extends ServiceEntityRepository
     }
 
     /**
-     * El contrato ABIERTO (endAt IS NULL) para esta tupla — tolerancia de
-     * coma flotante igual que CommunicationPackageRepository::findByDestination()
+     * El contrato ABIERTO (endAt IS NULL) para esta tupla+categoría —
+     * tolerancia de coma flotante igual que
+     * CommunicationPackageRepository::findByDestination()
      * (DestinationKey::EPSILON). Es la clave de deduplicación de
      * CommunicationContractService::upsertContract(): dos paquetes con la
-     * misma tupla y tenant terminan en el contrato que esto devuelve.
+     * misma tupla+tenant+categoría terminan en el contrato que esto
+     * devuelve — desde la Fase 3 del rediseño por categoría, `$serviceKey`
+     * es parte de esta identidad (índice único
+     * uniq_com_contract_open_per_tenant_amount incluye service_key), así
+     * que dos paquetes que comparten tupla pero difieren en categoría
+     * producen DOS contratos distintos, no uno solo mezclado.
      */
-    public function findOpenContract(?Account $tenant, float $amount, string $currency): ?CommunicationContract
+    public function findOpenContract(?Account $tenant, float $amount, string $currency, string $serviceKey): ?CommunicationContract
     {
         $qb = $this->createQueryBuilder('c')
             ->andWhere('c.destinationAmount BETWEEN :min AND :max')
             ->andWhere('c.destinationCurrency = :currency')
+            ->andWhere('c.serviceKey = :serviceKey')
             ->andWhere('c.endAt IS NULL')
             ->setParameter('min', $amount - DestinationKey::EPSILON)
             ->setParameter('max', $amount + DestinationKey::EPSILON)
             ->setParameter('currency', strtoupper($currency))
+            ->setParameter('serviceKey', $serviceKey)
             ->setMaxResults(1);
 
         if ($tenant === null) {

--- a/src/Repository/CommunicationPackageRepository.php
+++ b/src/Repository/CommunicationPackageRepository.php
@@ -116,7 +116,9 @@ class CommunicationPackageRepository extends ServiceEntityRepository
      * Paquete cuyo destino coincide con la tupla dada, con tolerancia de
      * coma flotante (DestinationKey::EPSILON) — usado por
      * CommunicationContractService::createByRange() para resolver, monto a
-     * monto, a qué CommunicationPackage corresponde cada paso del rango.
+     * monto, a qué CommunicationPackage corresponde cada paso del rango, y
+     * por linkTenantContractsToPromotionPackages() para hallar el paquete
+     * regular equivalente de uno de promoción.
      *
      * Excluye SIEMPRE los paquetes generados por una promoción
      * (promotion IS NOT NULL, ver CommunicationPackage::$promotion) — son
@@ -124,19 +126,29 @@ class CommunicationPackageRepository extends ServiceEntityRepository
      * contratos no debe poder engancharse a uno por coincidencia de monto.
      * Para resolver dentro del lote de una promoción concreta, ver
      * findByDestinationForPromotion().
+     *
+     * `$serviceKey` (Fase 3 del rediseño por categoría) — opcional, sin
+     * filtrar por defecto (compatibilidad con BenefitOperationResolver,
+     * que todavía no lo pasa). Cuando se da, cierra la fuga donde dos
+     * paquetes de categorías DISTINTAS que comparten tupla monto/moneda se
+     * confundían entre sí (ej. un paquete promocional enganchándose al
+     * contrato de otra categoría).
      */
-    public function findByDestination(float $amount, string $currency): ?CommunicationPackage
+    public function findByDestination(float $amount, string $currency, ?string $serviceKey = null): ?CommunicationPackage
     {
-        return $this->createQueryBuilder('p')
+        $qb = $this->createQueryBuilder('p')
             ->andWhere('p.destinationAmount BETWEEN :min AND :max')
             ->andWhere('p.destinationCurrency = :currency')
             ->andWhere('p.promotion IS NULL')
             ->setParameter('min', $amount - DestinationKey::EPSILON)
             ->setParameter('max', $amount + DestinationKey::EPSILON)
-            ->setParameter('currency', strtoupper($currency))
-            ->setMaxResults(1)
-            ->getQuery()
-            ->getOneOrNullResult();
+            ->setParameter('currency', strtoupper($currency));
+
+        if ($serviceKey !== null) {
+            $qb->andWhere('p.serviceKey = :serviceKey')->setParameter('serviceKey', $serviceKey);
+        }
+
+        return $qb->setMaxResults(1)->getQuery()->getOneOrNullResult();
     }
 
     /**

--- a/src/Service/Pricing/CommunicationContractService.php
+++ b/src/Service/Pricing/CommunicationContractService.php
@@ -22,15 +22,20 @@ use Symfony\Bundle\SecurityBundle\Security;
  * Administración de CommunicationContract (V2) — calcado de
  * PackageContractService en estructura: alta única + alta en lote (misma
  * TargetAccountResolver), ambas idempotentes por (tenant, destinationAmount,
- * destinationCurrency): una segunda llamada sobre la misma tupla ACTUALIZA
- * el contrato ABIERTO existente (endAt IS NULL) en vez de duplicarlo — el
- * índice único uniq_com_contract_open_per_tenant_amount lo garantiza a nivel
- * de esquema. "Pausar" (close()) es la única forma de dejar hueco a uno
- * nuevo distinto.
+ * destinationCurrency, serviceKey): una segunda llamada sobre la misma
+ * tupla+categoría ACTUALIZA el contrato ABIERTO existente (endAt IS NULL)
+ * en vez de duplicarlo — el índice único
+ * uniq_com_contract_open_per_tenant_amount (incluye service_key desde la
+ * Fase 3 del rediseño por categoría) lo garantiza a nivel de esquema.
+ * "Pausar" (close()) es la única forma de dejar hueco a uno nuevo distinto.
  *
  * Desde la Fase 6 (ManyToMany), un contrato puede cubrir VARIOS
  * CommunicationPackage que compartan tupla — ver upsertContract() y el
- * docblock de CommunicationContract.
+ * docblock de CommunicationContract. Desde la Fase 3 del rediseño por
+ * categoría, esos paquetes también deben compartir `serviceKey`
+ * (`CommunicationContract::addPackage()` lo exige) — dos paquetes con la
+ * misma tupla monto/moneda pero categorías distintas SIEMPRE terminan en
+ * dos contratos separados, nunca uno mezclado.
  */
 class CommunicationContractService
 {
@@ -56,6 +61,7 @@ class CommunicationContractService
     public function createSingle(CreateCommunicationContractDto $dto): CommunicationContract
     {
         $package = $this->findPackageOrFail((int) $dto->getCommunicationPackageId());
+        $this->assertServiceMatchesPackage((array) $dto->getService(), $package);
         $tenant = $this->resolveTenantOrFail($dto->getTenantId(), $dto->getEnvironmentId());
 
         $result = $this->upsertContract($package, $tenant);
@@ -73,6 +79,7 @@ class CommunicationContractService
     public function createBatch(CreateCommunicationContractBatchDto $dto): ContractBatchResult
     {
         $package = $this->findPackageOrFail((int) $dto->getCommunicationPackageId());
+        $this->assertServiceMatchesPackage((array) $dto->getService(), $package);
 
         $environment = $this->em->getRepository(Environment::class)->find($dto->getEnvironmentId());
         if ($environment === null) {
@@ -129,6 +136,7 @@ class CommunicationContractService
         }
 
         $tenant = $this->resolveTenantOrFail($dto->getTenantId(), $dto->getEnvironmentId());
+        $serviceKey = ServiceCategoryKey::fromService((array) $dto->getService());
 
         $priceFrom = (float) $dto->getPriceFrom();
         $priceTo = (float) $dto->getPriceTo();
@@ -143,7 +151,11 @@ class CommunicationContractService
         for ($i = 0; $i < $count; $i++) {
             $amount = round($from + $i * $step, 2);
 
-            $package = $this->packageRepository->findByDestination($amount, $destinationCurrency);
+            // Filtrado por categoría (Fase 3): sin esto, un monto que
+            // coincide con paquetes de MÁS de una categoría matchearía
+            // el primero que encuentre, sin relación con la categoría
+            // pedida en $dto->getService().
+            $package = $this->packageRepository->findByDestination($amount, $destinationCurrency, $serviceKey);
             if ($package === null) {
                 $skippedAmounts[] = $amount;
                 continue;
@@ -192,9 +204,21 @@ class CommunicationContractService
     {
         $linked = 0;
         foreach ($promoPackages as $promoPackage) {
+            // Filtrado por la categoría del propio paquete de promoción
+            // (Fase 3): antes de esto, un paquete promocional podía
+            // engancharse al contrato de OTRA categoría que casualmente
+            // compartiera tupla monto/moneda con el paquete regular
+            // equivocado — ahora, si el paquete de promoción no heredó
+            // correctamente la categoría del regular (ver
+            // CommunicationPromotionService::createV2(), que la toma del
+            // DTO de la promoción, no la deriva automáticamente), esto
+            // simplemente no encuentra match y se omite (getLinked() no
+            // cuenta este paquete) en vez de vincular la categoría
+            // equivocada.
             $regularPackage = $this->packageRepository->findByDestination(
                 (float) $promoPackage->getDestinationAmount(),
                 (string) $promoPackage->getDestinationCurrency(),
+                $promoPackage->getServiceKey(),
             );
             if ($regularPackage === null) {
                 continue;
@@ -258,7 +282,7 @@ class CommunicationContractService
             // solo permite un contrato abierto por tupla — si ya hay uno
             // para la tupla destino, avisar en vez de dejar que el flush()
             // reviente con una violación de integridad.
-            $conflict = $this->contractRepository->findOpenContract($contract->getTenant(), $amount, $currency);
+            $conflict = $this->contractRepository->findOpenContract($contract->getTenant(), $amount, $currency, $contract->getServiceKey());
             if ($conflict !== null && $conflict !== $contract) {
                 throw new MyCurrentException(
                     'COMMUNICATION_CONTRACT_ALREADY_EXISTS',
@@ -332,6 +356,34 @@ class CommunicationContractService
     }
 
     /**
+     * Fase 3 del rediseño por categoría: `service` es explícito y
+     * obligatorio en los DTOs de alta (decisión del usuario — "exigir la
+     * categoría explícitamente" en vez de derivarla en silencio del
+     * paquete elegido), pero como el paquete YA se identifica por
+     * `communicationPackageId`, lo único que falta validar es que ambos
+     * coincidan — si no, es casi seguro que el admin eligió el paquete
+     * equivocado, y mejor avisar que dejar el contrato en la categoría
+     * real del paquete sin que quien lo creó se entere.
+     *
+     * @param array{name?: string, subservice?: array{name?: string}} $dtoService
+     *
+     * @throws MyCurrentException
+     */
+    private function assertServiceMatchesPackage(array $dtoService, CommunicationPackage $package): void
+    {
+        $given = ServiceCategoryKey::fromService($dtoService);
+        $expected = $package->getServiceKey();
+
+        if ($given !== $expected) {
+            throw new MyCurrentException(
+                'COMMUNICATION_CONTRACT_SERVICE_MISMATCH',
+                'La categoría indicada no coincide con la del paquete elegido',
+                422,
+            );
+        }
+    }
+
+    /**
      * @throws MyCurrentException
      */
     private function findPackageOrFail(int $id): CommunicationPackage
@@ -396,19 +448,19 @@ class CommunicationContractService
     {
         $amount = (float) $package->getDestinationAmount();
         $currency = (string) $package->getDestinationCurrency();
+        $serviceKey = $package->getServiceKey();
 
-        $contract = $this->contractRepository->findOpenContract($tenant, $amount, $currency);
+        $contract = $this->contractRepository->findOpenContract($tenant, $amount, $currency, $serviceKey);
         if ($contract === null) {
             $service = $package->getService();
             $contract = (new CommunicationContract())
                 ->setTenant($tenant)
                 ->setDestinationAmount($amount)
                 ->setDestinationCurrency($currency)
-                // Fase 1 del rediseño por categoría (ver docblock de
-                // CommunicationContract): solo clasificación informativa
-                // por ahora, todavía NO forma parte de la identidad del
-                // contrato ni se usa para elegir/matchear uno existente
-                // arriba (eso es Fase 3).
+                // Fase 3 del rediseño por categoría: `service` ya forma
+                // parte de la identidad del contrato — findOpenContract()
+                // arriba ya filtró por $serviceKey, así que esto SIEMPRE
+                // coincide con lo que addPackage() va a exigir abajo.
                 ->setServiceCategory($service['name'] ?? null, $service['subservice']['name'] ?? null);
             $this->em->persist($contract);
             $contract->addPackage($package);

--- a/src/Service/Pricing/CommunicationPackageAdminService.php
+++ b/src/Service/Pricing/CommunicationPackageAdminService.php
@@ -254,6 +254,21 @@ class CommunicationPackageAdminService
             $package->setTags($dto->getTags());
         }
         if ($dto->getService() !== null) {
+            // Fase 3 del rediseño por categoría: cambiar la categoría de un
+            // paquete que YA está en algún contrato dejaría a ese contrato
+            // cubriendo un paquete de una categoría distinta a la suya —
+            // exactamente el invariante que CommunicationContract::
+            // addPackage() exige al agregar, pero que no se re-valida sobre
+            // paquetes ya agregados. No soportado todavía: bloquear en vez
+            // de corromper el invariante en silencio.
+            $newServiceKey = ServiceCategoryKey::fromService($dto->getService());
+            if ($newServiceKey !== $package->getServiceKey() && !$package->getContracts()->isEmpty()) {
+                throw new MyCurrentException(
+                    'COMMUNICATION_PACKAGE_CATEGORY_LOCKED',
+                    'No se puede cambiar la categoría de un paquete que ya está en algún contrato',
+                    409,
+                );
+            }
             $package->setService($dto->getService());
         }
         if ($dto->getValidity() !== null) {

--- a/tests/Entity/CommunicationContractTest.php
+++ b/tests/Entity/CommunicationContractTest.php
@@ -4,6 +4,7 @@ namespace App\Tests\Entity;
 
 use App\Entity\CommunicationContract;
 use App\Entity\CommunicationPackage;
+use App\Exception\MyCurrentException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -25,6 +26,18 @@ class CommunicationContractTest extends TestCase
             ->setDestinationCurrency('CUP')
             ->setPrice(10.0)
             ->setCurrency('USD');
+    }
+
+    private function packageInCategory(string $name, string $serviceName, string $subserviceName): CommunicationPackage
+    {
+        $package = (new CommunicationPackage())
+            ->setName($name)
+            ->setDescription($name)
+            ->setDestinationAmount(500.0)
+            ->setDestinationCurrency('CUP');
+        $package->setService(['name' => $serviceName, 'subservice' => ['name' => $subserviceName]]);
+
+        return $package;
     }
 
     public function testIsActiveAtWithinOpenEndedWindow(): void
@@ -107,5 +120,60 @@ class CommunicationContractTest extends TestCase
         $contract->removePackage($package);
 
         $this->assertCount(0, $contract->getPackages());
+    }
+
+    // ---- Fase 3: la categoría del contrato es parte de su identidad ----
+
+    public function testAddPackageAllowsTheFirstPackageRegardlessOfCategoryOrdering(): void
+    {
+        // El primer paquete nunca se rechaza a sí mismo — necesario porque
+        // muchos constructores de test (y upsertContract() en algunos
+        // casos) agregan el paquete antes o después de fijar la categoría
+        // del contrato indistintamente.
+        $package = $this->packageInCategory('Recarga', 'Mobile', 'AIRTIME');
+        $contract = new CommunicationContract();
+
+        $contract->addPackage($package);
+
+        $this->assertCount(1, $contract->getPackages());
+    }
+
+    public function testAddPackageRejectsASecondPackageOfADifferentCategory(): void
+    {
+        $mobile = $this->packageInCategory('Recarga', 'Mobile', 'AIRTIME');
+        $utilities = $this->packageInCategory('Nauta', 'Utilities', 'INTERNET');
+
+        $contract = (new CommunicationContract())->setServiceCategory('Mobile', 'AIRTIME');
+        $contract->addPackage($mobile);
+
+        $this->expectException(MyCurrentException::class);
+        $this->expectExceptionMessage('categoría distinta');
+
+        $contract->addPackage($utilities);
+    }
+
+    public function testAddPackageAllowsASecondPackageOfTheSameCategory(): void
+    {
+        $a = $this->packageInCategory('Recarga A', 'Mobile', 'AIRTIME');
+        $b = $this->packageInCategory('Recarga B', 'Mobile', 'AIRTIME');
+
+        $contract = (new CommunicationContract())->setServiceCategory('Mobile', 'AIRTIME');
+        $contract->addPackage($a);
+        $contract->addPackage($b);
+
+        $this->assertCount(2, $contract->getPackages());
+    }
+
+    public function testAddPackageReaddingTheSamePackageNeverTripsTheGuard(): void
+    {
+        // contains() ya lo intercepta antes de evaluar la categoría —
+        // re-agregar el mismo paquete es siempre un no-op, nunca un rechazo.
+        $package = $this->packageInCategory('Recarga', 'Mobile', 'AIRTIME');
+        $contract = (new CommunicationContract())->setServiceCategory('Mobile', 'AIRTIME');
+        $contract->addPackage($package);
+
+        $contract->addPackage($package);
+
+        $this->assertCount(1, $contract->getPackages());
     }
 }

--- a/tests/Functional/Pricing/CommunicationContractRepositoryTest.php
+++ b/tests/Functional/Pricing/CommunicationContractRepositoryTest.php
@@ -213,7 +213,7 @@ class CommunicationContractRepositoryTest extends ProviderFunctionalTestCase
         $open = $this->contract($package, $account, $now->modify('-1 day'));
         $this->em->flush();
 
-        $found = $this->repository()->findOpenContract($account, 500.0 + 0.001, 'cup');
+        $found = $this->repository()->findOpenContract($account, 500.0 + 0.001, 'cup', '|');
 
         $this->assertSame($open->getId(), $found?->getId());
     }
@@ -224,7 +224,7 @@ class CommunicationContractRepositoryTest extends ProviderFunctionalTestCase
         $environment = $this->createEnvironment();
         $account = $this->createAccount($client, $environment);
 
-        $this->assertNull($this->repository()->findOpenContract($account, 999.0, 'CUP'));
+        $this->assertNull($this->repository()->findOpenContract($account, 999.0, 'CUP', '|'));
     }
 
     public function testFindOpenContractDistinguishesTenantFromDefault(): void
@@ -238,8 +238,74 @@ class CommunicationContractRepositoryTest extends ProviderFunctionalTestCase
         $default = $this->contract($package, null, $now->modify('-1 day'));
         $this->em->flush();
 
-        $this->assertSame($default->getId(), $this->repository()->findOpenContract(null, 500.0, 'CUP')?->getId());
-        $this->assertNull($this->repository()->findOpenContract($account, 500.0, 'CUP'));
+        $this->assertSame($default->getId(), $this->repository()->findOpenContract(null, 500.0, 'CUP', '|')?->getId());
+        $this->assertNull($this->repository()->findOpenContract($account, 500.0, 'CUP', '|'));
+    }
+
+    // ---- Fase 3: service_key es parte de la identidad del contrato ----
+
+    public function testTwoOpenContractsCoexistForTheSameTupleWhenCategoriesDiffer(): void
+    {
+        // La regresión central que compra la Fase 3: antes, el índice único
+        // uniq_com_contract_open_per_tenant_amount solo cubría (tenant,
+        // monto, moneda) — dos contratos abiertos para la misma tupla
+        // habrían violado esa restricción sin importar la categoría. Ahora
+        // que service_key es parte del índice, coexisten sin conflicto.
+        $now = new \DateTimeImmutable();
+        $client = $this->createClient();
+        $environment = $this->createEnvironment();
+        $account = $this->createAccount($client, $environment);
+
+        $mobilePackage = $this->communicationPackage();
+        $mobilePackage->setService(['name' => 'Mobile', 'subservice' => ['name' => 'AIRTIME']]);
+        $mobileContract = $this->contract($mobilePackage, $account, $now->modify('-1 day'))
+            ->setServiceCategory('Mobile', 'AIRTIME');
+
+        $utilitiesPackage = $this->communicationPackage();
+        $utilitiesPackage->setService(['name' => 'Utilities', 'subservice' => ['name' => 'INTERNET']]);
+        $utilitiesContract = $this->contract($utilitiesPackage, $account, $now->modify('-1 day'))
+            ->setServiceCategory('Utilities', 'INTERNET');
+
+        // Misma tupla monto/moneda a propósito — es justo el caso que antes
+        // habría violado el índice único.
+        $utilitiesContract->setDestinationAmount((float) $mobileContract->getDestinationAmount());
+        $utilitiesContract->setDestinationCurrency((string) $mobileContract->getDestinationCurrency());
+
+        $this->em->flush(); // No debe lanzar UniqueConstraintViolationException.
+
+        $this->assertNotNull($mobileContract->getId());
+        $this->assertNotNull($utilitiesContract->getId());
+        $this->assertNotSame($mobileContract->getId(), $utilitiesContract->getId());
+    }
+
+    public function testFindOpenContractDistinguishesByCategoryOnTheSameTuple(): void
+    {
+        $now = new \DateTimeImmutable();
+        $client = $this->createClient();
+        $environment = $this->createEnvironment();
+        $account = $this->createAccount($client, $environment);
+
+        $mobilePackage = $this->communicationPackage();
+        $mobilePackage->setService(['name' => 'Mobile', 'subservice' => ['name' => 'AIRTIME']]);
+        $mobileContract = $this->contract($mobilePackage, $account, $now->modify('-1 day'))
+            ->setServiceCategory('Mobile', 'AIRTIME');
+
+        $utilitiesPackage = $this->communicationPackage();
+        $utilitiesPackage->setService(['name' => 'Utilities', 'subservice' => ['name' => 'INTERNET']]);
+        $utilitiesContract = $this->contract($utilitiesPackage, $account, $now->modify('-1 day'))
+            ->setServiceCategory('Utilities', 'INTERNET');
+        $utilitiesContract->setDestinationAmount((float) $mobileContract->getDestinationAmount());
+        $utilitiesContract->setDestinationCurrency((string) $mobileContract->getDestinationCurrency());
+        $this->em->flush();
+
+        $amount = (float) $mobileContract->getDestinationAmount();
+        $currency = (string) $mobileContract->getDestinationCurrency();
+
+        $foundMobile = $this->repository()->findOpenContract($account, $amount, $currency, 'Mobile|AIRTIME');
+        $foundUtilities = $this->repository()->findOpenContract($account, $amount, $currency, 'Utilities|INTERNET');
+
+        $this->assertSame($mobileContract->getId(), $foundMobile?->getId());
+        $this->assertSame($utilitiesContract->getId(), $foundUtilities?->getId());
     }
 
     public function testFindActiveTenantContractsForPackageReturnsOnlyContractsCoveringThatPackage(): void

--- a/tests/Service/Pricing/CommunicationContractServiceTest.php
+++ b/tests/Service/Pricing/CommunicationContractServiceTest.php
@@ -78,6 +78,14 @@ class CommunicationContractServiceTest extends TestCase
         return $package;
     }
 
+    private function packageInCategory(int $id, string $serviceName, string $subserviceName): CommunicationPackage
+    {
+        $package = $this->package($id);
+        $package->setService(['name' => $serviceName, 'subservice' => ['name' => $subserviceName]]);
+
+        return $package;
+    }
+
     private function contract(CommunicationPackage $package): CommunicationContract
     {
         return (new CommunicationContract())
@@ -298,6 +306,121 @@ class CommunicationContractServiceTest extends TestCase
         $this->assertSame($user, $contract->getCreatedBy());
     }
 
+    // ---- Fase 3: `service` explícito, validado contra la categoría real del paquete ----
+
+    public function testCreateSingleThrowsWhenServiceDoesNotMatchThePackagesActualCategory(): void
+    {
+        $dto = new CreateCommunicationContractDto(
+            communicationPackageId: 1,
+            price: 8.0,
+            currency: 'USD',
+            service: ['name' => 'Utilities', 'subservice' => ['name' => 'INTERNET']],
+        );
+        $package = $this->packageInCategory(1, 'Mobile', 'AIRTIME');
+
+        $this->em->method('getRepository')->with(CommunicationPackage::class)
+            ->willReturn($this->repoReturning($package));
+
+        $this->em->expects($this->never())->method('persist');
+        $this->em->expects($this->never())->method('flush');
+
+        try {
+            $this->service->createSingle($dto);
+            $this->fail('Se esperaba MyCurrentException');
+        } catch (MyCurrentException $e) {
+            $this->assertSame('COMMUNICATION_CONTRACT_SERVICE_MISMATCH', $e->getCodeWork());
+        }
+    }
+
+    public function testCreateSingleSucceedsWhenServiceMatchesThePackagesActualCategory(): void
+    {
+        $dto = new CreateCommunicationContractDto(
+            communicationPackageId: 1,
+            price: 8.0,
+            currency: 'USD',
+            service: ['name' => 'Mobile', 'subservice' => ['name' => 'AIRTIME']],
+        );
+        $package = $this->packageInCategory(1, 'Mobile', 'AIRTIME');
+
+        $this->em->method('getRepository')->with(CommunicationPackage::class)
+            ->willReturn($this->repoReturning($package));
+        $this->contractRepository->method('findOpenContract')->willReturn(null);
+
+        $contract = $this->service->createSingle($dto);
+
+        $this->assertSame('Mobile', $contract->getServiceName());
+    }
+
+    public function testCreateBatchThrowsWhenServiceDoesNotMatchThePackagesActualCategory(): void
+    {
+        $dto = new CreateCommunicationContractBatchDto(
+            communicationPackageId: 1,
+            environmentId: 5,
+            price: 8.0,
+            currency: 'USD',
+            service: ['name' => 'Utilities', 'subservice' => ['name' => 'INTERNET']],
+        );
+        $package = $this->packageInCategory(1, 'Mobile', 'AIRTIME');
+
+        $this->em->method('getRepository')->with(CommunicationPackage::class)
+            ->willReturn($this->repoReturning($package));
+
+        $this->em->expects($this->never())->method('flush');
+
+        try {
+            $this->service->createBatch($dto);
+            $this->fail('Se esperaba MyCurrentException');
+        } catch (MyCurrentException $e) {
+            $this->assertSame('COMMUNICATION_CONTRACT_SERVICE_MISMATCH', $e->getCodeWork());
+        }
+    }
+
+    /**
+     * La regresión central de la Fase 3: dos paquetes que comparten tupla
+     * monto/moneda pero pertenecen a categorías DISTINTAS producen DOS
+     * contratos separados — no uno solo mezclado. upsertContract() pasa
+     * el serviceKey de cada paquete a findOpenContract(); acá se verifica
+     * que ese serviceKey efectivamente llega distinto para cada paquete.
+     */
+    public function testCreateSingleForTwoPackagesOfDifferentCategoriesButSameTupleCreatesTwoContracts(): void
+    {
+        $mobile = $this->packageInCategory(1, 'Mobile', 'AIRTIME');
+        $utilities = $this->packageInCategory(2, 'Utilities', 'INTERNET');
+
+        $packageRepo = $this->createMock(EntityRepository::class);
+        $packageRepo->method('find')->willReturnCallback(
+            static fn (int $id) => match ($id) {
+                1 => $mobile,
+                2 => $utilities,
+                default => null,
+            }
+        );
+        $this->em->method('getRepository')->with(CommunicationPackage::class)->willReturn($packageRepo);
+        $this->em->method('persist')->willReturnCallback(fn ($e) => $this->assignId($e, random_int(1000, 999999)));
+
+        // findOpenContract() nunca encuentra nada existente para NINGUNA de
+        // las dos categorías — cada una crea la suya.
+        $this->contractRepository->expects($this->exactly(2))->method('findOpenContract')
+            ->with($this->anything(), 500.0, 'CUP', $this->logicalOr('Mobile|AIRTIME', 'Utilities|INTERNET'))
+            ->willReturn(null);
+
+        $dtoMobile = new CreateCommunicationContractDto(
+            communicationPackageId: 1, price: 8.0, currency: 'USD',
+            service: ['name' => 'Mobile', 'subservice' => ['name' => 'AIRTIME']],
+        );
+        $dtoUtilities = new CreateCommunicationContractDto(
+            communicationPackageId: 2, price: 5.0, currency: 'USD',
+            service: ['name' => 'Utilities', 'subservice' => ['name' => 'INTERNET']],
+        );
+
+        $contractMobile = $this->service->createSingle($dtoMobile);
+        $contractUtilities = $this->service->createSingle($dtoUtilities);
+
+        $this->assertNotSame($contractMobile, $contractUtilities);
+        $this->assertSame('Mobile', $contractMobile->getServiceName());
+        $this->assertSame('Utilities', $contractUtilities->getServiceName());
+    }
+
     public function testCreateBatchWithEmptyClientsAppliesToAllAccountsFromTargetResolver(): void
     {
         $dto = new CreateCommunicationContractBatchDto(
@@ -382,9 +505,9 @@ class CommunicationContractServiceTest extends TestCase
         $p200 = $this->package(3);
 
         $this->packageRepository->method('findByDestination')->willReturnMap([
-            [100.0, 'CUP', $p100],
-            [150.0, 'CUP', $p150],
-            [200.0, 'CUP', $p200],
+            [100.0, 'CUP', '|', $p100],
+            [150.0, 'CUP', '|', $p150],
+            [200.0, 'CUP', '|', $p200],
         ]);
         $this->contractRepository->method('findOpenContract')->willReturn(null);
 
@@ -533,6 +656,35 @@ class CommunicationContractServiceTest extends TestCase
 
         $this->assertSame(1, $result->created);
         $this->assertSame(12.5, $persisted[0]->getPrice());
+    }
+
+    public function testCreateByRangeFiltersPackagesByTheRequestedCategory(): void
+    {
+        // A diferencia de createSingle/createBatch (donde `service` se
+        // valida contra un paquete ya elegido), acá `service` es la ÚNICA
+        // forma de decidir la categoría — se pasa como filtro directo a
+        // findByDestination().
+        $dto = new CreateCommunicationContractRangeDto(
+            fromAmount: 500.0,
+            toAmount: 500.0,
+            step: 50.0,
+            destinationCurrency: 'CUP',
+            priceFrom: 10.0,
+            priceTo: 10.0,
+            currency: 'USD',
+            service: ['name' => 'Utilities', 'subservice' => ['name' => 'INTERNET']],
+        );
+
+        $package = $this->packageInCategory(1, 'Utilities', 'INTERNET');
+        $this->packageRepository->expects($this->once())->method('findByDestination')
+            ->with(500.0, 'CUP', 'Utilities|INTERNET')
+            ->willReturn($package);
+        $this->contractRepository->method('findOpenContract')->willReturn(null);
+        $this->em->method('persist')->willReturnCallback(fn ($e) => $this->assignId($e, 1));
+
+        $result = $this->service->createByRange($dto);
+
+        $this->assertSame(1, $result->created);
     }
 
     public function testUpdateOnlyTouchesProvidedFields(): void
@@ -735,7 +887,7 @@ class CommunicationContractServiceTest extends TestCase
         $promoPackage = $this->package(1);
         $regularPackage = $this->package(2);
         $this->packageRepository->method('findByDestination')
-            ->with(500.0, 'CUP')
+            ->with(500.0, 'CUP', '|')
             ->willReturn($regularPackage);
 
         $tenantA = $this->createMock(Account::class);
@@ -776,6 +928,32 @@ class CommunicationContractServiceTest extends TestCase
 
         $this->assertSame(0, $linked);
         $this->assertCount(2, $contract->getPackages());
+    }
+
+    public function testLinkTenantContractsFiltersTheRegularEquivalentByThePromoPackagesOwnCategory(): void
+    {
+        // Fase 3: cierra la fuga donde un paquete de promoción se
+        // enganchaba al contrato de OTRA categoría que casualmente
+        // compartía tupla monto/moneda — findByDestination() se filtra por
+        // la categoría del propio paquete de promoción, sin asumir que
+        // coincide con la de "cualquier" paquete regular en esa tupla.
+        $promoPackage = $this->packageInCategory(1, 'Utilities', 'INTERNET');
+        $regularPackage = $this->packageInCategory(2, 'Utilities', 'INTERNET');
+
+        $this->packageRepository->expects($this->once())->method('findByDestination')
+            ->with(500.0, 'CUP', 'Utilities|INTERNET')
+            ->willReturn($regularPackage);
+
+        $tenant = $this->createMock(Account::class);
+        $contract = $this->contract($regularPackage)->setTenant($tenant)->setServiceCategory('Utilities', 'INTERNET');
+
+        $this->contractRepository->method('findActiveTenantContractsForPackage')->willReturn([$contract]);
+        $this->em->expects($this->once())->method('flush');
+
+        $linked = $this->service->linkTenantContractsToPromotionPackages([$promoPackage]);
+
+        $this->assertSame(1, $linked);
+        $this->assertTrue($contract->getPackages()->contains($promoPackage));
     }
 
     public function testLinkTenantContractsForPromotionDelegatesUsingThePromotionsOwnPackages(): void

--- a/tests/Service/Pricing/CommunicationPackageAdminServiceTest.php
+++ b/tests/Service/Pricing/CommunicationPackageAdminServiceTest.php
@@ -195,6 +195,65 @@ class CommunicationPackageAdminServiceTest extends TestCase
         $this->assertSame(1, $updated->getDisplayOrder());
     }
 
+    // ---- Fase 3: la categoría no se puede editar una vez que el paquete está en algún contrato ----
+
+    public function testUpdateThrowsWhenChangingCategoryOfAPackageThatAlreadyHasAContract(): void
+    {
+        $package = (new CommunicationPackage())
+            ->setName('Recarga')->setDescription('Recarga')
+            ->setDestinationAmount(500.0)->setDestinationCurrency('CUP');
+        $package->setService(['name' => 'Mobile', 'subservice' => ['name' => 'AIRTIME']]);
+        $this->addContractTo($package, new CommunicationContract());
+
+        $dto = new UpdateCommunicationPackageDto(service: ['name' => 'Utilities', 'subservice' => ['name' => 'INTERNET']]);
+
+        $this->em->expects($this->never())->method('flush');
+
+        try {
+            $this->service->update($package, $dto);
+            $this->fail('Se esperaba MyCurrentException');
+        } catch (MyCurrentException $e) {
+            $this->assertSame('COMMUNICATION_PACKAGE_CATEGORY_LOCKED', $e->getCodeWork());
+        }
+        // La categoría original sigue intacta — el rechazo pasó ANTES de mutar el paquete.
+        $this->assertSame('Mobile', $package->getService()['name']);
+    }
+
+    public function testUpdateAllowsResendingTheSameCategoryEvenWithAContract(): void
+    {
+        // No es un cambio real — mismo `service`, misma serviceKey — no
+        // debe bloquearse aunque el paquete ya tenga contratos.
+        $package = (new CommunicationPackage())
+            ->setName('Recarga')->setDescription('Recarga')
+            ->setDestinationAmount(500.0)->setDestinationCurrency('CUP');
+        $package->setService(['name' => 'Mobile', 'subservice' => ['name' => 'AIRTIME']]);
+        $this->addContractTo($package, new CommunicationContract());
+
+        $dto = new UpdateCommunicationPackageDto(service: ['name' => 'Mobile', 'subservice' => ['name' => 'AIRTIME']]);
+
+        $this->em->expects($this->once())->method('flush');
+
+        $updated = $this->service->update($package, $dto);
+
+        $this->assertSame('Mobile', $updated->getService()['name']);
+    }
+
+    public function testUpdateAllowsChangingCategoryWhenPackageHasNoContracts(): void
+    {
+        $package = (new CommunicationPackage())
+            ->setName('Recarga')->setDescription('Recarga')
+            ->setDestinationAmount(500.0)->setDestinationCurrency('CUP');
+        $package->setService(['name' => 'Mobile', 'subservice' => ['name' => 'AIRTIME']]);
+
+        $dto = new UpdateCommunicationPackageDto(service: ['name' => 'Utilities', 'subservice' => ['name' => 'INTERNET']]);
+
+        $this->em->expects($this->once())->method('flush');
+
+        $updated = $this->service->update($package, $dto);
+
+        $this->assertSame('Utilities', $updated->getService()['name']);
+    }
+
     public function testToggleFlipsIsActiveAndFlushes(): void
     {
         $package = (new CommunicationPackage())


### PR DESCRIPTION
## Resumen

Última fase del rediseño de contratos por categoría (backend). Fases 1-2 ya en `develop` (#125). A diferencia de esas, esta fase muta **datos** (qué contrato termina cubriendo qué paquete) — deliberadamente al final, ya validada la lectura (Fase 2) en la práctica.

- `service_key` pasa a formar parte de la identidad del contrato: el índice único `uniq_com_contract_open_per_tenant_amount` gana `service_key` como cuarta columna (migración segura por construcción — ampliar un índice único con una columna más nunca puede introducir un conflicto que antes no existiera). `findOpenContract()`/`upsertContract()` la usan para deduplicar: dos paquetes que comparten tupla monto/moneda pero difieren en categoría producen ahora **dos** contratos, no uno mezclado (regresión central, cubierta con test funcional y unitario).
- `CreateCommunicationContractDto`/`Batch`/`Range` ganan `service` explícito y **obligatorio** (decisión ya tomada: exigirlo en vez de derivarlo en silencio del paquete elegido):
  - Single/Batch: se valida contra la categoría real de `communicationPackageId` (422 si no coincide) — atrapa el caso de elegir el paquete equivocado.
  - Range: es la única forma de decidir a qué categoría pertenecen los paquetes que matchean cada monto (no hay paquete elegido de antemano).
- `findByDestination()` gana filtro opcional por categoría; `linkTenantContractsToPromotionPackages()` lo usa filtrando por la categoría del propio paquete de promoción — cierra la fuga donde un paquete de promoción podía engancharse al contrato de OTRA categoría que casualmente compartía tupla monto/moneda.
- `CommunicationContract::addPackage()` rechaza un paquete de categoría distinta a la que ya cubre el contrato (a partir del segundo paquete — el primero nunca se rechaza a sí mismo, necesario porque varios constructores de test/servicio agregan el paquete antes de fijar la categoría).
- `CommunicationPackageAdminService::update()` bloquea cambiar la categoría de un paquete que ya está en algún contrato (409) — evita romper en silencio el invariante de `addPackage()` sobre paquetes ya agregados.

## Plan de pruebas
- [x] `php bin/phpunit --no-coverage` — 1098/1098 verde
- [x] `vendor/bin/phpstan analyse` — sin errores
- [x] Migración corrida contra `app` (dev) y `app_test` (test), sin backfill ni detección de conflictos necesarios (segura por construcción)
- [x] Test funcional contra Postgres real: dos contratos abiertos para la misma tupla con categorías distintas coexisten sin violar el índice único
- [x] Test funcional: `findOpenContract()` distingue por categoría sobre la misma tupla

🤖 Generado con [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeLYjtiTNMg6VWD3j6DCGK