### PR TITLE
Release: TDD obligatorio + beneficios de promociones V2 editables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,6 +284,27 @@ Ninguna funcionalidad backend administrable (credenciales, parámetros, catálog
 
 ---
 
+### 12. Toda funcionalidad nueva se desarrolla con TDD
+
+A partir de 2026-08-27, cualquier funcionalidad nueva (endpoint, DTO, servicio, regla de negocio) se implementa con TDD, no "código primero y test después":
+
+1. Escribir el test (unitario y/o funcional) que describe el comportamiento esperado — debe fallar (rojo) antes de tocar la implementación.
+2. Implementar lo mínimo necesario para que pase (verde).
+3. Refactorizar manteniendo los tests en verde.
+
+```bash
+# Ejemplo de ciclo con PHPUnit
+vendor/bin/phpunit --filter testNombreDelCaso tests/Service/Pricing/MiServicioTest.php   # 1. rojo
+# ... implementar ...
+vendor/bin/phpunit --filter testNombreDelCaso tests/Service/Pricing/MiServicioTest.php   # 2. verde
+```
+
+**Por qué:** un bug real (2026-08-27) mostró exactamente el costo de no hacerlo — los formularios de edición de paquetes y de promociones en `dashboard-cm` perdían u ocultaban silenciosamente campos (`operation`/`value`/`schedule` de beneficios; `clients`/`products`/`currency`/`amountFrom`/`amountTo`/`amountStep` de promociones, que `UpdatePromotionDto` nunca aceptó) porque ningún test cubría el round-trip completo (cargar → editar → guardar → volver a cargar). Escribir el test primero obliga a definir ese round-trip antes de que el código "parezca funcionar" en la UI.
+
+**Cómo aplica aquí:** ver la regla 11 arriba (tests + pantalla propia siguen siendo obligatorios para dar una funcionalidad por terminada) — TDD es *cómo* se llega a esos tests, no un requisito adicional distinto. No es retroactivo: no reescribas tests de código existente que no estás tocando solo por adoptar esta práctica.
+
+---
+
 ## Archivos de referencia
 
 | Propósito | Archivo |

--- a/src/Controller/DashboardPromotionController.php
+++ b/src/Controller/DashboardPromotionController.php
@@ -285,9 +285,18 @@ class DashboardPromotionController extends AbstractController
         ];
     }
 
+    /**
+     * `benefits` (V2) no es una propiedad de CommunicationPromotions — a
+     * diferencia de `terms` (V1, columna propia), los beneficios reales de
+     * una promoción V2 viven en cada CommunicationPackage generado, así que
+     * se resuelven aparte vía CommunicationPromotionService::
+     * getPackageBenefits() y se mezclan acá en vez de con un grupo de
+     * serialización (necesita ir a repositorio, un getter en la entidad no
+     * debería hacerlo).
+     */
     private function normalizeDetail(CommunicationPromotions $promotion): array
     {
-        return $this->serializer->normalize(
+        $data = $this->serializer->normalize(
             $promotion,
             'json',
             [
@@ -295,5 +304,11 @@ class DashboardPromotionController extends AbstractController
                 AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
             ]
         );
+
+        if ($promotion->isV2()) {
+            $data['benefits'] = $this->promotionService->getPackageBenefits($promotion);
+        }
+
+        return $data;
     }
 }

--- a/src/DTO/CreatePromotionV2Dto.php
+++ b/src/DTO/CreatePromotionV2Dto.php
@@ -3,6 +3,7 @@
 namespace App\DTO;
 
 use App\DTO\Validation\BenefitOperationValidator;
+use App\DTO\Validation\BenefitScheduleValidator;
 use App\OpenApi\Attribute\OAProperty;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
@@ -208,44 +209,7 @@ class CreatePromotionV2Dto implements IInput
     #[Assert\Callback]
     public function validateBenefitsSchedule(ExecutionContextInterface $context): void
     {
-        if ($this->benefits === null) {
-            return;
-        }
-
-        foreach ($this->benefits as $index => $benefit) {
-            if (!is_array($benefit) || !array_key_exists('schedule', $benefit) || $benefit['schedule'] === null) {
-                continue;
-            }
-
-            $schedule = $benefit['schedule'];
-            $path = "benefits[{$index}].schedule";
-
-            if (!is_array($schedule) || !array_key_exists('start', $schedule) || !array_key_exists('end', $schedule)) {
-                $context->buildViolation('schedule debe tener start y end (ambos null, o ambos "HH:mm")')
-                    ->atPath($path)
-                    ->addViolation();
-                continue;
-            }
-
-            [$start, $end] = [$schedule['start'], $schedule['end']];
-            if ($start === null && $end === null) {
-                continue;
-            }
-
-            $timeFormat = '/^([01]\d|2[0-3]):[0-5]\d$/';
-            if (!is_string($start) || !is_string($end) || !preg_match($timeFormat, $start) || !preg_match($timeFormat, $end)) {
-                $context->buildViolation('schedule.start/end deben ser ambos null (24h) o ambos "HH:mm"')
-                    ->atPath($path)
-                    ->addViolation();
-                continue;
-            }
-
-            if ($start === $end) {
-                $context->buildViolation('schedule.start y schedule.end no pueden ser iguales')
-                    ->atPath($path)
-                    ->addViolation();
-            }
-        }
+        BenefitScheduleValidator::validate($this->benefits, $context);
     }
 
     #[Assert\Callback]

--- a/src/DTO/UpdatePromotionDto.php
+++ b/src/DTO/UpdatePromotionDto.php
@@ -2,7 +2,11 @@
 
 namespace App\DTO;
 
+use App\DTO\Validation\BenefitOperationValidator;
+use App\DTO\Validation\BenefitScheduleValidator;
+use App\OpenApi\Attribute\OAProperty;
 use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 class UpdatePromotionDto implements IInput
 {
@@ -14,7 +18,49 @@ class UpdatePromotionDto implements IInput
 
     protected ?string $knowMore;
 
+    /**
+     * Solo para promociones V1 (legacy) — ver CommunicationClientPackage::
+     * mergeBenefitsWithPromotions(). Para V2 usar `benefits` en su lugar;
+     * enviar `terms` a una promoción V2 no tiene ningún efecto (nada lo lee).
+     */
     protected ?array $terms;
+
+    /**
+     * Solo para promociones V2 (catálogo compartido) — mismo shape que
+     * CreatePromotionV2Dto::$benefits. CommunicationPromotionService::
+     * updatePackageBenefits() lo propaga TAL CUAL a cada CommunicationPackage
+     * vinculado a esta promoción (mismo criterio que al crear el batch
+     * original): CommunicationPackageAdminService::update() recalcula
+     * additional_information/amount.base de los beneficios CREDITS/CURRENCY
+     * contra el destinationAmount propio de cada paquete, así que el mismo
+     * array "plantilla" produce el texto correcto en cada uno. Enviar
+     * `benefits` a una promoción V1 (con producto de origen) lanza
+     * PROMOTION_BENEFITS_NOT_APPLICABLE.
+     */
+    #[OAProperty(schema: [
+        'type' => 'array',
+        'nullable' => true,
+        'items' => [
+            'type' => 'object',
+            'properties' => [
+                'type' => ['type' => 'string', 'enum' => ['CREDITS', 'TALKTIME', 'DATA', 'SMS']],
+                'unit' => ['type' => 'string', 'enum' => ['CUP', 'USD', 'UNITS', 'MINUTES', 'GB', 'ILIM']],
+                'unit_type' => ['type' => 'string', 'enum' => ['CURRENCY', 'QUANTITY', 'DATA', 'TIME']],
+                'additional_information' => ['type' => 'string'],
+                'amount' => ['type' => 'object', 'properties' => [
+                    'base' => ['type' => 'integer'],
+                    'promotion_bonus' => ['type' => 'integer'],
+                ]],
+                'operation' => ['type' => 'string', 'nullable' => true, 'enum' => ['MULTIPLY', 'ADD', 'SET']],
+                'value' => ['type' => 'number', 'nullable' => true, 'example' => 6],
+                'schedule' => ['type' => 'object', 'nullable' => true, 'default' => null, 'properties' => [
+                    'start' => ['type' => 'string', 'nullable' => true, 'example' => '01:00'],
+                    'end' => ['type' => 'string', 'nullable' => true, 'example' => '06:00'],
+                ]],
+            ],
+        ],
+    ])]
+    protected ?array $benefits;
 
     protected ?array $validityInfo;
 
@@ -35,6 +81,7 @@ class UpdatePromotionDto implements IInput
         ?string $infoDescription = null,
         ?string $knowMore = null,
         ?array $terms = null,
+        ?array $benefits = null,
         ?array $validityInfo = null,
         ?string $startAt = null,
         ?string $endAt = null,
@@ -47,12 +94,25 @@ class UpdatePromotionDto implements IInput
         $this->infoDescription = $infoDescription;
         $this->knowMore = $knowMore;
         $this->terms = $terms;
+        $this->benefits = $benefits;
         $this->validityInfo = $validityInfo;
         $this->startAt = $startAt;
         $this->endAt = $endAt;
         $this->productId = $productId;
         $this->environmentId = $environmentId;
         $this->priority = $priority;
+    }
+
+    #[Assert\Callback]
+    public function validateBenefitsSchedule(ExecutionContextInterface $context): void
+    {
+        BenefitScheduleValidator::validate($this->benefits, $context);
+    }
+
+    #[Assert\Callback]
+    public function validateBenefitsOperation(ExecutionContextInterface $context): void
+    {
+        BenefitOperationValidator::validate($this->benefits, $context);
     }
 
     public function getName(): ?string { return $this->name; }
@@ -69,6 +129,9 @@ class UpdatePromotionDto implements IInput
 
     public function getTerms(): ?array { return $this->terms; }
     public function setTerms(?array $v): void { $this->terms = $v; }
+
+    public function getBenefits(): ?array { return $this->benefits; }
+    public function setBenefits(?array $v): void { $this->benefits = $v; }
 
     public function getValidityInfo(): ?array { return $this->validityInfo; }
     public function setValidityInfo(?array $v): void { $this->validityInfo = $v; }

--- a/src/DTO/Validation/BenefitScheduleValidator.php
+++ b/src/DTO/Validation/BenefitScheduleValidator.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\DTO\Validation;
+
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+
+/**
+ * Validación compartida de `benefits[].schedule` — usada desde
+ * CreatePromotionV2Dto y UpdatePromotionDto (mismo shape de `benefits`, ver
+ * CommunicationPackage::$benefits). `schedule` es opcional y puramente
+ * informativo — no se valida contra el `type`/`unit` del beneficio, solo su
+ * propia forma: ambos extremos null (24h) o ambos presentes en formato
+ * HH:mm y distintos entre sí (una franja de largo cero no tiene sentido).
+ */
+final class BenefitScheduleValidator
+{
+    public static function validate(?array $benefits, ExecutionContextInterface $context): void
+    {
+        if ($benefits === null) {
+            return;
+        }
+
+        foreach ($benefits as $index => $benefit) {
+            if (!is_array($benefit) || !array_key_exists('schedule', $benefit) || $benefit['schedule'] === null) {
+                continue;
+            }
+
+            $schedule = $benefit['schedule'];
+            $path = "benefits[{$index}].schedule";
+
+            if (!is_array($schedule) || !array_key_exists('start', $schedule) || !array_key_exists('end', $schedule)) {
+                $context->buildViolation('schedule debe tener start y end (ambos null, o ambos "HH:mm")')
+                    ->atPath($path)
+                    ->addViolation();
+                continue;
+            }
+
+            [$start, $end] = [$schedule['start'], $schedule['end']];
+            if ($start === null && $end === null) {
+                continue;
+            }
+
+            $timeFormat = '/^([01]\d|2[0-3]):[0-5]\d$/';
+            if (!is_string($start) || !is_string($end) || !preg_match($timeFormat, $start) || !preg_match($timeFormat, $end)) {
+                $context->buildViolation('schedule.start/end deben ser ambos null (24h) o ambos "HH:mm"')
+                    ->atPath($path)
+                    ->addViolation();
+                continue;
+            }
+
+            if ($start === $end) {
+                $context->buildViolation('schedule.start y schedule.end no pueden ser iguales')
+                    ->atPath($path)
+                    ->addViolation();
+            }
+        }
+    }
+}

--- a/src/Service/CommunicationPromotionService.php
+++ b/src/Service/CommunicationPromotionService.php
@@ -4,8 +4,10 @@ namespace App\Service;
 
 use App\DTO\CreateCommunicationPackageBatchDto;
 use App\DTO\CreatePromotionV2Dto;
+use App\DTO\UpdateCommunicationPackageDto;
 use App\DTO\UpdatePromotionDto;
 use App\Entity\CommunicationClientPackage;
+use App\Entity\CommunicationPackage;
 use App\Entity\CommunicationPrice;
 use App\Entity\CommunicationPricePackage;
 use App\Entity\CommunicationProduct;
@@ -15,6 +17,7 @@ use App\Entity\User;
 use App\Enums\JobPositionAreaEnum;
 use App\Exception\MyCurrentException;
 use App\Message\PromotionCreatedMessage;
+use App\Repository\CommunicationPackageRepository;
 use App\Repository\EnvironmentRepository;
 use App\Repository\SysConfigRepository;
 use App\Service\Pricing\CommunicationContractService;
@@ -47,6 +50,7 @@ class CommunicationPromotionService extends CommonService
         private readonly CommunicationPackageAdminService $packageAdminService,
         private readonly CommunicationContractService $contractService,
         private readonly CommunicationPromotionEquivalenceService $equivalenceService,
+        private readonly CommunicationPackageRepository $packageRepository,
     ) {
         parent::__construct($em, $security, $parameters, $mailer, $logger, $passwordHasher, $environmentRepository, $sysConfigRepo, $serializer);
     }
@@ -303,6 +307,17 @@ class CommunicationPromotionService extends CommonService
      */
     public function update(CommunicationPromotions $promotion, UpdatePromotionDto $dto): CommunicationPromotions
     {
+        // Falla ANTES de mutar nada — evita el caso raro de mandar
+        // productId+benefits en la misma petición, donde setProduct() más
+        // abajo cambiaría isV2() a mitad del método.
+        if ($dto->getBenefits() !== null && !$promotion->isV2()) {
+            throw new MyCurrentException(
+                'PROMOTION_BENEFITS_NOT_APPLICABLE',
+                'Esta promoción no es V2 — los beneficios se editan con terms, no benefits',
+                400,
+            );
+        }
+
         if ($dto->getName() !== null) {
             $promotion->setName($dto->getName());
         }
@@ -361,7 +376,60 @@ class CommunicationPromotionService extends CommonService
 
         $this->em->flush();
 
+        if ($dto->getBenefits() !== null) {
+            $this->updatePackageBenefits($promotion, $dto->getBenefits());
+        }
+
         return $promotion;
+    }
+
+    /**
+     * Beneficios "plantilla" de una promoción V2 — se toman de un
+     * CommunicationPackage cualquiera vinculado (todos comparten el mismo
+     * array salvo lo que CommunicationPackageAdminService::
+     * applyCreditBenefitDefaults() recalcula por paquete, ver
+     * updatePackageBenefits()). Vacío si la promoción todavía no tiene
+     * paquetes vinculados, o si es V1 (esa usa getTerms(), no esto).
+     *
+     * @return list<array<string, mixed>>
+     */
+    public function getPackageBenefits(CommunicationPromotions $promotion): array
+    {
+        $package = $this->packageRepository->findByPromotion($promotion)[0] ?? null;
+
+        return $package?->getBenefits() ?? [];
+    }
+
+    /**
+     * Propaga un array de beneficios "plantilla" a TODOS los
+     * CommunicationPackage vinculados a esta promoción (promotion_id) —
+     * reutiliza CommunicationPackageAdminService::update() por paquete para
+     * que applyCreditBenefitDefaults() recalcule additional_information/
+     * amount.base contra el destinationAmount propio de cada uno, igual que
+     * al crear el batch original (createV2()): un mismo array "plantilla"
+     * produce el texto/monto correcto en cada paquete pese a tener montos
+     * de destino distintos.
+     *
+     * @return int cantidad de paquetes actualizados
+     *
+     * @throws MyCurrentException si la promoción no es V2
+     */
+    public function updatePackageBenefits(CommunicationPromotions $promotion, array $benefits): int
+    {
+        if (!$promotion->isV2()) {
+            throw new MyCurrentException(
+                'PROMOTION_BENEFITS_NOT_APPLICABLE',
+                'Esta promoción no es V2 — los beneficios se editan con terms, no benefits',
+                400,
+            );
+        }
+
+        $packages = $this->packageRepository->findByPromotion($promotion);
+        foreach ($packages as $package) {
+            $this->packageAdminService->update($package, new UpdateCommunicationPackageDto(benefits: $benefits));
+        }
+
+        return count($packages);
     }
 
     /**

--- a/tests/DTO/UpdatePromotionDtoTest.php
+++ b/tests/DTO/UpdatePromotionDtoTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Tests\DTO;
+
+use App\DTO\UpdatePromotionDto;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Validation;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @covers \App\DTO\UpdatePromotionDto
+ *
+ * Cubre `benefits` (solo aplicable a promociones V2 — ver
+ * CommunicationPromotionService::updatePackageBenefits()), que reutiliza
+ * los mismos validadores compartidos que CreatePromotionV2Dto
+ * (BenefitScheduleValidator/BenefitOperationValidator, ver
+ * CreatePromotionV2DtoTest para la cobertura exhaustiva de esos
+ * validadores) — aquí solo se confirma que quedaron cableados.
+ */
+class UpdatePromotionDtoTest extends TestCase
+{
+    private ValidatorInterface $validator;
+
+    protected function setUp(): void
+    {
+        $this->validator = Validation::createValidatorBuilder()
+            ->enableAttributeMapping()
+            ->getValidator();
+    }
+
+    private function violationMessages(?array $benefits): array
+    {
+        $dto = new UpdatePromotionDto(benefits: $benefits);
+        $violations = $this->validator->validate($dto);
+
+        $result = [];
+        foreach ($violations as $v) {
+            $result[] = $v->getMessage();
+        }
+
+        return $result;
+    }
+
+    public function testTermsAloneWithoutBenefitsStaysValid(): void
+    {
+        $dto = new UpdatePromotionDto(terms: [['type' => 'CREDITS', 'unit' => 'CUP', 'unit_type' => 'CURRENCY']]);
+        $this->assertCount(0, $this->validator->validate($dto));
+    }
+
+    public function testNoBenefitsIsValid(): void
+    {
+        $this->assertSame([], $this->violationMessages(null));
+    }
+
+    public function testBenefitWithValidScheduleIsValid(): void
+    {
+        $benefits = [['type' => 'DATA', 'unit' => 'ILIM', 'unit_type' => 'DATA', 'schedule' => ['start' => '01:00', 'end' => '06:00']]];
+        $this->assertSame([], $this->violationMessages($benefits));
+    }
+
+    public function testBenefitWithMismatchedScheduleTimesIsInvalid(): void
+    {
+        $benefits = [['type' => 'DATA', 'unit' => 'ILIM', 'unit_type' => 'DATA', 'schedule' => ['start' => '01:00', 'end' => null]]];
+        $this->assertNotEmpty($this->violationMessages($benefits));
+    }
+
+    public function testBenefitWithOperationAndNumericValueIsValid(): void
+    {
+        $benefits = [['type' => 'CREDITS', 'unit' => 'CUP', 'unit_type' => 'CURRENCY', 'operation' => 'MULTIPLY', 'value' => 6]];
+        $this->assertSame([], $this->violationMessages($benefits));
+    }
+
+    public function testBenefitWithOperationButMissingValueIsInvalid(): void
+    {
+        $benefits = [['type' => 'CREDITS', 'unit' => 'CUP', 'unit_type' => 'CURRENCY', 'operation' => 'MULTIPLY']];
+        $this->assertNotEmpty($this->violationMessages($benefits));
+    }
+
+    public function testGetBenefitsReturnsWhatWasSet(): void
+    {
+        $benefits = [['type' => 'CREDITS', 'unit' => 'CUP', 'unit_type' => 'CURRENCY']];
+        $dto = new UpdatePromotionDto(benefits: $benefits);
+        $this->assertSame($benefits, $dto->getBenefits());
+    }
+}

--- a/tests/Functional/Controller/DashboardPromotionControllerBenefitsFunctionalTest.php
+++ b/tests/Functional/Controller/DashboardPromotionControllerBenefitsFunctionalTest.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace App\Tests\Functional\Controller;
+
+use App\Controller\DashboardPromotionController;
+use App\DTO\CreatePromotionV2Dto;
+use App\DTO\UpdatePromotionDto;
+use App\Repository\CommunicationPackageRepository;
+use App\Repository\CommunicationPromotionsRepository;
+use App\Service\CommunicationPromotionService;
+use App\Service\Pricing\CommunicationContractService;
+use App\Service\Pricing\CommunicationPromotionBindingService;
+use App\Service\Pricing\CommunicationPromotionEquivalenceService;
+use App\Tests\Functional\Provider\ProviderFunctionalTestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * @covers \App\Controller\DashboardPromotionController::show
+ * @covers \App\Controller\DashboardPromotionController::update
+ * @covers \App\Service\CommunicationPromotionService::getPackageBenefits
+ * @covers \App\Service\CommunicationPromotionService::updatePackageBenefits
+ *
+ * Contra Postgres real, a propósito: la parte que importa (que
+ * CommunicationPackageAdminService::applyCreditBenefitDefaults() recalcule
+ * additional_information/amount.base contra el destinationAmount PROPIO de
+ * cada paquete, no solo copie el array recibido) solo se puede confirmar con
+ * varios CommunicationPackage reales de montos distintos — un mock de
+ * CommunicationPackageAdminService::update() no ejercitaría esa lógica.
+ */
+class DashboardPromotionControllerBenefitsFunctionalTest extends ProviderFunctionalTestCase
+{
+    private function controller(): DashboardPromotionController
+    {
+        $controller = new DashboardPromotionController(
+            self::getContainer()->get(CommunicationPromotionsRepository::class),
+            $this->em,
+            self::getContainer()->get(NormalizerInterface::class),
+            self::getContainer()->get(CommunicationPromotionService::class),
+            self::getContainer()->get(CommunicationPromotionBindingService::class),
+            self::getContainer()->get(CommunicationPromotionEquivalenceService::class),
+            self::getContainer()->get(CommunicationContractService::class),
+        );
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('has')->willReturn(false);
+        $controller->setContainer($container);
+
+        return $controller;
+    }
+
+    public function testShowExposesTheBenefitsOfALinkedPackageForAV2Promotion(): void
+    {
+        $environment = $this->createEnvironment();
+
+        /** @var CommunicationPromotionService $promotionService */
+        $promotionService = self::getContainer()->get(CommunicationPromotionService::class);
+        $result = $promotionService->createV2(new CreatePromotionV2Dto(
+            name: 'Sextuplica',
+            description: 'Sextuplica',
+            packageNameTemplate: 'Promo {monto}',
+            packageDescriptionTemplate: 'Promo {monto}',
+            startAt: (new \DateTimeImmutable('-1 day'))->format('c'),
+            endAt: (new \DateTimeImmutable('+5 days'))->format('c'),
+            environmentId: $environment->getId(),
+            destinationCurrency: 'CUP',
+            amountFrom: 100.0,
+            amountTo: 100.0,
+            amountStep: 1.0,
+            benefits: [[
+                'type' => 'CREDITS', 'unit' => 'CUP', 'unit_type' => 'CURRENCY',
+                'operation' => 'MULTIPLY', 'value' => 6,
+            ]],
+        ));
+        $this->em->clear();
+
+        $response = $this->controller()->show($result->promotion->getId());
+        $data = json_decode($response->getContent(), true);
+
+        $this->assertSame('MULTIPLY', $data['benefits'][0]['operation']);
+        $this->assertSame(6, $data['benefits'][0]['value']);
+    }
+
+    public function testUpdatePropagatesNewBenefitsToEveryPackageAndRecalculatesEachOwnAmount(): void
+    {
+        $environment = $this->createEnvironment();
+
+        /** @var CommunicationPromotionService $promotionService */
+        $promotionService = self::getContainer()->get(CommunicationPromotionService::class);
+        $result = $promotionService->createV2(new CreatePromotionV2Dto(
+            name: 'Rango de montos',
+            description: 'Rango de montos',
+            packageNameTemplate: 'Promo {monto}',
+            packageDescriptionTemplate: 'Promo {monto}',
+            startAt: (new \DateTimeImmutable('-1 day'))->format('c'),
+            endAt: (new \DateTimeImmutable('+5 days'))->format('c'),
+            environmentId: $environment->getId(),
+            destinationCurrency: 'CUP',
+            // 3 paquetes: 100, 200, 300 CUP.
+            amountFrom: 100.0,
+            amountTo: 300.0,
+            amountStep: 100.0,
+            benefits: [[
+                'type' => 'CREDITS', 'unit' => 'CUP', 'unit_type' => 'CURRENCY',
+                'amount' => ['base' => 0, 'promotion_bonus' => 0],
+            ]],
+        ));
+        $promotionId = $result->promotion->getId();
+        $this->em->clear();
+
+        $newBenefits = [[
+            'type' => 'CREDITS', 'unit' => 'CUP', 'unit_type' => 'CURRENCY',
+            'operation' => 'MULTIPLY', 'value' => 6,
+        ]];
+
+        $response = $this->controller()->update($promotionId, new UpdatePromotionDto(benefits: $newBenefits));
+        $data = json_decode($response->getContent(), true);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('MULTIPLY', $data['benefits'][0]['operation']);
+
+        $this->em->clear();
+        /** @var CommunicationPackageRepository $packageRepository */
+        $packageRepository = self::getContainer()->get(CommunicationPackageRepository::class);
+        $packages = $packageRepository->createQueryBuilder('p')
+            ->andWhere('p.promotion = :promo')
+            ->setParameter('promo', $promotionId)
+            ->orderBy('p.destinationAmount', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        $this->assertCount(3, $packages);
+        // Cada paquete recalculó amount.base contra SU PROPIO destinationAmount
+        // (100/200/300), no copió un valor fijo del array recibido — prueba
+        // que se reutilizó CommunicationPackageAdminService::update() por
+        // paquete (applyCreditBenefitDefaults()), no un setBenefits() a ciegas.
+        $expectedBase = [100 => 100, 200 => 200, 300 => 300];
+        foreach ($packages as $package) {
+            $benefit = $package->getBenefits()[0];
+            $this->assertSame('MULTIPLY', $benefit['operation']);
+            $this->assertSame($expectedBase[(int) $package->getDestinationAmount()], $benefit['amount']['base']);
+        }
+    }
+
+    public function testUpdateWithoutBenefitsKeyLeavesExistingPackageBenefitsUntouched(): void
+    {
+        $environment = $this->createEnvironment();
+
+        /** @var CommunicationPromotionService $promotionService */
+        $promotionService = self::getContainer()->get(CommunicationPromotionService::class);
+        $result = $promotionService->createV2(new CreatePromotionV2Dto(
+            name: 'Sin cambios de beneficios',
+            description: 'Sin cambios de beneficios',
+            packageNameTemplate: 'Promo {monto}',
+            packageDescriptionTemplate: 'Promo {monto}',
+            startAt: (new \DateTimeImmutable('-1 day'))->format('c'),
+            endAt: (new \DateTimeImmutable('+5 days'))->format('c'),
+            environmentId: $environment->getId(),
+            destinationCurrency: 'CUP',
+            amountFrom: 150.0,
+            amountTo: 150.0,
+            amountStep: 1.0,
+            benefits: [[
+                'type' => 'CREDITS', 'unit' => 'CUP', 'unit_type' => 'CURRENCY',
+                'operation' => 'ADD', 'value' => 50,
+            ]],
+        ));
+        $promotionId = $result->promotion->getId();
+        $this->em->clear();
+
+        // Solo cambia el name — sin `benefits` en el DTO.
+        $response = $this->controller()->update($promotionId, new UpdatePromotionDto(name: 'Renombrada'));
+
+        $this->assertSame(200, $response->getStatusCode());
+
+        $this->em->clear();
+        /** @var CommunicationPackageRepository $packageRepository */
+        $packageRepository = self::getContainer()->get(CommunicationPackageRepository::class);
+        $packages = $packageRepository->createQueryBuilder('p')
+            ->andWhere('p.promotion = :promo')
+            ->setParameter('promo', $promotionId)
+            ->getQuery()
+            ->getResult();
+
+        $this->assertSame('ADD', $packages[0]->getBenefits()[0]['operation']);
+        $this->assertSame(50, $packages[0]->getBenefits()[0]['value']);
+    }
+}

--- a/tests/Service/CommunicationPromotionServiceV2Test.php
+++ b/tests/Service/CommunicationPromotionServiceV2Test.php
@@ -4,9 +4,12 @@ namespace App\Tests\Service;
 
 use App\DTO\CreateCommunicationPackageBatchDto;
 use App\DTO\CreatePromotionV2Dto;
+use App\DTO\UpdateCommunicationPackageDto;
 use App\Entity\CommunicationPackage;
+use App\Entity\CommunicationPromotions;
 use App\Entity\Environment;
 use App\Exception\MyCurrentException;
+use App\Repository\CommunicationPackageRepository;
 use App\Repository\EnvironmentRepository;
 use App\Repository\SysConfigRepository;
 use App\Service\CommunicationPromotionService;
@@ -40,6 +43,7 @@ class CommunicationPromotionServiceV2Test extends TestCase
     private CommunicationPackageAdminService&MockObject $packageAdminService;
     private CommunicationContractService&MockObject $contractService;
     private CommunicationPromotionEquivalenceService&MockObject $equivalenceService;
+    private CommunicationPackageRepository&MockObject $packageRepository;
     private CommunicationPromotionService $service;
 
     protected function setUp(): void
@@ -48,6 +52,7 @@ class CommunicationPromotionServiceV2Test extends TestCase
         $this->packageAdminService = $this->createMock(CommunicationPackageAdminService::class);
         $this->contractService = $this->createMock(CommunicationContractService::class);
         $this->equivalenceService = $this->createMock(CommunicationPromotionEquivalenceService::class);
+        $this->packageRepository = $this->createMock(CommunicationPackageRepository::class);
 
         $this->service = new CommunicationPromotionService(
             $this->em,
@@ -64,6 +69,7 @@ class CommunicationPromotionServiceV2Test extends TestCase
             $this->packageAdminService,
             $this->contractService,
             $this->equivalenceService,
+            $this->packageRepository,
         );
     }
 
@@ -220,5 +226,71 @@ class CommunicationPromotionServiceV2Test extends TestCase
         $result = $this->service->createV2($this->dto());
 
         $this->assertNull($result->promotion->getInfoDescription());
+    }
+
+    /**
+     * @covers \App\Service\CommunicationPromotionService::getPackageBenefits
+     * @covers \App\Service\CommunicationPromotionService::updatePackageBenefits
+     */
+    public function testGetPackageBenefitsReturnsTheBenefitsOfTheFirstLinkedPackage(): void
+    {
+        $promotion = $this->v2Promotion();
+        $package = (new CommunicationPackage())->setBenefits([['type' => 'CREDITS', 'unit' => 'CUP', 'unit_type' => 'CURRENCY']]);
+        $this->packageRepository->method('findByPromotion')->with($promotion)->willReturn([$package]);
+
+        $this->assertSame([['type' => 'CREDITS', 'unit' => 'CUP', 'unit_type' => 'CURRENCY']], $this->service->getPackageBenefits($promotion));
+    }
+
+    public function testGetPackageBenefitsReturnsEmptyArrayWhenNoPackagesLinkedYet(): void
+    {
+        $promotion = $this->v2Promotion();
+        $this->packageRepository->method('findByPromotion')->with($promotion)->willReturn([]);
+
+        $this->assertSame([], $this->service->getPackageBenefits($promotion));
+    }
+
+    public function testUpdatePackageBenefitsPropagatesToEveryLinkedPackage(): void
+    {
+        $promotion = $this->v2Promotion();
+        $packages = [new CommunicationPackage(), new CommunicationPackage(), new CommunicationPackage()];
+        $this->packageRepository->method('findByPromotion')->with($promotion)->willReturn($packages);
+
+        $newBenefits = [['type' => 'DATA', 'unit' => 'ILIM', 'unit_type' => 'DATA', 'operation' => 'ADD', 'value' => 20]];
+
+        $this->packageAdminService->expects($this->exactly(3))
+            ->method('update')
+            ->with(
+                $this->isInstanceOf(CommunicationPackage::class),
+                $this->callback(fn (UpdateCommunicationPackageDto $dto) => $dto->getBenefits() === $newBenefits)
+            );
+
+        $count = $this->service->updatePackageBenefits($promotion, $newBenefits);
+
+        $this->assertSame(3, $count);
+    }
+
+    public function testUpdatePackageBenefitsThrowsForAV1Promotion(): void
+    {
+        // Una promoción V1 tiene product != null (isV2() = product === null)
+        // — createV2()/dto() de este test solo generan V2, así que se
+        // construye directo con reflection en vez de un DTO legacy.
+        $promotion = new CommunicationPromotions();
+        $reflection = new \ReflectionProperty(CommunicationPromotions::class, 'product');
+        $reflection->setAccessible(true);
+        $reflection->setValue($promotion, $this->createMock(\App\Entity\CommunicationProduct::class));
+
+        $this->packageAdminService->expects($this->never())->method('update');
+
+        $this->expectException(MyCurrentException::class);
+        $this->expectExceptionMessage('Esta promoción no es V2 — los beneficios se editan con terms, no benefits');
+
+        $this->service->updatePackageBenefits($promotion, [['type' => 'CREDITS']]);
+    }
+
+    private function v2Promotion(): CommunicationPromotions
+    {
+        // isV2() === true cuando $product es null — estado por defecto de una
+        // promoción recién construida, sin necesidad de reflection aquí.
+        return new CommunicationPromotions();
     }
 }


### PR DESCRIPTION
## Summary
- **docs:** exige TDD (rojo→verde→refactor) para funcionalidad nueva, en `CLAUDE.md` (PR #134).
- **feat(promotions):** los beneficios reales de una promoción V2 viven en cada `CommunicationPackage` generado (`promotion_id`), no en `CommunicationPromotions::$terms` (columna legacy V1, que nada lee para V2). `UpdatePromotionDto` gana `benefits`; `CommunicationPromotionService::updatePackageBenefits()` lo propaga a todos los paquetes vinculados, recalculando `amount.base`/`additional_information` de los beneficios CREDITS/CURRENCY contra el `destinationAmount` propio de cada uno (mismo criterio que al generar el batch original). Enviar `benefits` a una promoción V1 lanza `PROMOTION_BENEFITS_NOT_APPLICABLE` (PR #135).

Ver PR hermano en dashboard-cm para el frontend correspondiente.

## Test plan
- [x] `php bin/phpunit --no-coverage` — 1050/1050 en verde
- [x] `vendor/bin/phpstan analyse` — limpio
- [x] Test funcional nuevo contra Postgres real (`DashboardPromotionControllerBenefitsFunctionalTest`) — confirma que cada paquete recalcula `amount.base` contra su propio `destinationAmount`, no copia un valor fijo

🤖 Generated with [Claude Code](https://claude.com/claude-code)