### PR TITLE
fix(promotions): serializa isV2() como "isV2", no "v2"

### DIFF
--- a/src/Entity/CommunicationPromotions.php
+++ b/src/Entity/CommunicationPromotions.php
@@ -260,8 +260,19 @@ class CommunicationPromotions
      * ver createV2()). false = legacy (V1). Expuesto en el listado para
      * que el dashboard sepa qué acciones mostrar (bindings legacy vs.
      * equivalencias V2).
+     *
+     * Sin #[SerializedName], Symfony serializa un getter `isV2()` como
+     * "v2" (le quita el prefijo "is" y baja la primera letra de lo que
+     * queda) — el frontend siempre leía `promo.isV2` (undefined, nunca
+     * "v2"), así que tanto el badge de bindings/equivalencias del listado
+     * como la pestaña Beneficios/Condiciones del formulario de edición
+     * quedaban permanentemente en su rama V1, sin importar si la
+     * promoción era V2 de verdad. Bug real detectado en producción
+     * 2026-08-28 (ver DashboardPromotionControllerBenefitsFunctionalTest
+     * ::testShowExposesTheBenefitsOfALinkedPackageForAV2Promotion).
      */
     #[Groups(['comProm:read', 'promotion:list', 'promotion:detail'])]
+    #[SerializedName('isV2')]
     public function isV2(): bool
     {
         return $this->product === null;

--- a/tests/Functional/Controller/DashboardPromotionControllerBenefitsFunctionalTest.php
+++ b/tests/Functional/Controller/DashboardPromotionControllerBenefitsFunctionalTest.php
@@ -79,6 +79,12 @@ class DashboardPromotionControllerBenefitsFunctionalTest extends ProviderFunctio
 
         $this->assertSame('MULTIPLY', $data['benefits'][0]['operation']);
         $this->assertSame(6, $data['benefits'][0]['value']);
+        // Symfony serializa isV2() como "v2" por convención (strip "is" +
+        // lowercase primera letra) salvo que se fuerce el nombre — el
+        // frontend depende de la clave EXACTA "isV2" (promotion-list y
+        // promotion-form la leen así) para decidir qué UI mostrar.
+        $this->assertArrayHasKey('isV2', $data, 'isV2 debe serializarse bajo esa clave exacta, no "v2"');
+        $this->assertTrue($data['isV2']);
     }
 
     public function testUpdatePropagatesNewBenefitsToEveryPackageAndRecalculatesEachOwnAmount(): void


### PR DESCRIPTION
## Summary
Bug real detectado en producción justo después de desplegar el fix de "editar benefits de una promoción V2" (#135): sin `#[SerializedName]`, Symfony convierte el getter `isV2()` a la clave JSON `"v2"` (le quita el prefijo `is` y baja la primera letra de lo que queda). El frontend siempre leyó `promo.isV2` (`undefined`, nunca `"v2"`) — así que tanto el badge de bindings/equivalencias del listado de promociones como la nueva pestaña "Beneficios" del formulario de edición quedaban permanentemente en su rama V1, sin importar si la promoción era V2 de verdad.

Este bug es **preexistente** (`isV2()` ya existía antes de mis cambios) — recién se hizo visible porque el nuevo código del frontend depende de esa clave para decidir "Beneficios" vs. "Condiciones".

## Test plan
- [x] Test funcional nuevo confirma en rojo→verde que la clave serializada es `isV2`, no `v2` (`DashboardPromotionControllerBenefitsFunctionalTest::testShowExposesTheBenefitsOfALinkedPackageForAV2Promotion`)
- [x] `vendor/bin/phpstan analyse` — limpio
- [x] Suite completa `php bin/phpunit --no-coverage` — 1050/1050 en verde

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGZSuxX18gJ4N9XUmvmadS