### PR TITLE
Merge develop into master

### DIFF
--- a/src/Service/Pricing/BenefitOperationResolver.php
+++ b/src/Service/Pricing/BenefitOperationResolver.php
@@ -81,10 +81,32 @@ class BenefitOperationResolver
                 'total_excluding_tax' => self::normalizeNumber($totalExcludingTax),
                 'total_including_tax' => self::normalizeNumber($totalExcludingTax),
             ];
+
+            // El texto debe reflejar el resultado de la operación (ej.
+            // "sextuplica" 800 CUP → "4800 CUP"), no el destinationAmount
+            // original que dejó fijo applyCreditBenefitDefaults() al crear.
+            if (($benefit['type'] ?? null) === 'CREDITS' && $isCurrency) {
+                $benefit['additional_information'] = sprintf(
+                    '%s %s',
+                    self::formatAmount($totalExcludingTax),
+                    (string) ($benefit['unit'] ?? ''),
+                );
+            }
         }
         unset($benefit);
 
         return $benefits;
+    }
+
+    /**
+     * "1250" para montos enteros, "275.5" para fraccionarios — sin ceros de
+     * relleno (igual que CommunicationPackageAdminService::formatAmount()).
+     */
+    private static function formatAmount(float $amount): string
+    {
+        return $amount == floor($amount)
+            ? (string) (int) $amount
+            : rtrim(rtrim(number_format($amount, 2, '.', ''), '0'), '.');
     }
 
     /**

--- a/tests/Service/Pricing/BenefitOperationResolverTest.php
+++ b/tests/Service/Pricing/BenefitOperationResolverTest.php
@@ -44,6 +44,32 @@ class BenefitOperationResolverTest extends TestCase
         $this->assertSame(3000, $benefit['amount']['promotion_bonus']);
         $this->assertSame(3600, $benefit['amount']['total_excluding_tax']);
         $this->assertSame(3600, $benefit['amount']['total_including_tax']);
+        $this->assertSame('3600 CUP', $benefit['additional_information']);
+    }
+
+    public function testAddForACreditsCurrencyBenefitAlsoUpdatesAdditionalInformationToTheResultingTotal(): void
+    {
+        $package = $this->package(600.0, 'CUP')->setBenefits([[
+            'type' => 'CREDITS', 'unit' => 'CUP', 'unit_type' => 'CURRENCY',
+            'operation' => 'ADD', 'value' => 50, 'additional_information' => '600 CUP',
+        ]]);
+
+        $benefit = $this->resolver->resolve($package)[0];
+
+        $this->assertSame('650 CUP', $benefit['additional_information']);
+    }
+
+    public function testDoesNotTouchAdditionalInformationForANonCurrencyBenefit(): void
+    {
+        $package = $this->package(600.0, 'CUP')->setBenefits([[
+            'type' => 'DATA', 'unit' => 'GB', 'unit_type' => 'DATA',
+            'operation' => 'ADD', 'value' => 20, 'additional_information' => 'Datos extra',
+        ]]);
+        $this->packageRepository->method('findByDestination')->willReturn(null);
+
+        $benefit = $this->resolver->resolve($package)[0];
+
+        $this->assertSame('Datos extra', $benefit['additional_information']);
     }
 
     public function testAddForANonCurrencyBenefitUsesTheRegularEquivalentPackagesBenefitAsBaseline(): void


### PR DESCRIPTION
## Summary
Despliega a producción el fix de `BenefitOperationResolver` (PR #132): recalcula `additional_information` de beneficios de saldo (CREDITS/CURRENCY) con `operation` (MULTIPLY/ADD/SET) para reflejar el monto resultante, no el destinationAmount original.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGZSuxX18gJ4N9XUmvmadS