### PR TITLE
fix(promotions): la vigencia de una promoción V2 se lee/escribe en los paquetes

### DIFF
--- a/src/Controller/DashboardPromotionController.php
+++ b/src/Controller/DashboardPromotionController.php
@@ -307,6 +307,13 @@ class DashboardPromotionController extends AbstractController
 
         if ($promotion->isV2()) {
             $data['benefits'] = $this->promotionService->getPackageBenefits($promotion);
+            // Mismo motivo que `benefits`: validityInfo (columna propia de
+            // CommunicationPromotions) es un concepto V1 — la vigencia real
+            // de una V2 vive en cada CommunicationPackage generado.
+            $packageValidity = $this->promotionService->getPackageValidity($promotion);
+            if ($packageValidity !== null) {
+                $data['validityInfo'] = $packageValidity;
+            }
         }
 
         return $data;

--- a/src/Service/CommunicationPromotionService.php
+++ b/src/Service/CommunicationPromotionService.php
@@ -335,6 +335,13 @@ class CommunicationPromotionService extends CommonService
         }
         if ($dto->getValidityInfo() !== null) {
             $promotion->setValidityInfo($dto->getValidityInfo());
+            // Para V2 la vigencia real vive en los CommunicationPackage
+            // generados, no en esta columna (ver getPackageValidity()) —
+            // se sigue guardando arriba por compatibilidad/auditoría, pero
+            // lo que el dashboard realmente lee es lo que se propaga acá.
+            if ($promotion->isV2()) {
+                $this->updatePackageValidity($promotion, $dto->getValidityInfo());
+            }
         }
         if ($dto->getStartAt() !== null) {
             try {
@@ -427,6 +434,40 @@ class CommunicationPromotionService extends CommonService
         $packages = $this->packageRepository->findByPromotion($promotion);
         foreach ($packages as $package) {
             $this->packageAdminService->update($package, new UpdateCommunicationPackageDto(benefits: $benefits));
+        }
+
+        return count($packages);
+    }
+
+    /**
+     * Vigencia "plantilla" de una promoción V2 — igual que getPackageBenefits(),
+     * mismo bug de fondo: CommunicationPromotions::$validityInfo es una
+     * columna V1 (solo la lee createPackagesForPromotion()/
+     * CommunicationClientPackage::getValidity(), ninguno aplica a V2) que
+     * createV2() nunca escribe — la vigencia real vive en
+     * CommunicationPackage::$validity (mismo shape {quantity, unit}).
+     */
+    public function getPackageValidity(CommunicationPromotions $promotion): ?array
+    {
+        $package = $this->packageRepository->findByPromotion($promotion)[0] ?? null;
+
+        return $package?->getValidity();
+    }
+
+    /**
+     * Propaga {quantity, unit} a TODOS los CommunicationPackage vinculados a
+     * esta promoción — a diferencia de los beneficios, la vigencia no
+     * depende del destinationAmount de cada paquete, así que se copia tal
+     * cual (mismo criterio que CreatePromotionV2Dto::$validity al crear el
+     * batch original).
+     *
+     * @return int cantidad de paquetes actualizados
+     */
+    public function updatePackageValidity(CommunicationPromotions $promotion, ?array $validity): int
+    {
+        $packages = $this->packageRepository->findByPromotion($promotion);
+        foreach ($packages as $package) {
+            $this->packageAdminService->update($package, new UpdateCommunicationPackageDto(validity: $validity));
         }
 
         return count($packages);

--- a/tests/Functional/Controller/DashboardPromotionControllerBenefitsFunctionalTest.php
+++ b/tests/Functional/Controller/DashboardPromotionControllerBenefitsFunctionalTest.php
@@ -191,4 +191,87 @@ class DashboardPromotionControllerBenefitsFunctionalTest extends ProviderFunctio
         $this->assertSame('ADD', $packages[0]->getBenefits()[0]['operation']);
         $this->assertSame(50, $packages[0]->getBenefits()[0]['value']);
     }
+
+    /**
+     * Mismo bug de fondo que benefits/terms: CommunicationPromotions::
+     * $validityInfo es una columna V1 (solo la lee
+     * createPackagesForPromotion()/CommunicationClientPackage::getValidity()
+     * — ninguno de los dos aplica a V2) que createV2() nunca escribe. La
+     * vigencia real de una promoción V2 vive en CommunicationPackage::
+     * $validity (idéntico shape {quantity, unit}), poblado por
+     * CreatePromotionV2Dto::$validity al crear el batch.
+     */
+    public function testShowExposesPackageValidityInsteadOfThePromotionsOwnColumnForAV2Promotion(): void
+    {
+        $environment = $this->createEnvironment();
+
+        /** @var CommunicationPromotionService $promotionService */
+        $promotionService = self::getContainer()->get(CommunicationPromotionService::class);
+        $result = $promotionService->createV2(new CreatePromotionV2Dto(
+            name: 'Con vigencia',
+            description: 'Con vigencia',
+            packageNameTemplate: 'Promo {monto}',
+            packageDescriptionTemplate: 'Promo {monto}',
+            startAt: (new \DateTimeImmutable('-1 day'))->format('c'),
+            endAt: (new \DateTimeImmutable('+5 days'))->format('c'),
+            environmentId: $environment->getId(),
+            destinationCurrency: 'CUP',
+            amountFrom: 100.0,
+            amountTo: 100.0,
+            amountStep: 1.0,
+            validity: ['quantity' => 330, 'unit' => 'DAYS'],
+        ));
+        $this->em->clear();
+
+        $response = $this->controller()->show($result->promotion->getId());
+        $data = json_decode($response->getContent(), true);
+
+        $this->assertSame(['quantity' => 330, 'unit' => 'DAYS'], $data['validityInfo']);
+    }
+
+    public function testUpdatePropagatesValidityToEveryPackageForAV2Promotion(): void
+    {
+        $environment = $this->createEnvironment();
+
+        /** @var CommunicationPromotionService $promotionService */
+        $promotionService = self::getContainer()->get(CommunicationPromotionService::class);
+        $result = $promotionService->createV2(new CreatePromotionV2Dto(
+            name: 'Cambia vigencia',
+            description: 'Cambia vigencia',
+            packageNameTemplate: 'Promo {monto}',
+            packageDescriptionTemplate: 'Promo {monto}',
+            startAt: (new \DateTimeImmutable('-1 day'))->format('c'),
+            endAt: (new \DateTimeImmutable('+5 days'))->format('c'),
+            environmentId: $environment->getId(),
+            destinationCurrency: 'CUP',
+            amountFrom: 100.0,
+            amountTo: 200.0,
+            amountStep: 100.0,
+            validity: ['quantity' => 330, 'unit' => 'DAYS'],
+        ));
+        $promotionId = $result->promotion->getId();
+        $this->em->clear();
+
+        $response = $this->controller()->update($promotionId, new UpdatePromotionDto(
+            validityInfo: ['quantity' => 15, 'unit' => 'DAYS'],
+        ));
+        $data = json_decode($response->getContent(), true);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(['quantity' => 15, 'unit' => 'DAYS'], $data['validityInfo']);
+
+        $this->em->clear();
+        /** @var CommunicationPackageRepository $packageRepository */
+        $packageRepository = self::getContainer()->get(CommunicationPackageRepository::class);
+        $packages = $packageRepository->createQueryBuilder('p')
+            ->andWhere('p.promotion = :promo')
+            ->setParameter('promo', $promotionId)
+            ->getQuery()
+            ->getResult();
+
+        $this->assertCount(2, $packages);
+        foreach ($packages as $package) {
+            $this->assertSame(['quantity' => 15, 'unit' => 'DAYS'], $package->getValidity());
+        }
+    }
 }


### PR DESCRIPTION
## Summary
Mismo bug de fondo que benefits (#135) e isV2 (#137): `CommunicationPromotions::$validityInfo` es una columna V1 que `createV2()` nunca escribe — la vigencia real de una promoción V2 vive en `CommunicationPackage::$validity` (poblado por `CreatePromotionV2Dto::$validity` al crear el batch). Por eso "Duración de vigencia" aparecía vacío en el formulario de edición para promociones V2 reales (confirmado en producción: la promoción tenía 330 días de vigencia en sus paquetes, pero la columna propia de la promoción mostraba `""`/vacío o quedaba corrompida a `{"quantity":"","unit":"DAYS"}` en cada guardado, ya que `save()` siempre manda ese campo).

`getPackageValidity()`/`updatePackageValidity()` replican el patrón de `getPackageBenefits()`/`updatePackageBenefits()`: el controlador expone la vigencia del paquete en vez de la columna de la promoción para V2, y `update()` propaga los cambios a todos los paquetes vinculados.

## Test plan
- [x] Test funcional nuevo confirma en rojo→verde que GET expone la vigencia real de los paquetes, y que PATCH la propaga a todos ellos
- [x] `vendor/bin/phpstan analyse` — limpio
- [x] Suite completa `php bin/phpunit --no-coverage` — 1052/1052 en verde

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGZSuxX18gJ4N9XUmvmadS