### PR TITLE
Release: filtros de paquetes del catálogo (promoción, tipo, fecha de creación)

### DIFF
--- a/src/Controller/DashboardCommunicationPackagesController.php
+++ b/src/Controller/DashboardCommunicationPackagesController.php
@@ -314,6 +314,36 @@ class DashboardCommunicationPackagesController extends AbstractController
         if ($search = $request->query->get('search')) {
             $qb->andWhere('p.name LIKE :s')->setParameter('s', "%{$search}%");
         }
+        if ($request->query->has('inPromotion')) {
+            $qb->andWhere($request->query->getBoolean('inPromotion') ? 'p.promotion IS NOT NULL' : 'p.promotion IS NULL');
+        }
+        if ($tag = $request->query->get('tag')) {
+            // tags es json (no jsonb) — DQL no puede comparar json con LIKE
+            // directamente (Postgres lo rechaza: "operator does not exist:
+            // json ~~ unknown"), así que se resuelve el conjunto de ids por
+            // SQL crudo y se filtra por IN() en la QueryBuilder normal.
+            $ids = $this->packageIdsWithTag($tag);
+            $qb->andWhere('p.id IN (:tagIds)')->setParameter('tagIds', $ids === [] ? [0] : $ids);
+        }
+        if ($createdFrom = $request->query->get('createdFrom')) {
+            $qb->andWhere('p.createdAt >= :createdFrom')->setParameter('createdFrom', new \DateTimeImmutable($createdFrom));
+        }
+        if ($createdTo = $request->query->get('createdTo')) {
+            $qb->andWhere('p.createdAt <= :createdTo')->setParameter('createdTo', new \DateTimeImmutable($createdTo . ' 23:59:59'));
+        }
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function packageIdsWithTag(string $tag): array
+    {
+        $rows = $this->em->getConnection()->executeQuery(
+            'SELECT id FROM communication_package WHERE tags::text LIKE :tag',
+            ['tag' => '%"' . addcslashes($tag, '%_\\') . '"%']
+        )->fetchFirstColumn();
+
+        return array_map('intval', $rows);
     }
 
     private function serialize(CommunicationPackage $package, bool $hasBindings = false): array
@@ -335,6 +365,7 @@ class DashboardCommunicationPackagesController extends AbstractController
             'createdAt' => $package->getCreatedAt()?->format('c'),
             'updatedAt' => $package->getUpdatedAt()?->format('c'),
             'hasBindings' => $hasBindings,
+            'promotionId' => $package->getPromotion()?->getId(),
         ];
     }
 

--- a/src/DTO/Out/CommunicationPackageOutDto.php
+++ b/src/DTO/Out/CommunicationPackageOutDto.php
@@ -21,4 +21,6 @@ final class CommunicationPackageOutDto
     public ?string $updatedAt = null;
     /** true si el paquete tiene al menos un vínculo explícito paquete→producto por proveedor. */
     public bool $hasBindings = false;
+    /** No nulo = paquete generado por rango para esta promoción (ver CommunicationPackage::$promotion). */
+    public ?int $promotionId = null;
 }

--- a/tests/Functional/Pricing/DashboardCommunicationPackagesControllerListTest.php
+++ b/tests/Functional/Pricing/DashboardCommunicationPackagesControllerListTest.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace App\Tests\Functional\Pricing;
+
+use App\Controller\DashboardCommunicationPackagesController;
+use App\Entity\CommunicationPackage;
+use App\Entity\CommunicationPromotions;
+use App\Repository\CommunicationPackageProviderProductRepository;
+use App\Service\Pricing\CommunicationPackageAdminService;
+use App\Service\Pricing\CommunicationPackageBindingService;
+use App\Service\Pricing\PackageCatalogResolver;
+use App\Tests\Functional\Provider\ProviderFunctionalTestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @covers \App\Controller\DashboardCommunicationPackagesController
+ *
+ * Contra Postgres real — a propósito: el filtro por tag depende de una
+ * comparación LIKE contra la representación de texto de una columna `json`
+ * (no `jsonb`), que Doctrine DQL no puede expresar directamente (Postgres
+ * rechaza `json ~~ unknown`) — solo un test contra SQL real confirma que el
+ * cast manual (`tags::text LIKE ...`) funciona de verdad.
+ */
+class DashboardCommunicationPackagesControllerListTest extends ProviderFunctionalTestCase
+{
+    private static int $counter = 0;
+
+    private function controller(): DashboardCommunicationPackagesController
+    {
+        $controller = new DashboardCommunicationPackagesController(
+            $this->em,
+            self::getContainer()->get(CommunicationPackageAdminService::class),
+            self::getContainer()->get(PackageCatalogResolver::class),
+            self::getContainer()->get(CommunicationPackageBindingService::class),
+            self::getContainer()->get(CommunicationPackageProviderProductRepository::class),
+        );
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('has')->willReturn(false);
+        $controller->setContainer($container);
+
+        return $controller;
+    }
+
+    private function communicationPackage(string $name, array $tags = []): CommunicationPackage
+    {
+        self::$counter++;
+
+        $package = (new CommunicationPackage())
+            ->setName($name)
+            ->setDescription($name)
+            ->setDestinationAmount(500.0 + self::$counter)
+            ->setDestinationCurrency('CUP')
+            ->setTags($tags);
+
+        $this->em->persist($package);
+
+        return $package;
+    }
+
+    /**
+     * createdAt solo se fija vía #[ORM\PrePersist] (siempre "ahora") — para
+     * un test de orden determinístico hace falta pisarlo con SQL crudo
+     * después del flush, no hay setter público a propósito (ver entidad).
+     */
+    private function setCreatedAt(CommunicationPackage $package, \DateTimeImmutable $when): void
+    {
+        $this->em->getConnection()->executeStatement(
+            'UPDATE communication_package SET created_at = :when WHERE id = :id',
+            ['when' => $when->format('Y-m-d H:i:s'), 'id' => $package->getId()]
+        );
+    }
+
+    public function testFiltersByTagUsingRawJsonTextComparison(): void
+    {
+        $internet = $this->communicationPackage('Nauta WiFi', ['INTERNET']);
+        $airtime = $this->communicationPackage('Recarga simple', ['AIRTIME']);
+        $this->em->flush();
+        $this->em->clear();
+
+        $response = $this->controller()->list(new Request(['tag' => 'INTERNET']));
+        $data = json_decode($response->getContent(), true);
+
+        $this->assertCount(1, $data['results']);
+        $this->assertSame($internet->getId(), $data['results'][0]['id']);
+    }
+
+    public function testFilterByTagNeverMatchesASubstringOfAnotherTag(): void
+    {
+        // UNLIMITED contiene "LIMIT" como substring — el LIKE debe matchear
+        // por el valor JSON completo entre comillas ("TAG"), no cualquier
+        // substring suelto del array serializado.
+        $this->communicationPackage('Nauta PLUS', ['INTERNET', 'UNLIMITED']);
+        $this->em->flush();
+        $this->em->clear();
+
+        $response = $this->controller()->list(new Request(['tag' => 'LIMIT']));
+        $data = json_decode($response->getContent(), true);
+
+        $this->assertCount(0, $data['results']);
+    }
+
+    public function testFiltersByInPromotionTrueAndFalse(): void
+    {
+        $promotion = (new CommunicationPromotions())
+            ->setName('Promo test')
+            ->setDescription('Promo test')
+            ->setStartAt(new \DateTimeImmutable('-1 day'))
+            ->setEndAt(new \DateTimeImmutable('+5 days'));
+        $this->em->persist($promotion);
+
+        $regular = $this->communicationPackage('Catálogo normal');
+        $promoPackage = $this->communicationPackage('Paquete de promo');
+        $promoPackage->setPromotion($promotion);
+        $this->em->flush();
+        $this->em->clear();
+
+        $onlyPromo = json_decode($this->controller()->list(new Request(['inPromotion' => 'true']))->getContent(), true);
+        $this->assertCount(1, $onlyPromo['results']);
+        $this->assertSame($promoPackage->getId(), $onlyPromo['results'][0]['id']);
+        $this->assertSame($promotion->getId(), $onlyPromo['results'][0]['promotionId']);
+
+        $onlyRegular = json_decode($this->controller()->list(new Request(['inPromotion' => 'false']))->getContent(), true);
+        $this->assertCount(1, $onlyRegular['results']);
+        $this->assertSame($regular->getId(), $onlyRegular['results'][0]['id']);
+        $this->assertNull($onlyRegular['results'][0]['promotionId']);
+    }
+
+    public function testFiltersByCreatedAtDateRange(): void
+    {
+        $old = $this->communicationPackage('Paquete viejo');
+        $recent = $this->communicationPackage('Paquete reciente');
+        $this->em->flush();
+        $this->setCreatedAt($old, new \DateTimeImmutable('2026-01-01 10:00:00'));
+        $this->setCreatedAt($recent, new \DateTimeImmutable('2026-06-15 10:00:00'));
+        $this->em->clear();
+
+        $data = json_decode(
+            $this->controller()->list(new Request(['createdFrom' => '2026-06-01', 'createdTo' => '2026-06-30']))->getContent(),
+            true
+        );
+
+        $this->assertCount(1, $data['results']);
+        $this->assertSame($recent->getId(), $data['results'][0]['id']);
+    }
+
+    public function testSortsByCreatedAtAscendingAndDescending(): void
+    {
+        $first = $this->communicationPackage('Primero creado');
+        $second = $this->communicationPackage('Segundo creado');
+        $this->em->flush();
+        $this->setCreatedAt($first, new \DateTimeImmutable('2026-01-01 10:00:00'));
+        $this->setCreatedAt($second, new \DateTimeImmutable('2026-02-01 10:00:00'));
+        $this->em->clear();
+
+        $asc = json_decode($this->controller()->list(new Request(['orderBy' => 'createdAt ASC']))->getContent(), true);
+        $this->assertSame([$first->getId(), $second->getId()], array_column($asc['results'], 'id'));
+
+        $desc = json_decode($this->controller()->list(new Request(['orderBy' => 'createdAt DESC']))->getContent(), true);
+        $this->assertSame([$second->getId(), $first->getId()], array_column($desc['results'], 'id'));
+    }
+}


### PR DESCRIPTION
## Summary
`GET /catalog/packages` suma 3 filtros nuevos: `inPromotion` (paquetes generados por una promoción vs. catálogo regular), `tag` (AIRTIME/BUNDLE/DATA/SMS/INTERNET/LANDLINE/UNLIMITED) y `createdFrom`/`createdTo` (rango de fecha de creación). El orden por fecha de creación (`orderBy=createdAt`) ya estaba soportado, solo faltaba exponerlo. `serialize()` ahora incluye `promotionId`.

Ver PR #130 para el detalle completo.

## Test plan
- [x] `php bin/phpunit --no-coverage` — 1034/1034 en verde
- [x] `vendor/bin/phpstan analyse` — limpio
- [x] Test funcional nuevo contra Postgres real (el filtro de tag necesita el cast real, no se puede probar con mocks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)