### PR TITLE
feat(catalog): filtra paquetes por service/subservice

### DIFF
--- a/src/Controller/DashboardCommunicationPackagesController.php
+++ b/src/Controller/DashboardCommunicationPackagesController.php
@@ -24,6 +24,7 @@ use App\Repository\CommunicationPackageProviderProductRepository;
 use App\Service\Pricing\CommunicationPackageAdminService;
 use App\Service\Pricing\CommunicationPackageBindingService;
 use App\Service\Pricing\PackageCatalogResolver;
+use App\Service\Pricing\ServiceCategoryKey;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\QueryBuilder;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -330,6 +331,21 @@ class DashboardCommunicationPackagesController extends AbstractController
         }
         if ($createdTo = $request->query->get('createdTo')) {
             $qb->andWhere('p.createdAt <= :createdTo')->setParameter('createdTo', new \DateTimeImmutable($createdTo . ' 23:59:59'));
+        }
+        if ($service = $request->query->get('service')) {
+            $subservice = $request->query->get('subservice');
+            if ($subservice) {
+                // Categoría exacta (service+subservice) — serviceKey es una
+                // columna plana ("{name}|{subserviceName}", ver
+                // ServiceCategoryKey), a diferencia de tags no necesita SQL
+                // crudo para comparar.
+                $qb->andWhere('p.serviceKey = :serviceKey')
+                    ->setParameter('serviceKey', ServiceCategoryKey::of($service, $subservice));
+            } else {
+                // Solo service — cualquier subservicio de esa categoría.
+                $qb->andWhere('p.serviceKey LIKE :serviceKeyPrefix')
+                    ->setParameter('serviceKeyPrefix', addcslashes($service, '%_\\') . '|%');
+            }
         }
     }
 

--- a/tests/Functional/Pricing/DashboardCommunicationPackagesControllerListTest.php
+++ b/tests/Functional/Pricing/DashboardCommunicationPackagesControllerListTest.php
@@ -145,6 +145,44 @@ class DashboardCommunicationPackagesControllerListTest extends ProviderFunctiona
         $this->assertSame($recent->getId(), $data['results'][0]['id']);
     }
 
+    public function testFiltersByServiceOnlyMatchesAnySubserviceOfThatService(): void
+    {
+        $mobileAirtime = $this->communicationPackage('Mobile Airtime');
+        $mobileAirtime->setService(['name' => 'Mobile', 'subservice' => ['name' => 'AIRTIME']]);
+        $mobileData = $this->communicationPackage('Mobile Data');
+        $mobileData->setService(['name' => 'Mobile', 'subservice' => ['name' => 'DATA']]);
+        $utilities = $this->communicationPackage('Nauta WiFi');
+        $utilities->setService(['name' => 'Utilities', 'subservice' => ['name' => 'INTERNET']]);
+        $this->em->flush();
+        $this->em->clear();
+
+        $data = json_decode($this->controller()->list(new Request(['service' => 'Mobile']))->getContent(), true);
+
+        $this->assertCount(2, $data['results']);
+        $this->assertEqualsCanonicalizing(
+            [$mobileAirtime->getId(), $mobileData->getId()],
+            array_column($data['results'], 'id')
+        );
+    }
+
+    public function testFiltersByServiceAndSubserviceMatchesTheExactCategoryOnly(): void
+    {
+        $mobileAirtime = $this->communicationPackage('Mobile Airtime');
+        $mobileAirtime->setService(['name' => 'Mobile', 'subservice' => ['name' => 'AIRTIME']]);
+        $mobileData = $this->communicationPackage('Mobile Data');
+        $mobileData->setService(['name' => 'Mobile', 'subservice' => ['name' => 'DATA']]);
+        $this->em->flush();
+        $this->em->clear();
+
+        $data = json_decode(
+            $this->controller()->list(new Request(['service' => 'Mobile', 'subservice' => 'AIRTIME']))->getContent(),
+            true
+        );
+
+        $this->assertCount(1, $data['results']);
+        $this->assertSame($mobileAirtime->getId(), $data['results'][0]['id']);
+    }
+
     public function testSortsByCreatedAtAscendingAndDescending(): void
     {
         $first = $this->communicationPackage('Primero creado');


### PR DESCRIPTION
## Summary
`GET /catalog/packages` suma filtros `service`/`subservice`, reutilizando `CommunicationPackage::serviceKey` (columna plana "{name}|{subserviceName}", ver `ServiceCategoryKey`, ya usada por `CommunicationContract` para el mismo propósito):
- Solo `service` → `serviceKey LIKE '{service}|%'` (cualquier subservicio de esa categoría).
- `service` + `subservice` → `serviceKey = '{service}|{subservice}'` (categoría exacta).

Pedido del usuario para el filtro del catálogo de paquetes en el dashboard (ver PR hermano en dashboard-cm para la UI).

## Test plan
- [x] Tests funcionales nuevos contra Postgres real, rojo→verde
- [x] `vendor/bin/phpstan analyse` — limpio
- [x] Suite completa `php bin/phpunit --no-coverage` — 1054/1054 en verde

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGZSuxX18gJ4N9XUmvmadS