### PR TITLE
feat(provider-routing): enrutado por servicio/subservicio + failover al proveedor secundario

### DIFF
--- a/migrations/Version20260828120000.php
+++ b/migrations/Version20260828120000.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Extiende client_provider_routing con clasificación por servicio/subservicio
+ * (mismo vocabulario que communication_package/communication_contract, ver
+ * ServiceCategoryKey) — permite reglas de enrutado específicas por
+ * categoría, no solo por cliente/entorno/tipo de venta.
+ *
+ * Sin backfill: las filas existentes quedan con service_key = '|' (comodín
+ * "cualquier categoría"), que es exactamente su semántica actual —
+ * ProviderDispatchResolver las sigue considerando aplicables a cualquier
+ * paquete.
+ */
+final class Version20260828120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Añade service_name/subservice_name/service_key a client_provider_routing y amplía uniq_cpr_scope';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE client_provider_routing ADD COLUMN IF NOT EXISTS service_name VARCHAR(255) NULL');
+        $this->addSql('ALTER TABLE client_provider_routing ADD COLUMN IF NOT EXISTS subservice_name VARCHAR(255) NULL');
+        $this->addSql("ALTER TABLE client_provider_routing ADD COLUMN IF NOT EXISTS service_key VARCHAR(191) NOT NULL DEFAULT '|'");
+
+        // Reemplaza uniq_cpr_scope (Version20260801120000) incorporando
+        // service_key: dos filas activas del mismo (client, environment,
+        // sale_type) ahora pueden coexistir si son de categorías distintas.
+        $this->addSql('DROP INDEX IF EXISTS uniq_cpr_scope');
+        $this->addSql(<<<'SQL'
+            CREATE UNIQUE INDEX IF NOT EXISTS uniq_cpr_scope
+                ON client_provider_routing (client_id, environment_id, sale_type, service_key)
+                NULLS NOT DISTINCT
+                WHERE is_active = TRUE
+        SQL);
+
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_cpr_service_key ON client_provider_routing (service_key)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IF EXISTS uniq_cpr_scope');
+        $this->addSql(<<<'SQL'
+            CREATE UNIQUE INDEX IF NOT EXISTS uniq_cpr_scope
+                ON client_provider_routing (client_id, environment_id, sale_type)
+                NULLS NOT DISTINCT
+                WHERE is_active = TRUE
+        SQL);
+        $this->addSql('DROP INDEX IF EXISTS idx_cpr_service_key');
+        $this->addSql('ALTER TABLE client_provider_routing DROP COLUMN IF EXISTS service_key');
+        $this->addSql('ALTER TABLE client_provider_routing DROP COLUMN IF EXISTS subservice_name');
+        $this->addSql('ALTER TABLE client_provider_routing DROP COLUMN IF EXISTS service_name');
+    }
+}

--- a/src/Controller/DashboardProviderRoutingController.php
+++ b/src/Controller/DashboardProviderRoutingController.php
@@ -409,6 +409,8 @@ class DashboardProviderRoutingController extends AbstractController
             'saleType'         => $routing->getSaleType(),
             'provider'         => $routing->getProvider(),
             'fallbackProvider' => $routing->getFallbackProvider(),
+            'serviceName'      => $routing->getServiceName(),
+            'subserviceName'   => $routing->getSubserviceName(),
             'isActive'         => $routing->isActive(),
             'notes'            => $routing->getNotes(),
             'createdAt'        => $routing->getCreatedAt()?->format('c'),

--- a/src/DTO/CreateProviderRoutingDto.php
+++ b/src/DTO/CreateProviderRoutingDto.php
@@ -5,6 +5,7 @@ namespace App\DTO;
 use App\Enums\CommunicationProviderEnum;
 use App\OpenApi\Attribute\OAProperty;
 use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 class CreateProviderRoutingDto implements IInput
 {
@@ -26,9 +27,17 @@ class CreateProviderRoutingDto implements IInput
     #[Assert\Choice(callback: [CommunicationProviderEnum::class, 'values'])]
     protected ?string $provider;
 
-    #[OAProperty(schema: ['type' => 'string', 'enum' => ['ETECSA', 'DTONE'], 'nullable' => true], description: 'Proveedor de respaldo (reservado para failover, Fase 5 — hoy no se usa en el despacho)')]
+    #[OAProperty(schema: ['type' => 'string', 'enum' => ['ETECSA', 'DTONE'], 'nullable' => true], description: 'Proveedor de respaldo: si el proveedor principal no puede despachar (no disponible) o rechaza el envío, se intenta este')]
     #[Assert\Choice(callback: [CommunicationProviderEnum::class, 'values'])]
     protected ?string $fallbackProvider;
+
+    #[OAProperty(schema: ['type' => 'string', 'enum' => ['Mobile', 'uSIM', 'Devices', 'Utilities'], 'nullable' => true], description: 'Servicio al que aplica este enrutado. null = cualquier servicio')]
+    #[Assert\Length(max: 255)]
+    protected ?string $serviceName;
+
+    #[OAProperty(schema: ['type' => 'string', 'enum' => ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET', 'LANDLINE', 'uSIM'], 'nullable' => true], description: 'Subservicio al que aplica. Solo válido junto con serviceName. null = cualquier subservicio de esa categoría')]
+    #[Assert\Length(max: 255)]
+    protected ?string $subserviceName;
 
     #[OAProperty(description: 'Nota interna sobre el motivo de este enrutado')]
     #[Assert\Length(max: 255)]
@@ -40,6 +49,8 @@ class CreateProviderRoutingDto implements IInput
         ?string $saleType = null,
         ?string $provider = null,
         ?string $fallbackProvider = null,
+        ?string $serviceName = null,
+        ?string $subserviceName = null,
         ?string $notes = null,
     ) {
         $this->clientId = $clientId;
@@ -47,7 +58,26 @@ class CreateProviderRoutingDto implements IInput
         $this->saleType = $saleType;
         $this->provider = $provider;
         $this->fallbackProvider = $fallbackProvider;
+        $this->serviceName = $serviceName;
+        $this->subserviceName = $subserviceName;
         $this->notes = $notes;
+    }
+
+    #[Assert\Callback]
+    public function validateServiceCategory(ExecutionContextInterface $context): void
+    {
+        if ($this->subserviceName !== null && $this->serviceName === null) {
+            $context->buildViolation('subserviceName requiere serviceName')
+                ->atPath('subserviceName')
+                ->addViolation();
+        }
+
+        if ($this->serviceName !== null && str_contains($this->serviceName, '|')) {
+            $context->buildViolation('serviceName no puede contener "|"')->atPath('serviceName')->addViolation();
+        }
+        if ($this->subserviceName !== null && str_contains($this->subserviceName, '|')) {
+            $context->buildViolation('subserviceName no puede contener "|"')->atPath('subserviceName')->addViolation();
+        }
     }
 
     public function getClientId(): ?int { return $this->clientId; }
@@ -64,6 +94,12 @@ class CreateProviderRoutingDto implements IInput
 
     public function getFallbackProvider(): ?string { return $this->fallbackProvider; }
     public function setFallbackProvider(?string $v): void { $this->fallbackProvider = $v; }
+
+    public function getServiceName(): ?string { return $this->serviceName; }
+    public function setServiceName(?string $v): void { $this->serviceName = $v; }
+
+    public function getSubserviceName(): ?string { return $this->subserviceName; }
+    public function setSubserviceName(?string $v): void { $this->subserviceName = $v; }
 
     public function getNotes(): ?string { return $this->notes; }
     public function setNotes(?string $v): void { $this->notes = $v; }

--- a/src/DTO/Out/ProviderRoutingOutDto.php
+++ b/src/DTO/Out/ProviderRoutingOutDto.php
@@ -19,6 +19,12 @@ final class ProviderRoutingOutDto
     #[OAProperty(schema: ['type' => 'string', 'enum' => ['ETECSA', 'DTONE'], 'nullable' => true])]
     public ?string $fallbackProvider = null;
 
+    #[OAProperty(schema: ['type' => 'string', 'enum' => ['Mobile', 'uSIM', 'Devices', 'Utilities'], 'nullable' => true])]
+    public ?string $serviceName = null;
+
+    #[OAProperty(schema: ['type' => 'string', 'enum' => ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET', 'LANDLINE', 'uSIM'], 'nullable' => true])]
+    public ?string $subserviceName = null;
+
     public bool $isActive = true;
     public ?string $notes = null;
     public ?string $createdAt = null;

--- a/src/DTO/UpdateProviderRoutingDto.php
+++ b/src/DTO/UpdateProviderRoutingDto.php
@@ -5,10 +5,16 @@ namespace App\DTO;
 use App\Enums\CommunicationProviderEnum;
 use App\OpenApi\Attribute\OAProperty;
 use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 /**
  * El cliente (clientId) no es editable: identifica de qué fila se trata.
  * Para reasignar una fila a otro cliente, elimínala y crea una nueva.
+ *
+ * Convención de limpieza para serviceName/subserviceName: `null` = no
+ * tocar el campo, `''` (cadena vacía) = limpiarlo a comodín. Es la única
+ * forma de distinguir "no viene en el PATCH" de "se quiere volver a
+ * comodín" cuando ambos casos parten de un valor no-null en la fila.
  */
 class UpdateProviderRoutingDto implements IInput
 {
@@ -24,9 +30,17 @@ class UpdateProviderRoutingDto implements IInput
     #[Assert\Choice(callback: [CommunicationProviderEnum::class, 'values'])]
     protected ?string $provider;
 
-    #[OAProperty(schema: ['type' => 'string', 'enum' => ['ETECSA', 'DTONE'], 'nullable' => true], description: 'Proveedor de respaldo (reservado para failover, Fase 5)')]
+    #[OAProperty(schema: ['type' => 'string', 'enum' => ['ETECSA', 'DTONE'], 'nullable' => true], description: 'Proveedor de respaldo: si el proveedor principal no puede despachar o rechaza el envío, se intenta este')]
     #[Assert\Choice(callback: [CommunicationProviderEnum::class, 'values'])]
     protected ?string $fallbackProvider;
+
+    #[OAProperty(schema: ['type' => 'string', 'enum' => ['Mobile', 'uSIM', 'Devices', 'Utilities'], 'nullable' => true], description: 'Servicio al que aplica. null = no tocar, "" = volver a comodín (cualquier servicio)')]
+    #[Assert\Length(max: 255)]
+    protected ?string $serviceName;
+
+    #[OAProperty(schema: ['type' => 'string', 'enum' => ['AIRTIME', 'BUNDLE', 'DATA', 'SMS', 'INTERNET', 'LANDLINE', 'uSIM'], 'nullable' => true], description: 'Subservicio. null = no tocar, "" = volver a comodín. Solo válido junto con serviceName')]
+    #[Assert\Length(max: 255)]
+    protected ?string $subserviceName;
 
     #[OAProperty(description: 'Nota interna sobre el motivo de este enrutado')]
     #[Assert\Length(max: 255)]
@@ -40,6 +54,8 @@ class UpdateProviderRoutingDto implements IInput
         ?string $saleType = null,
         ?string $provider = null,
         ?string $fallbackProvider = null,
+        ?string $serviceName = null,
+        ?string $subserviceName = null,
         ?string $notes = null,
         ?bool $isActive = null,
     ) {
@@ -47,8 +63,29 @@ class UpdateProviderRoutingDto implements IInput
         $this->saleType = $saleType;
         $this->provider = $provider;
         $this->fallbackProvider = $fallbackProvider;
+        $this->serviceName = $serviceName;
+        $this->subserviceName = $subserviceName;
         $this->notes = $notes;
         $this->isActive = $isActive;
+    }
+
+    #[Assert\Callback]
+    public function validateServiceCategory(ExecutionContextInterface $context): void
+    {
+        // '' (limpiar serviceName) + subserviceName no vacío es la misma
+        // combinación imposible que null + subserviceName no vacío.
+        if (!empty($this->subserviceName) && empty($this->serviceName)) {
+            $context->buildViolation('subserviceName requiere serviceName')
+                ->atPath('subserviceName')
+                ->addViolation();
+        }
+
+        if ($this->serviceName !== null && str_contains($this->serviceName, '|')) {
+            $context->buildViolation('serviceName no puede contener "|"')->atPath('serviceName')->addViolation();
+        }
+        if ($this->subserviceName !== null && str_contains($this->subserviceName, '|')) {
+            $context->buildViolation('subserviceName no puede contener "|"')->atPath('subserviceName')->addViolation();
+        }
     }
 
     public function getEnvironmentId(): ?int { return $this->environmentId; }
@@ -62,6 +99,12 @@ class UpdateProviderRoutingDto implements IInput
 
     public function getFallbackProvider(): ?string { return $this->fallbackProvider; }
     public function setFallbackProvider(?string $v): void { $this->fallbackProvider = $v; }
+
+    public function getServiceName(): ?string { return $this->serviceName; }
+    public function setServiceName(?string $v): void { $this->serviceName = $v; }
+
+    public function getSubserviceName(): ?string { return $this->subserviceName; }
+    public function setSubserviceName(?string $v): void { $this->subserviceName = $v; }
 
     public function getNotes(): ?string { return $this->notes; }
     public function setNotes(?string $v): void { $this->notes = $v; }

--- a/src/Entity/ClientProviderRouting.php
+++ b/src/Entity/ClientProviderRouting.php
@@ -3,15 +3,21 @@
 namespace App\Entity;
 
 use App\Repository\ClientProviderRoutingRepository;
+use App\Service\Pricing\ServiceCategoryKey;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
  * Enrutado de proveedor por cliente (Fase 2 del enrutado multi-proveedor).
- * Es control de ADMISIÓN, no de despacho: decide qué proveedores puede
- * consumir un cliente (ver App\Provider\ProviderResolver::allowedForClient())
- * y cuál es el default para altas nuevas (resolveForAccount()). El
- * despacho/consulta de una venta ya creada lee el snapshot de
- * CommunicationSaleInfo::provider, nunca esta tabla.
+ * Además de admisión (qué proveedores puede consumir un cliente, ver
+ * App\Provider\ProviderResolver::allowedForClient()), desde la extensión
+ * por categoría (agosto 2026) también es control de DESPACHO: cada fila
+ * puede acotarse por entorno, tipo de venta y servicio/subservicio
+ * (serviceKey), y App\Provider\ProviderDispatchResolver recorre las filas
+ * activas de más a menos específica probando primero `provider` y luego
+ * `fallbackProvider` — ver el docblock de ese resolver para el algoritmo
+ * completo. Una vez admitida una venta, el snapshot de
+ * CommunicationSaleInfo::provider es la fuente de verdad para esa venta en
+ * particular; esta tabla solo decide qué proveedor se intenta primero.
  */
 #[ORM\Entity(repositoryClass: ClientProviderRoutingRepository::class)]
 class ClientProviderRouting
@@ -35,8 +41,34 @@ class ClientProviderRouting
     #[ORM\Column(length: 20)]
     private ?string $provider = null;
 
+    /**
+     * Proveedor de respaldo: si `provider` no puede despachar (no
+     * disponible, o rechaza explícitamente el envío) ProviderDispatchResolver
+     * prueba este a continuación — ver SaleProviderFailoverService para el
+     * único salto que se hace tras un rechazo ya en ejecución.
+     */
     #[ORM\Column(length: 20, nullable: true)]
     private ?string $fallbackProvider = null;
+
+    /**
+     * Clasificación (mismo shape de nombre/subservicio que
+     * CommunicationPackage::$service / CommunicationContract::$serviceName)
+     * — se setean juntos vía setServiceCategory(), nunca $serviceKey sola.
+     */
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $serviceName = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $subserviceName = null;
+
+    /**
+     * Derivada de $serviceName/$subserviceName vía ServiceCategoryKey — SE
+     * DERIVA EN EL SETTER (ver setServiceCategory()), nunca en un lifecycle
+     * callback (mismo razonamiento que CommunicationContract::$serviceKey).
+     * Default '|' como resguardo, coincide con ServiceCategoryKey::of(null, null).
+     */
+    #[ORM\Column(length: 191)]
+    private string $serviceKey = '|';
 
     /**
      * Orden en que ProviderDispatchResolver (V2 Fase 2) prueba los
@@ -68,6 +100,10 @@ class ClientProviderRouting
     {
         $this->createdAt = new \DateTimeImmutable('now');
         $this->updatedAt = new \DateTimeImmutable('now');
+        // Vía setServiceCategory(), no asignación directa — mismo criterio
+        // que CommunicationContract::__construct(): un único punto deriva
+        // $serviceKey, el default de la propiedad es solo un resguardo.
+        $this->setServiceCategory(null, null);
     }
 
     public function getId(): ?int
@@ -131,6 +167,35 @@ class ClientProviderRouting
     public function setFallbackProvider(?string $fallbackProvider): static
     {
         $this->fallbackProvider = $fallbackProvider;
+
+        return $this;
+    }
+
+    public function getServiceName(): ?string
+    {
+        return $this->serviceName;
+    }
+
+    public function getSubserviceName(): ?string
+    {
+        return $this->subserviceName;
+    }
+
+    public function getServiceKey(): string
+    {
+        return $this->serviceKey;
+    }
+
+    /**
+     * Única forma de establecer la categoría — deriva $serviceKey en el
+     * mismo paso, no hay setServiceKey() independiente (ver docblock de la
+     * propiedad).
+     */
+    public function setServiceCategory(?string $serviceName, ?string $subserviceName): static
+    {
+        $this->serviceName = $serviceName;
+        $this->subserviceName = $subserviceName;
+        $this->serviceKey = ServiceCategoryKey::of($serviceName, $subserviceName);
 
         return $this;
     }

--- a/src/Provider/PromotionProviderDispatchResolver.php
+++ b/src/Provider/PromotionProviderDispatchResolver.php
@@ -80,14 +80,19 @@ class PromotionProviderDispatchResolver
             return [$this->defaultProvider()];
         }
 
-        $rows = $this->routingRepo->findActiveProvidersOrderedForClient($client->getId());
+        // findActiveRouteScopesForClient() devuelve una proyección escalar
+        // (ver su docblock) — este resolver, a diferencia de
+        // ProviderDispatchResolver, NO filtra por scope ni expande
+        // fallbackProvider: las promociones no tienen categoría
+        // servicio/subservicio propia, fuera de alcance de esta extensión.
+        $rows = $this->routingRepo->findActiveRouteScopesForClient($client->getId());
         if ($rows === []) {
             return [$this->defaultProvider()];
         }
 
         $providers = [];
         foreach ($rows as $row) {
-            $provider = CommunicationProviderEnum::tryFrom($row->getProvider() ?? '');
+            $provider = CommunicationProviderEnum::tryFrom($row['provider'] ?? '');
             if ($provider !== null) {
                 $providers[] = $provider;
             }

--- a/src/Provider/ProviderDispatchResolver.php
+++ b/src/Provider/ProviderDispatchResolver.php
@@ -19,14 +19,27 @@ use Symfony\Component\HttpFoundation\Response;
  * Elige QUÉ proveedor despacha de verdad la venta de un CommunicationPackage
  * (V2) — reemplaza al rol de CommunicationSaleService::resolveAndGuardProvider(),
  * que decidía por el proveedor "dueño" del producto. Aquí es al revés: se
- * recorre la lista de PRIORIDAD del cliente (ClientProviderRouting::$priority)
- * y se busca, para cada proveedor en orden, un producto que cubra la tupla
- * de destino del paquete — el primero que sirve, gana.
+ * recorre la lista de candidatos del cliente (ClientProviderRouting) y se
+ * busca, para cada proveedor en orden, un producto que cubra la tupla de
+ * destino del paquete — el primero que sirve, gana.
+ *
+ * La lista de candidatos se construye en tres pasos, ver candidateProviders():
+ *   1. Se descartan las filas cuyo entorno/tipo de venta/servicio/subservicio
+ *      no aplican a esta venta (null en la fila = comodín, aplica siempre).
+ *   2. Las filas aplicables se ordenan por ESPECIFICIDAD (cuántas
+ *      dimensiones fija, no comodín) de mayor a menor — a igual
+ *      especificidad manda ClientProviderRouting::$priority/id, en el
+ *      mismo orden que ya trae el repositorio (usort() es estable en
+ *      PHP 8).
+ *   3. Cada fila aporta su `provider` y, si tiene, su `fallbackProvider` a
+ *      continuación — ver selectExcluding() para cómo se usa esto en un
+ *      failover tras rechazo (tanto en la selección inicial como al
+ *      reintentar).
  *
  * Mismo kill switch y fallback a proveedor único que
  * ProviderResolver::allowedForClient() usa hoy (comunications.provider.routing.enabled
- * + communications.provider.default) — sin filas de routing activas para el
- * cliente, o con el switch apagado, se prueba solo el proveedor por
+ * + communications.provider.default) — sin filas de routing aplicables para
+ * el cliente, o con el switch apagado, se prueba solo el proveedor por
  * defecto.
  *
  * Excepción al fallback: un paquete generado por una promoción
@@ -35,7 +48,7 @@ use Symfony\Component\HttpFoundation\Response;
  * de "nunca despachar en silencio con el producto equivocado": si el admin
  * (o el poblado automático por proveedor) no dejó una equivalencia para
  * este tramo, ese proveedor simplemente no participa, se prueba el
- * siguiente candidato de prioridad.
+ * siguiente candidato.
  */
 class ProviderDispatchResolver
 {
@@ -51,17 +64,9 @@ class ProviderDispatchResolver
 
     public function select(Account $account, CommunicationPackage $package, ?string $saleType = null): SelectedDispatch
     {
-        $environmentType = $account->getEnvironment()?->getType();
-
-        foreach ($this->candidateProviders($account) as $provider) {
-            if (!$this->availabilityService->canDispatchTo($provider->value, $environmentType)) {
-                continue;
-            }
-
-            $product = $this->findDispatchableProduct($account, $package, $provider->value, $saleType);
-            if ($product !== null) {
-                return new SelectedDispatch($provider, $product, $product->getExternalRef());
-            }
+        $selected = $this->selectExcluding($account, $package, $saleType, []);
+        if ($selected !== null) {
+            return $selected;
         }
 
         throw new MyCurrentException(
@@ -72,29 +77,109 @@ class ProviderDispatchResolver
     }
 
     /**
+     * Igual que select(), salvo que (a) salta cualquier proveedor en
+     * $excludeProviders (ya intentado por SaleProviderFailoverService) y
+     * (b) devuelve null en vez de lanzar cuando nadie puede despachar —
+     * quien llama decide qué hacer con "no hay a quién más intentarle".
+     *
+     * @param list<CommunicationProviderEnum> $excludeProviders
+     */
+    public function selectExcluding(Account $account, CommunicationPackage $package, ?string $saleType, array $excludeProviders): ?SelectedDispatch
+    {
+        $environmentType = $account->getEnvironment()?->getType();
+
+        foreach ($this->candidateProviders($account, $package, $saleType) as $provider) {
+            if (in_array($provider, $excludeProviders, true)) {
+                continue;
+            }
+
+            if (!$this->availabilityService->canDispatchTo($provider->value, $environmentType)) {
+                continue;
+            }
+
+            $product = $this->findDispatchableProduct($account, $package, $provider->value, $saleType);
+            if ($product !== null) {
+                return new SelectedDispatch($provider, $product, $product->getExternalRef());
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * @return list<CommunicationProviderEnum>
      */
-    private function candidateProviders(Account $account): array
+    private function candidateProviders(Account $account, CommunicationPackage $package, ?string $saleType): array
     {
         $client = $account->getClient();
         if ($client === null || !$this->routingEnabled()) {
             return [$this->defaultProvider()];
         }
 
-        $rows = $this->routingRepo->findActiveProvidersOrderedForClient($client->getId());
+        $rows = $this->routingRepo->findActiveRouteScopesForClient($client->getId());
         if ($rows === []) {
             return [$this->defaultProvider()];
         }
 
+        $environmentId = $account->getEnvironment()?->getId();
+        $service = $package->getService();
+        $packageServiceName = $service['name'] ?? null;
+        $packageSubserviceName = $service['subservice']['name'] ?? null;
+
+        $applicable = array_values(array_filter(
+            $rows,
+            fn (array $row) => $this->rowApplies($row, $environmentId, $saleType, $packageServiceName, $packageSubserviceName),
+        ));
+
+        if ($applicable === []) {
+            return [$this->defaultProvider()];
+        }
+
+        usort($applicable, fn (array $a, array $b) => $this->specificity($b) <=> $this->specificity($a));
+
         $providers = [];
-        foreach ($rows as $row) {
-            $provider = CommunicationProviderEnum::tryFrom($row->getProvider() ?? '');
-            if ($provider !== null) {
-                $providers[] = $provider;
+        foreach ($applicable as $row) {
+            foreach ([$row['provider'], $row['fallbackProvider']] as $code) {
+                $provider = CommunicationProviderEnum::tryFrom($code ?? '');
+                if ($provider !== null && !in_array($provider, $providers, true)) {
+                    $providers[] = $provider;
+                }
             }
         }
 
         return $providers === [] ? [$this->defaultProvider()] : $providers;
+    }
+
+    /**
+     * @param array{environmentId:?int, saleType:?string, serviceName:?string, subserviceName:?string} $row
+     */
+    private function rowApplies(array $row, ?int $environmentId, ?string $saleType, ?string $packageServiceName, ?string $packageSubserviceName): bool
+    {
+        if ($row['environmentId'] !== null && $row['environmentId'] !== $environmentId) {
+            return false;
+        }
+        if ($row['saleType'] !== null && $row['saleType'] !== $saleType) {
+            return false;
+        }
+        if ($row['serviceName'] !== null && trim($row['serviceName']) !== trim($packageServiceName ?? '')) {
+            return false;
+        }
+        if ($row['subserviceName'] !== null && trim($row['subserviceName']) !== trim($packageSubserviceName ?? '')) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array{environmentId:?int, saleType:?string, serviceName:?string, subserviceName:?string} $row
+     */
+    private function specificity(array $row): int
+    {
+        return ($row['environmentId'] !== null ? 8 : 0)
+            + ($row['saleType'] !== null ? 4 : 0)
+            + ($row['serviceName'] !== null ? 2 : 0)
+            + ($row['subserviceName'] !== null ? 1 : 0);
     }
 
     /**

--- a/src/Provider/TransactionStatus.php
+++ b/src/Provider/TransactionStatus.php
@@ -279,4 +279,41 @@ final class TransactionStatus
     {
         return $status['retry']['lastAttemptAt'] ?? $status['lastRetryAt'] ?? null;
     }
+
+    /**
+     * Código del proveedor original si esta venta ya hizo un failover
+     * (SaleProviderFailoverService::promoteToFallback()), null si no.
+     *
+     * @param array<string, mixed> $status
+     */
+    public static function failoverFromOf(array $status): ?string
+    {
+        return $status['retry']['failoverFrom'] ?? null;
+    }
+
+    /**
+     * Reinyecta el bloque `retry` de un sobre PREVIO en uno RECIÉN
+     * construido con fromDispatch()/fromStatus() — esos dos siempre arman
+     * un envelope desde cero, así que perderían cualquier `retry` puesto
+     * por una llamada anterior de withRetry() (p. ej. el marcador
+     * `failoverFrom` de un failover ya hecho, o el contador de
+     * GATEWAY_MISSING). Sin esto, un segundo rechazo del proveedor
+     * secundario no vería que ya hubo un failover y podría rebotar de
+     * vuelta al proveedor original indefinidamente. No-op si $new ya trae
+     * su propio `retry` (p. ej. viene de withRetry()) o si $previous no
+     * tenía ninguno.
+     *
+     * @param array<string, mixed> $previous
+     * @param Envelope $new
+     * @return Envelope
+     */
+    public static function carryRetryBlock(array $previous, array $new): array
+    {
+        if (!isset($new['retry']) && isset($previous['retry'])) {
+            $new['retry'] = $previous['retry'];
+        }
+
+        /** @var Envelope $new */
+        return $new;
+    }
 }

--- a/src/Repository/ClientProviderRoutingRepository.php
+++ b/src/Repository/ClientProviderRoutingRepository.php
@@ -104,16 +104,26 @@ class ClientProviderRoutingRepository extends ServiceEntityRepository
     }
 
     /**
-     * Lista PLANA (sin distinguir environment/saleType) de las filas activas
-     * de un cliente, en orden de prioridad — lo que consultará
-     * ProviderDispatchResolver (V2 Fase 2) para probar proveedores en orden
-     * hasta que uno acepte la venta. Desempate por id ASC cuando dos filas
-     * comparten priority (p. ej. ambas en el valor DEFAULT tras el backfill
-     * de Version20260810120200), para que el orden sea determinista.
+     * Proyección ESCALAR (no entidades) de las filas activas de un cliente,
+     * en orden de prioridad — lo que consulta ProviderDispatchResolver para
+     * probar proveedores en orden hasta que uno acepte la venta. Escalar a
+     * propósito: el resultado se guarda en caché serializado, y una entidad
+     * Doctrine deserializada queda detached — leer una relación lazy
+     * (environment) sobre ella revienta con LazyInitializationException.
+     * Desempate por id ASC cuando dos filas comparten priority (p. ej.
+     * ambas en el valor DEFAULT tras el backfill de Version20260810120200),
+     * para que el orden sea determinista.
      *
-     * @return list<ClientProviderRouting>
+     * Lista PLANA a propósito (sin filtrar por environment/saleType/categoría
+     * aquí): ProviderDispatchResolver::candidateProviders() hace ese
+     * filtrado en PHP sobre este mismo resultado cacheado, para no explotar
+     * la clave de caché con una dimensión más por combinación de scope.
+     *
+     * @return list<array{id:int, provider:?string, fallbackProvider:?string,
+     *   environmentId:?int, saleType:?string, serviceName:?string,
+     *   subserviceName:?string, priority:int}>
      */
-    public function findActiveProvidersOrderedForClient(int $clientId): array
+    public function findActiveRouteScopesForClient(int $clientId): array
     {
         $key = sprintf('cpr_priority_%d', $clientId);
 
@@ -121,6 +131,16 @@ class ClientProviderRoutingRepository extends ServiceEntityRepository
             $item->tag([self::CACHE_TAG]);
 
             return $this->createQueryBuilder('cpr')
+                ->select(
+                    'cpr.id AS id',
+                    'cpr.provider AS provider',
+                    'cpr.fallbackProvider AS fallbackProvider',
+                    'IDENTITY(cpr.environment) AS environmentId',
+                    'cpr.saleType AS saleType',
+                    'cpr.serviceName AS serviceName',
+                    'cpr.subserviceName AS subserviceName',
+                    'cpr.priority AS priority',
+                )
                 ->andWhere('cpr.client = :clientId')
                 ->andWhere('cpr.isActive = :active')
                 ->setParameter('clientId', $clientId)
@@ -128,7 +148,7 @@ class ClientProviderRoutingRepository extends ServiceEntityRepository
                 ->orderBy('cpr.priority', 'ASC')
                 ->addOrderBy('cpr.id', 'ASC')
                 ->getQuery()
-                ->getResult();
+                ->getArrayResult();
         });
     }
 

--- a/src/Service/CommunicationSaleService.php
+++ b/src/Service/CommunicationSaleService.php
@@ -37,6 +37,7 @@ use App\Provider\ProviderDispatchResolver;
 use App\Provider\ProviderRegistry;
 use App\Provider\ProviderResolver;
 use App\Provider\PromotionProviderDispatchResolver;
+use App\Service\Provider\SaleProviderFailoverService;
 use App\Provider\TransactionStatus;
 use App\Repository\BalanceOperationRepository;
 use App\Repository\EnvironmentRepository;
@@ -97,6 +98,7 @@ class CommunicationSaleService extends CommonService
         private readonly PackageCatalogResolver $packageCatalogResolver,
         private readonly ProviderDispatchResolver $dispatchResolver,
         private readonly PromotionProviderDispatchResolver $promotionDispatchResolver,
+        private readonly SaleProviderFailoverService $failoverService,
     ) {
         parent::__construct(
             $em,
@@ -523,11 +525,28 @@ class CommunicationSaleService extends CommonService
                 );
 
                 $dispatchResult = $adapter->recharge($context, $request);
-                $dispatchEnvelope = TransactionStatus::fromDispatch($dispatchResult, $provider->value, ['request' => $body]);
+                // carryRetryBlock() preserva el marcador de un failover
+                // previo (o el contador de GATEWAY_MISSING) — fromDispatch()
+                // arma un sobre nuevo desde cero y lo perdería.
+                $dispatchEnvelope = TransactionStatus::carryRetryBlock(
+                    $saleRecharge->getTransactionStatus(),
+                    TransactionStatus::fromDispatch($dispatchResult, $provider->value, ['request' => $body]),
+                );
                 $saleRecharge->setTransactionStatus($dispatchEnvelope);
                 $saleRecharge->setStateProcess(CommunicationStateEnum::PENDING->value);
 
                 if ($dispatchResult->outcome === ProviderOutcomeEnum::REJECTED) {
+                    // Rechazo determinista del proveedor (no un timeout/error
+                    // de transporte, que ya llega como UNKNOWN) — único punto
+                    // seguro para intentar el proveedor secundario, ver
+                    // SaleProviderFailoverService.
+                    if ($this->failoverService->promoteToFallback($saleRecharge, 'Provider rejected the recharge: ' . ($dispatchResult->message ?? ''))) {
+                        $this->em->flush();
+                        $this->dispatchOrDefer($saleRecharge, fn () => new SaleRechargeMessage($saleRecharge->getId()));
+
+                        return;
+                    }
+
                     $saleRecharge->setState(CommunicationStateEnum::REJECTED);
                     $this->historicalSaleService->createHistoricalCommunication(
                         $saleRecharge->getId(),
@@ -789,9 +808,23 @@ class CommunicationSaleService extends CommonService
             if ($dispatchResult->outcome === ProviderOutcomeEnum::ACCEPTED) {
                 $sale->setState(CommunicationStateEnum::PENDING);
             } elseif ($dispatchResult->outcome === ProviderOutcomeEnum::FAILED) {
+                // Rechazo determinista del proveedor (no un timeout/error de
+                // transporte, que ya llega como UNKNOWN) — único punto
+                // seguro para intentar el proveedor secundario, ver
+                // SaleProviderFailoverService.
+                if ($this->failoverService->promoteToFallback($sale, 'Provider failed the sale: ' . ($dispatchResult->message ?? ''))) {
+                    $this->em->flush();
+                    $this->dispatchOrDefer($sale, fn () => new SalePackageMessage($sale->getId()));
+
+                    return;
+                }
+
                 $sale->setState(CommunicationStateEnum::FAILED);
             }
-            $sale->setTransactionStatus(TransactionStatus::fromDispatch($dispatchResult, $provider->value));
+            $sale->setTransactionStatus(TransactionStatus::carryRetryBlock(
+                $sale->getTransactionStatus(),
+                TransactionStatus::fromDispatch($dispatchResult, $provider->value),
+            ));
             $sale->setStateProcess(CommunicationStateEnum::PENDING->value);
 
             if ($dispatchResult->outcome === ProviderOutcomeEnum::UNKNOWN) {
@@ -1078,7 +1111,10 @@ class CommunicationSaleService extends CommonService
                 return;
             }
 
-            $statusEnvelope = TransactionStatus::fromStatus($statusResult, $provider->value);
+            $statusEnvelope = TransactionStatus::carryRetryBlock(
+                $sale->getTransactionStatus(),
+                TransactionStatus::fromStatus($statusResult, $provider->value),
+            );
             $sale->setTransactionStatus($statusEnvelope);
 
             if ($statusResult->outcome === ProviderOutcomeEnum::COMPLETED) {
@@ -1108,6 +1144,19 @@ class CommunicationSaleService extends CommonService
                     $statusEnvelope
                 );
             } elseif ($statusResult->outcome === ProviderOutcomeEnum::REJECTED) {
+                // Camino habitual de ETECSA: solo devuelve ACCEPTED en el
+                // dispatch y confirma el rechazo aquí — mismo failover que
+                // el rechazo síncrono de CSQ/DTOne en invokeRechargeCommunication()/
+                // executeNewSaleInfo(), ver SaleProviderFailoverService.
+                if ($this->failoverService->promoteToFallback($sale, 'Provider confirmed rejection on status check: ' . ($statusResult->message ?? ''))) {
+                    $this->em->flush();
+                    $isRecharge
+                        ? $this->dispatchOrDefer($sale, fn () => new SaleRechargeMessage($sale->getId()))
+                        : $this->dispatchOrDefer($sale, fn () => new SalePackageMessage($sale->getId()));
+
+                    return;
+                }
+
                 $sale->setState(CommunicationStateEnum::REJECTED);
                 $sale->setStateProcess(CommunicationStateEnum::REJECTED->value);
                 if ($statusResult->recordHistory) {

--- a/src/Service/Provider/SaleProviderFailoverService.php
+++ b/src/Service/Provider/SaleProviderFailoverService.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Service\Provider;
+
+use App\Entity\CommunicationSaleInfo;
+use App\Entity\CommunicationSaleRecharge;
+use App\Enums\CommunicationProviderEnum;
+use App\Enums\CommunicationStateEnum;
+use App\Enums\ProviderOutcomeEnum;
+use App\Provider\ProviderDispatchResolver;
+use App\Provider\TransactionStatus;
+use App\Repository\SysConfigRepository;
+use App\Service\HistoricalSaleService;
+
+/**
+ * Único salto principal → secundario tras un RECHAZO DETERMINISTA del
+ * proveedor — nunca tras un timeout/error de transporte, que los
+ * adaptadores ya absorben como ProviderOutcomeEnum::UNKNOWN antes de llegar
+ * a los call sites de este servicio (ver CommunicationSaleService, catch
+ * genérico tras dispatch: "Jamás debe reintentarse el ENVÍO mismo tras un
+ * UNKNOWN: eso podría cobrar dos veces la misma recarga"). REJECTED sí es
+ * seguro: el proveedor confirmó que NO procesó la operación.
+ *
+ * Reutiliza ProviderDispatchResolver::selectExcluding() — la misma lista de
+ * candidatos (proveedor + fallbackProvider de cada fila de
+ * ClientProviderRouting aplicable) que ya usó la selección inicial, solo
+ * que saltando el proveedor que acaba de rechazar.
+ *
+ * Sin extender CommonService (servicio nuevo con pocas dependencias, ver
+ * CLAUDE.md).
+ */
+class SaleProviderFailoverService
+{
+    public const FAILOVER_ENABLED_KEY = 'communications.provider.failover.enabled';
+
+    public function __construct(
+        private readonly ProviderDispatchResolver $dispatchResolver,
+        private readonly SysConfigRepository $sysConfigRepo,
+        private readonly HistoricalSaleService $historicalSaleService,
+    ) {
+    }
+
+    /**
+     * Muta $sale (provider/dispatchProduct/dispatchExternalRef/stateProcess/
+     * transactionStatus) y registra un CommunicationSaleHistory si encuentra
+     * un candidato — NO hace flush ni reencola el mensaje de despacho, eso
+     * es responsabilidad de quien llama (ya está en medio de su propio
+     * flujo de persistencia). Devuelve false sin mutar nada si el failover
+     * no aplica.
+     */
+    public function promoteToFallback(CommunicationSaleInfo $sale, string $reason): bool
+    {
+        if ($this->sysConfigRepo->findCachedValue(self::FAILOVER_ENABLED_KEY) === '0') {
+            return false;
+        }
+
+        $currentStatus = $sale->getTransactionStatus();
+        // Un único salto por venta: si ya hay un failover registrado, no se
+        // intenta un segundo (evita ping-pong entre dos proveedores que
+        // rechazan por turnos). El marcador sobrevive a los sucesivos
+        // fromDispatch()/fromStatus() vía TransactionStatus::carryRetryBlock().
+        if (TransactionStatus::failoverFromOf($currentStatus) !== null) {
+            return false;
+        }
+
+        $account = $sale->getTenant();
+        $package = $sale->getCatalogPackage();
+        $currentProvider = CommunicationProviderEnum::tryFrom($sale->getProvider() ?? '');
+        if ($account === null || $package === null || $currentProvider === null) {
+            return false;
+        }
+
+        $saleType = $sale instanceof CommunicationSaleRecharge ? 'recharge' : 'sale';
+
+        $selected = $this->dispatchResolver->selectExcluding($account, $package, $saleType, [$currentProvider]);
+        if ($selected === null) {
+            return false;
+        }
+
+        $sale->setProvider($selected->provider->value);
+        $sale->setDispatchProduct($selected->product);
+        $sale->setDispatchExternalRef($selected->externalRef);
+        $sale->setStateProcess(CommunicationStateEnum::CREATED->value);
+        $sale->setTransactionStatus(TransactionStatus::withRetry(
+            $currentStatus,
+            ProviderOutcomeEnum::RETRYABLE,
+            'INTERNAL_PROVIDER_FAILOVER',
+            $reason,
+            [
+                'failoverFrom' => $currentProvider->value,
+                'failoverTo' => $selected->provider->value,
+                'reason' => $reason,
+            ],
+        ));
+
+        $this->historicalSaleService->createHistoricalCommunication(
+            $sale->getId(),
+            CommunicationStateEnum::CREATED,
+            $sale->getTransactionStatus(),
+        );
+
+        return true;
+    }
+}

--- a/src/Service/ProviderRoutingAdminService.php
+++ b/src/Service/ProviderRoutingAdminService.php
@@ -16,6 +16,7 @@ use App\Exception\MyCurrentException;
 use App\Provider\ProviderCredentialsResolver;
 use App\Provider\ProviderResolver;
 use App\Repository\ClientProviderRoutingRepository;
+use App\Service\Pricing\ServiceCategoryKey;
 use App\Service\Provider\ClientCatalogImportService;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -46,8 +47,9 @@ class ProviderRoutingAdminService
         }
 
         $environment = $this->resolveEnvironmentOrFail($dto->getEnvironmentId());
+        $serviceKey = ServiceCategoryKey::of($dto->getServiceName(), $dto->getSubserviceName());
 
-        $this->assertScopeIsFree($client->getId(), $dto->getEnvironmentId(), $dto->getSaleType());
+        $this->assertScopeIsFree($client->getId(), $dto->getEnvironmentId(), $dto->getSaleType(), $serviceKey);
         $this->assertProviderIsEnabled($dto->getProvider(), $environment?->getType());
 
         $routing = new ClientProviderRouting();
@@ -56,6 +58,7 @@ class ProviderRoutingAdminService
         $routing->setSaleType($dto->getSaleType());
         $routing->setProvider($dto->getProvider());
         $routing->setFallbackProvider($dto->getFallbackProvider());
+        $routing->setServiceCategory($dto->getServiceName(), $dto->getSubserviceName());
         $routing->setNotes($dto->getNotes());
 
         $user = $this->security->getUser();
@@ -77,7 +80,8 @@ class ProviderRoutingAdminService
     public function update(ClientProviderRouting $routing, UpdateProviderRoutingDto $dto): ClientProviderRouting
     {
         $providerChanged = $dto->getProvider() !== null && $dto->getProvider() !== $routing->getProvider();
-        $scopeTouched = $dto->getEnvironmentId() !== null || $dto->getSaleType() !== null;
+        $scopeTouched = $dto->getEnvironmentId() !== null || $dto->getSaleType() !== null
+            || $dto->getServiceName() !== null || $dto->getSubserviceName() !== null;
 
         $effectiveEnvironment = $routing->getEnvironment();
 
@@ -86,16 +90,33 @@ class ProviderRoutingAdminService
                 ? $this->resolveEnvironmentOrFail($dto->getEnvironmentId())
                 : $routing->getEnvironment();
             $saleType = $dto->getSaleType() ?? $routing->getSaleType();
+            // Convención del DTO: null = no tocar, '' = limpiar a comodín —
+            // ver docblock de UpdateProviderRoutingDto.
+            $serviceName = $dto->getServiceName() !== null
+                ? ($dto->getServiceName() === '' ? null : $dto->getServiceName())
+                : $routing->getServiceName();
+            $subserviceName = $dto->getSubserviceName() !== null
+                ? ($dto->getSubserviceName() === '' ? null : $dto->getSubserviceName())
+                : $routing->getSubserviceName();
+
+            // Limpiar serviceName a comodín sin tocar subserviceName
+            // dejaría un subservicio "huérfano" (sin servicio) — mismo
+            // requisito que exige el DTO de entrada para altas nuevas.
+            if ($serviceName === null) {
+                $subserviceName = null;
+            }
 
             $this->assertScopeIsFree(
                 $routing->getClient()->getId(),
                 $environment?->getId(),
                 $saleType,
+                ServiceCategoryKey::of($serviceName, $subserviceName),
                 excludeId: $routing->getId(),
             );
 
             $routing->setEnvironment($environment);
             $routing->setSaleType($saleType);
+            $routing->setServiceCategory($serviceName, $subserviceName);
             $effectiveEnvironment = $environment;
         }
 
@@ -149,6 +170,12 @@ class ProviderRoutingAdminService
      * en null hasta la Fase 3 (communication_product.provider aún no
      * existe, así que hoy no hay forma de saber a qué proveedor pertenece
      * cada CommunicationProduct).
+     *
+     * NO es category-aware: sigue usando ProviderResolver::resolveEffectiveFor()
+     * (admisión, no despacho), que no filtra por servicio/subservicio.
+     * Fuera de alcance de la extensión por categoría — currentEffectiveProvider
+     * puede no reflejar exactamente lo que ProviderDispatchResolver elegiría
+     * para un paquete de una categoría específica.
      */
     public function preview(int $clientId, ?int $environmentId, ?string $saleType, string $proposedProvider): ProviderRoutingPreviewOutDto
     {
@@ -188,12 +215,14 @@ class ProviderRoutingAdminService
      * la garantía final, pero validar aquí antes de intentar el flush da un
      * error 409 legible en vez de una excepción de Doctrine sin traducir.
      */
-    private function assertScopeIsFree(int $clientId, ?int $environmentId, ?string $saleType, ?int $excludeId = null): void
+    private function assertScopeIsFree(int $clientId, ?int $environmentId, ?string $saleType, string $serviceKey, ?int $excludeId = null): void
     {
         $qb = $this->em->getRepository(ClientProviderRouting::class)->createQueryBuilder('cpr')
             ->andWhere('cpr.client = :clientId')
             ->andWhere('cpr.isActive = true')
-            ->setParameter('clientId', $clientId);
+            ->andWhere('cpr.serviceKey = :serviceKey')
+            ->setParameter('clientId', $clientId)
+            ->setParameter('serviceKey', $serviceKey);
 
         $qb->andWhere($environmentId !== null ? 'cpr.environment = :environmentId' : 'cpr.environment IS NULL');
         if ($environmentId !== null) {
@@ -213,7 +242,7 @@ class ProviderRoutingAdminService
         if ($existing !== null) {
             throw new MyCurrentException(
                 'PROVIDER_ROUTING_DUPLICATE',
-                'Ya existe un enrutado activo para este cliente/entorno/tipo de venta.',
+                'Ya existe un enrutado activo para este cliente/entorno/tipo de venta/categoría.',
                 Response::HTTP_CONFLICT,
             );
         }
@@ -271,6 +300,7 @@ class ProviderRoutingAdminService
                 $routing->getClient()->getId(),
                 $routing->getEnvironment()?->getId(),
                 $routing->getSaleType(),
+                $routing->getServiceKey(),
                 excludeId: $routing->getId(),
             );
         }

--- a/tests/Controller/DashboardProviderRoutingControllerTest.php
+++ b/tests/Controller/DashboardProviderRoutingControllerTest.php
@@ -228,6 +228,20 @@ class DashboardProviderRoutingControllerTest extends TestCase
         $this->assertSame('DTONE', $data['provider']);
     }
 
+    public function testShowSerializesServiceCategory(): void
+    {
+        $routing = $this->routingMock(1, 'DTONE');
+        $routing->method('getServiceName')->willReturn('Mobile');
+        $routing->method('getSubserviceName')->willReturn('AIRTIME');
+        $this->routingRepo->method('find')->with(1)->willReturn($routing);
+
+        $response = $this->controller->show(1);
+        $data = json_decode($response->getContent(), true);
+
+        $this->assertSame('Mobile', $data['serviceName']);
+        $this->assertSame('AIRTIME', $data['subserviceName']);
+    }
+
     // ---- create ----
 
     public function testCreateReturnsCreatedRouting(): void

--- a/tests/DTO/CreateProviderRoutingDtoTest.php
+++ b/tests/DTO/CreateProviderRoutingDtoTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Tests\DTO;
+
+use App\DTO\CreateProviderRoutingDto;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Validation;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @covers \App\DTO\CreateProviderRoutingDto
+ *
+ * Cubre específicamente validateServiceCategory() — el resto de constraints
+ * (#[Assert\NotNull], #[Assert\Choice], etc.) ya las ejercita Symfony y no
+ * aportan valor repetirlas aquí.
+ */
+class CreateProviderRoutingDtoTest extends TestCase
+{
+    private ValidatorInterface $validator;
+
+    protected function setUp(): void
+    {
+        $this->validator = Validation::createValidatorBuilder()
+            ->enableAttributeMapping()
+            ->getValidator();
+    }
+
+    private function dto(?string $serviceName, ?string $subserviceName): CreateProviderRoutingDto
+    {
+        return new CreateProviderRoutingDto(
+            clientId: 1,
+            provider: 'DTONE',
+            serviceName: $serviceName,
+            subserviceName: $subserviceName,
+        );
+    }
+
+    public function testSubserviceNameWithoutServiceNameIsRejected(): void
+    {
+        $violations = $this->validator->validate($this->dto(null, 'AIRTIME'));
+
+        $this->assertGreaterThan(0, count($violations));
+        $this->assertSame('subserviceName', $violations[0]->getPropertyPath());
+    }
+
+    public function testServiceNameWithSubserviceNameIsValid(): void
+    {
+        $violations = $this->validator->validate($this->dto('Mobile', 'AIRTIME'));
+
+        $this->assertCount(0, $violations);
+    }
+
+    public function testServiceNameAloneIsValid(): void
+    {
+        $violations = $this->validator->validate($this->dto('Mobile', null));
+
+        $this->assertCount(0, $violations);
+    }
+
+    public function testBothNullIsValid(): void
+    {
+        $violations = $this->validator->validate($this->dto(null, null));
+
+        $this->assertCount(0, $violations);
+    }
+
+    public function testServiceNameContainingTheSeparatorIsRejected(): void
+    {
+        $violations = $this->validator->validate($this->dto('Mo|bile', null));
+
+        $this->assertGreaterThan(0, count($violations));
+    }
+}

--- a/tests/DTO/UpdateProviderRoutingDtoTest.php
+++ b/tests/DTO/UpdateProviderRoutingDtoTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Tests\DTO;
+
+use App\DTO\UpdateProviderRoutingDto;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Validation;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @covers \App\DTO\UpdateProviderRoutingDto
+ *
+ * Cubre validateServiceCategory() con la convención propia de este DTO:
+ * null = no tocar, '' = limpiar a comodín — ver su docblock de clase.
+ */
+class UpdateProviderRoutingDtoTest extends TestCase
+{
+    private ValidatorInterface $validator;
+
+    protected function setUp(): void
+    {
+        $this->validator = Validation::createValidatorBuilder()
+            ->enableAttributeMapping()
+            ->getValidator();
+    }
+
+    public function testSubserviceNameWithoutServiceNameIsRejected(): void
+    {
+        $dto = new UpdateProviderRoutingDto(subserviceName: 'AIRTIME');
+
+        $violations = $this->validator->validate($dto);
+
+        $this->assertGreaterThan(0, count($violations));
+        $this->assertSame('subserviceName', $violations[0]->getPropertyPath());
+    }
+
+    /**
+     * '' (limpiar serviceName) + subserviceName sin tocar (null) es válido
+     * a nivel de DTO — el servicio resuelve el "efectivo" y, si queda sin
+     * servicio, limpia también el subservicio (ver ProviderRoutingAdminService::update()).
+     */
+    public function testClearingServiceNameWithSubserviceNameUntouchedIsValidAtDtoLevel(): void
+    {
+        $dto = new UpdateProviderRoutingDto(serviceName: '');
+
+        $violations = $this->validator->validate($dto);
+
+        $this->assertCount(0, $violations);
+    }
+
+    public function testClearingBothIsValid(): void
+    {
+        $dto = new UpdateProviderRoutingDto(serviceName: '', subserviceName: '');
+
+        $violations = $this->validator->validate($dto);
+
+        $this->assertCount(0, $violations);
+    }
+
+    public function testClearingServiceNameWhileSettingSubserviceNameIsRejected(): void
+    {
+        $dto = new UpdateProviderRoutingDto(serviceName: '', subserviceName: 'AIRTIME');
+
+        $violations = $this->validator->validate($dto);
+
+        $this->assertGreaterThan(0, count($violations));
+    }
+
+    public function testUntouchedIsValid(): void
+    {
+        $dto = new UpdateProviderRoutingDto();
+
+        $violations = $this->validator->validate($dto);
+
+        $this->assertCount(0, $violations);
+    }
+}

--- a/tests/Functional/Provider/ClientProviderRoutingPriorityFunctionalTest.php
+++ b/tests/Functional/Provider/ClientProviderRoutingPriorityFunctionalTest.php
@@ -4,15 +4,17 @@ namespace App\Tests\Functional\Provider;
 
 use App\Enums\CommunicationProviderEnum;
 use App\Repository\ClientProviderRoutingRepository;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 
 /**
- * @covers \App\Repository\ClientProviderRoutingRepository::findActiveProvidersOrderedForClient
+ * @covers \App\Repository\ClientProviderRoutingRepository::findActiveRouteScopesForClient
  *
- * V2 Fase 1: nuevo método de orden por prioridad — lo consumirá
- * ProviderDispatchResolver (Fase 2) para probar proveedores en orden hasta
- * que uno acepte la venta. Ningún flujo de despacho actual lo usa todavía
- * (ver Version20260810120200), así que este test cubre solo el
- * repositorio en sí.
+ * findActiveRouteScopesForClient() devuelve una proyección ESCALAR (no
+ * entidades) — ver su docblock para el porqué. Sigue siendo una lista
+ * PLANA a propósito (sin filtrar por environment/saleType/categoría aquí):
+ * App\Provider\ProviderDispatchResolver hace ese filtrado en PHP sobre
+ * este mismo resultado — ver ProviderDispatchResolverTest para la
+ * cobertura de esa parte.
  */
 class ClientProviderRoutingPriorityFunctionalTest extends ProviderFunctionalTestCase
 {
@@ -25,22 +27,22 @@ class ClientProviderRoutingPriorityFunctionalTest extends ProviderFunctionalTest
     {
         $client = $this->createClient();
 
-        // uniq_cpr_scope exige (client, environment, saleType) distinto por
-        // fila activa — se usa un saleType distinto por fila para poder
-        // tener 3 proveedores activos del mismo cliente a la vez, igual que
-        // en producción (cada fila real suele venir de un routing por
-        // saleType/entorno, no de 3 filas "generales" idénticas).
+        // uniq_cpr_scope exige (client, environment, saleType, serviceKey)
+        // distinto por fila activa — se usa un saleType distinto por fila
+        // para poder tener 3 proveedores activos del mismo cliente a la
+        // vez, igual que en producción (cada fila real suele venir de un
+        // routing por saleType/entorno, no de 3 filas "generales" idénticas).
         $this->createRouting($client, CommunicationProviderEnum::ETECSA->value, saleType: 'sale', priority: 200);
         $csq = $this->createRouting($client, CommunicationProviderEnum::CSQ->value, saleType: 'recharge', priority: 0);
         $dtone = $this->createRouting($client, CommunicationProviderEnum::DTONE->value, priority: 100);
 
-        $result = $this->repository()->findActiveProvidersOrderedForClient($client->getId());
+        $result = $this->repository()->findActiveRouteScopesForClient($client->getId());
 
         $this->assertSame(
             [$csq->getId(), $dtone->getId()],
-            [$result[0]->getId(), $result[1]->getId()],
+            [$result[0]['id'], $result[1]['id']],
         );
-        $this->assertSame(CommunicationProviderEnum::CSQ->value, $result[0]->getProvider());
+        $this->assertSame(CommunicationProviderEnum::CSQ->value, $result[0]['provider']);
     }
 
     public function testTieBreaksBySmallestIdWhenPriorityMatches(): void
@@ -53,10 +55,10 @@ class ClientProviderRoutingPriorityFunctionalTest extends ProviderFunctionalTest
         $first = $this->createRouting($client, CommunicationProviderEnum::ETECSA->value, saleType: 'recharge');
         $second = $this->createRouting($client, CommunicationProviderEnum::DTONE->value, saleType: 'sale');
 
-        $result = $this->repository()->findActiveProvidersOrderedForClient($client->getId());
+        $result = $this->repository()->findActiveRouteScopesForClient($client->getId());
 
-        $this->assertSame($first->getId(), $result[0]->getId());
-        $this->assertSame($second->getId(), $result[1]->getId());
+        $this->assertSame($first->getId(), $result[0]['id']);
+        $this->assertSame($second->getId(), $result[1]['id']);
     }
 
     public function testIncludesRowsRegardlessOfEnvironmentOrSaleTypeScope(): void
@@ -67,16 +69,36 @@ class ClientProviderRoutingPriorityFunctionalTest extends ProviderFunctionalTest
         // Lista PLANA a propósito: a diferencia de findResolvedFor()
         // (admisión, precedencia por especificidad), este método no filtra
         // por scope — ProviderDispatchResolver recorre TODAS las filas
-        // activas del cliente en orden de prioridad, sin importar a qué
-        // (environment, saleType) estén ligadas.
+        // activas del cliente en PHP, sin importar a qué (environment,
+        // saleType, categoría) estén ligadas.
         $general = $this->createRouting($client, CommunicationProviderEnum::ETECSA->value, priority: 0);
         $scoped = $this->createRouting($client, CommunicationProviderEnum::DTONE->value, $environment, 'recharge', priority: 10);
 
-        $result = $this->repository()->findActiveProvidersOrderedForClient($client->getId());
+        $result = $this->repository()->findActiveRouteScopesForClient($client->getId());
 
         $this->assertCount(2, $result);
-        $this->assertSame($general->getId(), $result[0]->getId());
-        $this->assertSame($scoped->getId(), $result[1]->getId());
+        $this->assertSame($general->getId(), $result[0]['id']);
+        $this->assertSame($scoped->getId(), $result[1]['id']);
+    }
+
+    public function testProjectsFallbackProviderAndServiceCategory(): void
+    {
+        $client = $this->createClient();
+
+        $routing = $this->createRouting(
+            $client,
+            CommunicationProviderEnum::CSQ->value,
+            fallbackProvider: CommunicationProviderEnum::DTONE->value,
+            serviceName: 'Mobile',
+            subserviceName: 'AIRTIME',
+        );
+
+        $result = $this->repository()->findActiveRouteScopesForClient($client->getId());
+
+        $this->assertSame($routing->getId(), $result[0]['id']);
+        $this->assertSame('DTONE', $result[0]['fallbackProvider']);
+        $this->assertSame('Mobile', $result[0]['serviceName']);
+        $this->assertSame('AIRTIME', $result[0]['subserviceName']);
     }
 
     public function testExcludesInactiveRows(): void
@@ -86,10 +108,10 @@ class ClientProviderRoutingPriorityFunctionalTest extends ProviderFunctionalTest
         $active = $this->createRouting($client, CommunicationProviderEnum::ETECSA->value);
         $this->createRouting($client, CommunicationProviderEnum::DTONE->value, isActive: false);
 
-        $result = $this->repository()->findActiveProvidersOrderedForClient($client->getId());
+        $result = $this->repository()->findActiveRouteScopesForClient($client->getId());
 
         $this->assertCount(1, $result);
-        $this->assertSame($active->getId(), $result[0]->getId());
+        $this->assertSame($active->getId(), $result[0]['id']);
     }
 
     public function testCacheIsAutomaticallyInvalidatedWhenARoutingRowChanges(): void
@@ -103,12 +125,12 @@ class ClientProviderRoutingPriorityFunctionalTest extends ProviderFunctionalTest
         $repository = $this->repository();
 
         $this->createRouting($client, CommunicationProviderEnum::ETECSA->value);
-        $this->assertCount(1, $repository->findActiveProvidersOrderedForClient($client->getId()));
+        $this->assertCount(1, $repository->findActiveRouteScopesForClient($client->getId()));
 
         // saleType distinto solo para no chocar con uniq_cpr_scope.
         $this->createRouting($client, CommunicationProviderEnum::DTONE->value, saleType: 'sale');
 
-        $this->assertCount(2, $repository->findActiveProvidersOrderedForClient($client->getId()));
+        $this->assertCount(2, $repository->findActiveRouteScopesForClient($client->getId()));
     }
 
     public function testInvalidateCacheForcesAFreshQuery(): void
@@ -117,10 +139,39 @@ class ClientProviderRoutingPriorityFunctionalTest extends ProviderFunctionalTest
         $repository = $this->repository();
 
         $this->createRouting($client, CommunicationProviderEnum::ETECSA->value);
-        $this->assertCount(1, $repository->findActiveProvidersOrderedForClient($client->getId()));
+        $this->assertCount(1, $repository->findActiveRouteScopesForClient($client->getId()));
 
         $repository->invalidateCache();
 
-        $this->assertCount(1, $repository->findActiveProvidersOrderedForClient($client->getId()));
+        $this->assertCount(1, $repository->findActiveRouteScopesForClient($client->getId()));
+    }
+
+    // ---- uniq_cpr_scope con service_key (Version20260828120000) ----
+
+    public function testTwoActiveRowsForTheSameScopeWithDifferentCategoriesCoexist(): void
+    {
+        $client = $this->createClient();
+
+        $mobile = $this->createRouting($client, CommunicationProviderEnum::CSQ->value, serviceName: 'Mobile', subserviceName: 'AIRTIME');
+        $utilities = $this->createRouting($client, CommunicationProviderEnum::DTONE->value, serviceName: 'Utilities', subserviceName: 'INTERNET');
+
+        $result = $this->repository()->findActiveRouteScopesForClient($client->getId());
+
+        $this->assertCount(2, $result);
+        $this->assertSame(
+            [$mobile->getId(), $utilities->getId()],
+            array_column($result, 'id'),
+        );
+    }
+
+    public function testTheDatabaseRejectsTwoActiveRowsForTheSameScopeAndCategory(): void
+    {
+        $client = $this->createClient();
+
+        $this->createRouting($client, CommunicationProviderEnum::CSQ->value, serviceName: 'Mobile', subserviceName: 'AIRTIME');
+
+        $this->expectException(UniqueConstraintViolationException::class);
+
+        $this->createRouting($client, CommunicationProviderEnum::DTONE->value, serviceName: 'Mobile', subserviceName: 'AIRTIME');
     }
 }

--- a/tests/Functional/Provider/ProviderFunctionalTestCase.php
+++ b/tests/Functional/Provider/ProviderFunctionalTestCase.php
@@ -233,12 +233,17 @@ abstract class ProviderFunctionalTestCase extends FunctionalTestCase
         ?string $saleType = null,
         bool $isActive = true,
         ?int $priority = null,
+        ?string $fallbackProvider = null,
+        ?string $serviceName = null,
+        ?string $subserviceName = null,
     ): ClientProviderRouting {
         $routing = (new ClientProviderRouting())
             ->setClient($client)
             ->setEnvironment($environment)
             ->setSaleType($saleType)
             ->setProvider($provider)
+            ->setFallbackProvider($fallbackProvider)
+            ->setServiceCategory($serviceName, $subserviceName)
             ->setIsActive($isActive);
 
         if ($priority !== null) {

--- a/tests/Provider/PromotionProviderDispatchResolverTest.php
+++ b/tests/Provider/PromotionProviderDispatchResolverTest.php
@@ -69,12 +69,23 @@ class PromotionProviderDispatchResolverTest extends TestCase
         return $account;
     }
 
-    private function routing(string $provider): ClientProviderRouting&MockObject
+    /**
+     * @return array{id:int, provider:?string, fallbackProvider:?string,
+     *   environmentId:?int, saleType:?string, serviceName:?string,
+     *   subserviceName:?string, priority:int}
+     */
+    private function routing(string $provider): array
     {
-        $routing = $this->createMock(ClientProviderRouting::class);
-        $routing->method('getProvider')->willReturn($provider);
-
-        return $routing;
+        return [
+            'id' => 1,
+            'provider' => $provider,
+            'fallbackProvider' => null,
+            'environmentId' => null,
+            'saleType' => null,
+            'serviceName' => null,
+            'subserviceName' => null,
+            'priority' => 100,
+        ];
     }
 
     private function promotion(?CommunicationProduct $defaultProduct): CommunicationPromotions&MockObject
@@ -103,7 +114,7 @@ class PromotionProviderDispatchResolverTest extends TestCase
         $binding->method('getProduct')->willReturn($bound);
         $promotion = $this->promotion(null);
 
-        $this->routingRepo->method('findActiveProvidersOrderedForClient')->willReturn([$this->routing('CSQ')]);
+        $this->routingRepo->method('findActiveRouteScopesForClient')->willReturn([$this->routing('CSQ')]);
         $this->availabilityService->method('canDispatchTo')->willReturn(true);
         $this->promotionBindingRepo = $this->createMock(CommunicationPromotionProviderProductRepository::class);
         $this->promotionBindingRepo->method('findForPromotionAndProvider')
@@ -130,7 +141,7 @@ class PromotionProviderDispatchResolverTest extends TestCase
         $default = $this->product('ETECSA', 'ref-default');
         $promotion = $this->promotion($default);
 
-        $this->routingRepo->method('findActiveProvidersOrderedForClient')->willReturn([$this->routing('ETECSA')]);
+        $this->routingRepo->method('findActiveRouteScopesForClient')->willReturn([$this->routing('ETECSA')]);
         $this->availabilityService->method('canDispatchTo')->willReturn(true);
 
         $selected = $this->resolver->select($account, $promotion);
@@ -147,7 +158,7 @@ class PromotionProviderDispatchResolverTest extends TestCase
 
         // El único candidato es CSQ, pero el producto "de origen" es de
         // ETECSA — sin vínculo explícito, CSQ no tiene nada que ofrecer.
-        $this->routingRepo->method('findActiveProvidersOrderedForClient')->willReturn([$this->routing('CSQ')]);
+        $this->routingRepo->method('findActiveRouteScopesForClient')->willReturn([$this->routing('CSQ')]);
         $this->availabilityService->method('canDispatchTo')->willReturn(true);
 
         $this->expectException(MyCurrentException::class);
@@ -163,7 +174,7 @@ class PromotionProviderDispatchResolverTest extends TestCase
         $binding->method('getProduct')->willReturn($bound);
         $promotion = $this->promotion(null);
 
-        $this->routingRepo->method('findActiveProvidersOrderedForClient')
+        $this->routingRepo->method('findActiveRouteScopesForClient')
             ->willReturn([$this->routing('CSQ'), $this->routing('DTONE')]);
         $this->availabilityService->method('canDispatchTo')
             ->willReturnCallback(fn ($provider) => $provider !== 'CSQ');
@@ -190,7 +201,7 @@ class PromotionProviderDispatchResolverTest extends TestCase
         $binding->method('getProduct')->willReturn($bound);
         $promotion = $this->promotion(null);
 
-        $this->routingRepo->method('findActiveProvidersOrderedForClient')
+        $this->routingRepo->method('findActiveRouteScopesForClient')
             ->willReturn([$this->routing('CSQ'), $this->routing('DTONE')]);
         $this->availabilityService->method('canDispatchTo')->willReturn(true);
         $this->promotionBindingRepo = $this->createMock(CommunicationPromotionProviderProductRepository::class);
@@ -216,7 +227,7 @@ class PromotionProviderDispatchResolverTest extends TestCase
         $binding->method('getProduct')->willReturn($bound);
         $promotion = $this->promotion(null);
 
-        $this->routingRepo->method('findActiveProvidersOrderedForClient')->willReturn([$this->routing('CSQ')]);
+        $this->routingRepo->method('findActiveRouteScopesForClient')->willReturn([$this->routing('CSQ')]);
         $this->availabilityService->method('canDispatchTo')->willReturn(true);
         $this->promotionBindingRepo = $this->createMock(CommunicationPromotionProviderProductRepository::class);
         $this->promotionBindingRepo->method('findForPromotionAndProvider')->willReturn($binding);
@@ -237,7 +248,7 @@ class PromotionProviderDispatchResolverTest extends TestCase
         $account = $this->account(1);
         $promotion = $this->promotion(null);
 
-        $this->routingRepo->method('findActiveProvidersOrderedForClient')->willReturn([$this->routing('CSQ')]);
+        $this->routingRepo->method('findActiveRouteScopesForClient')->willReturn([$this->routing('CSQ')]);
         $this->availabilityService->method('canDispatchTo')->willReturn(false);
 
         try {
@@ -265,7 +276,7 @@ class PromotionProviderDispatchResolverTest extends TestCase
             $this->sysConfigRepo,
         );
 
-        $this->routingRepo->expects($this->never())->method('findActiveProvidersOrderedForClient');
+        $this->routingRepo->expects($this->never())->method('findActiveRouteScopesForClient');
         $this->availabilityService->method('canDispatchTo')->willReturn(true);
 
         $selected = $this->resolver->select($account, $promotion);

--- a/tests/Provider/ProviderDispatchResolverTest.php
+++ b/tests/Provider/ProviderDispatchResolverTest.php
@@ -4,7 +4,6 @@ namespace App\Tests\Provider;
 
 use App\Entity\Account;
 use App\Entity\Client;
-use App\Entity\ClientProviderRouting;
 use App\Entity\CommunicationPackage;
 use App\Entity\CommunicationPackageProviderProduct;
 use App\Entity\CommunicationProduct;
@@ -27,8 +26,10 @@ use PHPUnit\Framework\TestCase;
  * @covers \App\Provider\ProviderDispatchResolver
  *
  * A diferencia de ProviderResolver (admisión: un solo proveedor resuelto
- * por especificidad), este resuelve DESPACHO: recorre la lista de
- * prioridad completa hasta encontrar un proveedor disponible con un
+ * por especificidad), este resuelve DESPACHO: filtra las filas de
+ * ClientProviderRouting aplicables a esta venta (entorno/tipo de
+ * venta/categoría), las ordena por especificidad y recorre proveedor +
+ * fallbackProvider de cada una hasta encontrar uno disponible con un
  * producto que cubra la tupla — el camino "con promoción" es Fase 5, no
  * cubierto aquí.
  */
@@ -69,24 +70,50 @@ class ProviderDispatchResolverTest extends TestCase
             });
     }
 
-    private function account(int $clientId): Account&MockObject
+    private function account(int $clientId, ?int $environmentId = 10): Account&MockObject
     {
         $client = $this->createMock(Client::class);
         $client->method('getId')->willReturn($clientId);
 
+        $environment = $this->createMock(Environment::class);
+        $environment->method('getId')->willReturn($environmentId);
+
         $account = $this->createMock(Account::class);
         $account->method('getClient')->willReturn($client);
-        $account->method('getEnvironment')->willReturn($this->createMock(Environment::class));
+        $account->method('getEnvironment')->willReturn($environment);
 
         return $account;
     }
 
-    private function routing(string $provider): ClientProviderRouting&MockObject
-    {
-        $routing = $this->createMock(ClientProviderRouting::class);
-        $routing->method('getProvider')->willReturn($provider);
-
-        return $routing;
+    /**
+     * Fila escalar tal como la devuelve
+     * ClientProviderRoutingRepository::findActiveRouteScopesForClient() —
+     * null en cualquier dimensión = comodín, aplica siempre.
+     *
+     * @return array{id:int, provider:?string, fallbackProvider:?string,
+     *   environmentId:?int, saleType:?string, serviceName:?string,
+     *   subserviceName:?string, priority:int}
+     */
+    private function routeScope(
+        string $provider,
+        ?string $fallbackProvider = null,
+        ?int $environmentId = null,
+        ?string $saleType = null,
+        ?string $serviceName = null,
+        ?string $subserviceName = null,
+        int $priority = 100,
+        int $id = 1,
+    ): array {
+        return [
+            'id' => $id,
+            'provider' => $provider,
+            'fallbackProvider' => $fallbackProvider,
+            'environmentId' => $environmentId,
+            'saleType' => $saleType,
+            'serviceName' => $serviceName,
+            'subserviceName' => $subserviceName,
+            'priority' => $priority,
+        ];
     }
 
     private function package(): CommunicationPackage
@@ -96,6 +123,16 @@ class ProviderDispatchResolverTest extends TestCase
             ->setDescription('Paquete')
             ->setDestinationAmount(500.0)
             ->setDestinationCurrency('CUP');
+    }
+
+    private function packageWithService(string $name, ?string $subserviceName = null): CommunicationPackage
+    {
+        $shape = ['name' => $name];
+        if ($subserviceName !== null) {
+            $shape['subservice'] = ['name' => $subserviceName];
+        }
+
+        return $this->package()->setService($shape);
     }
 
     /**
@@ -114,8 +151,8 @@ class ProviderDispatchResolverTest extends TestCase
         $product = $this->createMock(CommunicationProduct::class);
         $product->method('getExternalRef')->willReturn('ref-1');
 
-        $this->routingRepo->method('findActiveProvidersOrderedForClient')
-            ->willReturn([$this->routing('CSQ'), $this->routing('DTONE')]);
+        $this->routingRepo->method('findActiveRouteScopesForClient')
+            ->willReturn([$this->routeScope('CSQ', priority: 0, id: 1), $this->routeScope('DTONE', priority: 10, id: 2)]);
         $this->availabilityService->method('canDispatchTo')->willReturn(true);
         $this->productRepository->method('findMatchingDestination')
             ->willReturnCallback(fn ($amount, $currency, $env, $provider) => $provider === 'CSQ' ? [$product] : []);
@@ -137,7 +174,7 @@ class ProviderDispatchResolverTest extends TestCase
         $binding = $this->createMock(CommunicationPackageProviderProduct::class);
         $binding->method('getProduct')->willReturn($bound);
 
-        $this->routingRepo->method('findActiveProvidersOrderedForClient')->willReturn([$this->routing('CSQ')]);
+        $this->routingRepo->method('findActiveRouteScopesForClient')->willReturn([$this->routeScope('CSQ')]);
         $this->availabilityService->method('canDispatchTo')->willReturn(true);
         $this->packageBindingRepo = $this->createMock(CommunicationPackageProviderProductRepository::class);
         $this->packageBindingRepo->method('findForPackageAndProvider')
@@ -169,7 +206,7 @@ class ProviderDispatchResolverTest extends TestCase
         $auto = $this->createMock(CommunicationProduct::class);
         $auto->method('getExternalRef')->willReturn('ref-auto');
 
-        $this->routingRepo->method('findActiveProvidersOrderedForClient')->willReturn([$this->routing('CSQ')]);
+        $this->routingRepo->method('findActiveRouteScopesForClient')->willReturn([$this->routeScope('CSQ')]);
         $this->availabilityService->method('canDispatchTo')->willReturn(true);
         $this->packageBindingRepo = $this->createMock(CommunicationPackageProviderProductRepository::class);
         $this->packageBindingRepo->method('findForPackageAndProvider')->willReturn($binding);
@@ -201,7 +238,7 @@ class ProviderDispatchResolverTest extends TestCase
         $auto = $this->createMock(CommunicationProduct::class);
         $auto->method('getExternalRef')->willReturn('ref-auto');
 
-        $this->routingRepo->method('findActiveProvidersOrderedForClient')->willReturn([$this->routing('CSQ')]);
+        $this->routingRepo->method('findActiveRouteScopesForClient')->willReturn([$this->routeScope('CSQ')]);
         $this->availabilityService->method('canDispatchTo')->willReturn(true);
         $this->packageBindingRepo = $this->createMock(CommunicationPackageProviderProductRepository::class);
         $this->packageBindingRepo->method('findForPackageAndProvider')->willReturn($binding);
@@ -227,8 +264,8 @@ class ProviderDispatchResolverTest extends TestCase
         $product = $this->createMock(CommunicationProduct::class);
         $product->method('getExternalRef')->willReturn('ref-dtone');
 
-        $this->routingRepo->method('findActiveProvidersOrderedForClient')
-            ->willReturn([$this->routing('CSQ'), $this->routing('DTONE')]);
+        $this->routingRepo->method('findActiveRouteScopesForClient')
+            ->willReturn([$this->routeScope('CSQ', priority: 0, id: 1), $this->routeScope('DTONE', priority: 10, id: 2)]);
         $this->availabilityService->method('canDispatchTo')
             ->willReturnCallback(fn ($provider) => $provider !== 'CSQ');
         $this->productRepository->method('findMatchingDestination')->willReturn([$product]);
@@ -245,8 +282,8 @@ class ProviderDispatchResolverTest extends TestCase
         $product = $this->createMock(CommunicationProduct::class);
         $product->method('getExternalRef')->willReturn('ref-dtone');
 
-        $this->routingRepo->method('findActiveProvidersOrderedForClient')
-            ->willReturn([$this->routing('CSQ'), $this->routing('DTONE')]);
+        $this->routingRepo->method('findActiveRouteScopesForClient')
+            ->willReturn([$this->routeScope('CSQ', priority: 0, id: 1), $this->routeScope('DTONE', priority: 10, id: 2)]);
         $this->availabilityService->method('canDispatchTo')->willReturn(true);
         $this->productRepository->method('findMatchingDestination')
             ->willReturnCallback(fn ($amount, $currency, $env, $provider) => $provider === 'DTONE' ? [$product] : []);
@@ -261,7 +298,7 @@ class ProviderDispatchResolverTest extends TestCase
         $account = $this->account(1);
         $package = $this->package();
 
-        $this->routingRepo->method('findActiveProvidersOrderedForClient')->willReturn([$this->routing('CSQ')]);
+        $this->routingRepo->method('findActiveRouteScopesForClient')->willReturn([$this->routeScope('CSQ')]);
         $this->availabilityService->method('canDispatchTo')->willReturn(false);
 
         try {
@@ -278,7 +315,7 @@ class ProviderDispatchResolverTest extends TestCase
         $account = $this->account(1);
         $package = $this->package();
 
-        $this->routingRepo->method('findActiveProvidersOrderedForClient')->willReturn([$this->routing('CSQ')]);
+        $this->routingRepo->method('findActiveRouteScopesForClient')->willReturn([$this->routeScope('CSQ')]);
         $this->availabilityService->method('canDispatchTo')->willReturn(true);
         $this->productRepository->method('findMatchingDestination')->willReturn([]);
 
@@ -306,7 +343,7 @@ class ProviderDispatchResolverTest extends TestCase
             $this->sysConfigRepo,
         );
 
-        $this->routingRepo->expects($this->never())->method('findActiveProvidersOrderedForClient');
+        $this->routingRepo->expects($this->never())->method('findActiveRouteScopesForClient');
         $this->availabilityService->method('canDispatchTo')->willReturn(true);
         $this->productRepository->method('findMatchingDestination')->willReturn([$product]);
 
@@ -325,7 +362,7 @@ class ProviderDispatchResolverTest extends TestCase
         $product = $this->createMock(CommunicationProduct::class);
         $product->method('getExternalRef')->willReturn('ref-default');
 
-        $this->routingRepo->method('findActiveProvidersOrderedForClient')->willReturn([]);
+        $this->routingRepo->method('findActiveRouteScopesForClient')->willReturn([]);
         $this->availabilityService->method('canDispatchTo')->willReturn(true);
         $this->productRepository->method('findMatchingDestination')->willReturn([$product]);
 
@@ -339,7 +376,7 @@ class ProviderDispatchResolverTest extends TestCase
         $account = $this->account(1);
         $package = $this->promotionalPackage();
 
-        $this->routingRepo->method('findActiveProvidersOrderedForClient')->willReturn([$this->routing('CSQ')]);
+        $this->routingRepo->method('findActiveRouteScopesForClient')->willReturn([$this->routeScope('CSQ')]);
         $this->availabilityService->method('canDispatchTo')->willReturn(true);
         // Sin vínculo explícito (setUp ya deja findForPackageAndProvider en null).
         $this->productRepository->expects($this->never())->method('findMatchingDestination');
@@ -360,8 +397,8 @@ class ProviderDispatchResolverTest extends TestCase
         $binding = $this->createMock(CommunicationPackageProviderProduct::class);
         $binding->method('getProduct')->willReturn($bound);
 
-        $this->routingRepo->method('findActiveProvidersOrderedForClient')
-            ->willReturn([$this->routing('CSQ'), $this->routing('DTONE')]);
+        $this->routingRepo->method('findActiveRouteScopesForClient')
+            ->willReturn([$this->routeScope('CSQ', priority: 0, id: 1), $this->routeScope('DTONE', priority: 10, id: 2)]);
         $this->availabilityService->method('canDispatchTo')->willReturn(true);
         $this->packageBindingRepo = $this->createMock(CommunicationPackageProviderProductRepository::class);
         $this->packageBindingRepo->method('findForPackageAndProvider')
@@ -393,7 +430,7 @@ class ProviderDispatchResolverTest extends TestCase
         $binding = $this->createMock(CommunicationPackageProviderProduct::class);
         $binding->method('getProduct')->willReturn($bound);
 
-        $this->routingRepo->method('findActiveProvidersOrderedForClient')->willReturn([$this->routing('ETECSA')]);
+        $this->routingRepo->method('findActiveRouteScopesForClient')->willReturn([$this->routeScope('ETECSA')]);
         $this->availabilityService->method('canDispatchTo')->willReturn(true);
         $this->packageBindingRepo = $this->createMock(CommunicationPackageProviderProductRepository::class);
         $this->packageBindingRepo->method('findForPackageAndProvider')->willReturn($binding);
@@ -409,5 +446,205 @@ class ProviderDispatchResolverTest extends TestCase
         $selected = $this->resolver->select($account, $package);
 
         $this->assertSame('ref-bound', $selected->externalRef);
+    }
+
+    // ---- Fase de categoría/scope (nuevo) ----
+
+    public function testDiscardsARowScopedToAnotherEnvironment(): void
+    {
+        $account = $this->account(1, environmentId: 10);
+        $package = $this->package();
+        $product = $this->createMock(CommunicationProduct::class);
+        $product->method('getExternalRef')->willReturn('ref-default-env');
+
+        $this->routingRepo->method('findActiveRouteScopesForClient')
+            ->willReturn([$this->routeScope('CSQ', environmentId: 99)]);
+        $this->availabilityService->method('canDispatchTo')->willReturn(true);
+        $this->productRepository->method('findMatchingDestination')->willReturn([$product]);
+
+        // La única fila no aplica (otro entorno) → cae al proveedor por defecto.
+        $selected = $this->resolver->select($account, $package);
+
+        $this->assertSame(CommunicationProviderEnum::ETECSA, $selected->provider);
+    }
+
+    public function testDiscardsARowScopedToAnotherSaleType(): void
+    {
+        $account = $this->account(1);
+        $package = $this->package();
+        $product = $this->createMock(CommunicationProduct::class);
+        $product->method('getExternalRef')->willReturn('ref-default');
+        // ProductSaleTypeMatcher exige isMobileOrInternetService() para
+        // considerar un producto elegible como 'recharge'.
+        $product->method('isMobileOrInternetService')->willReturn(true);
+
+        $this->routingRepo->method('findActiveRouteScopesForClient')
+            ->willReturn([$this->routeScope('CSQ', saleType: 'sale')]);
+        $this->availabilityService->method('canDispatchTo')->willReturn(true);
+        $this->productRepository->method('findMatchingDestination')->willReturn([$product]);
+
+        $selected = $this->resolver->select($account, $package, 'recharge');
+
+        $this->assertSame(CommunicationProviderEnum::ETECSA, $selected->provider);
+    }
+
+    public function testDiscardsARowScopedToAnotherServiceCategory(): void
+    {
+        $account = $this->account(1);
+        $package = $this->packageWithService('Utilities', 'INTERNET');
+        $product = $this->createMock(CommunicationProduct::class);
+        $product->method('getExternalRef')->willReturn('ref-default');
+
+        $this->routingRepo->method('findActiveRouteScopesForClient')
+            ->willReturn([$this->routeScope('CSQ', serviceName: 'Mobile', subserviceName: 'AIRTIME')]);
+        $this->availabilityService->method('canDispatchTo')->willReturn(true);
+        $this->productRepository->method('findMatchingDestination')->willReturn([$product]);
+
+        $selected = $this->resolver->select($account, $package);
+
+        $this->assertSame(CommunicationProviderEnum::ETECSA, $selected->provider);
+    }
+
+    public function testAServiceOnlyRowMatchesAnySubserviceOfThatCategory(): void
+    {
+        $account = $this->account(1);
+        $package = $this->packageWithService('Mobile', 'DATA');
+        $product = $this->createMock(CommunicationProduct::class);
+        $product->method('getExternalRef')->willReturn('ref-csq');
+
+        $this->routingRepo->method('findActiveRouteScopesForClient')
+            ->willReturn([$this->routeScope('CSQ', serviceName: 'Mobile')]);
+        $this->availabilityService->method('canDispatchTo')->willReturn(true);
+        $this->productRepository->method('findMatchingDestination')->willReturn([$product]);
+
+        $selected = $this->resolver->select($account, $package);
+
+        $this->assertSame(CommunicationProviderEnum::CSQ, $selected->provider);
+    }
+
+    public function testTheMostSpecificApplicableRowWinsOverAWildcardRow(): void
+    {
+        $account = $this->account(1, environmentId: 10);
+        $package = $this->packageWithService('Mobile', 'AIRTIME');
+        $specificProduct = $this->createMock(CommunicationProduct::class);
+        $specificProduct->method('getExternalRef')->willReturn('ref-csq');
+
+        // Comodín total, creada primero (id menor) — si el orden fuera solo
+        // por id/priority, ganaría esta.
+        $wildcard = $this->routeScope('ETECSA', priority: 0, id: 1);
+        // Específica a environment+service+subservice, creada después.
+        $specific = $this->routeScope('CSQ', environmentId: 10, serviceName: 'Mobile', subserviceName: 'AIRTIME', priority: 100, id: 2);
+
+        $this->routingRepo->method('findActiveRouteScopesForClient')->willReturn([$wildcard, $specific]);
+        $this->availabilityService->method('canDispatchTo')->willReturn(true);
+        $this->productRepository->method('findMatchingDestination')
+            ->willReturnCallback(fn ($amount, $currency, $env, $provider) => $provider === 'CSQ' ? [$specificProduct] : []);
+
+        $selected = $this->resolver->select($account, $package);
+
+        $this->assertSame(CommunicationProviderEnum::CSQ, $selected->provider);
+    }
+
+    public function testTiesInSpecificityKeepPriorityThenIdOrder(): void
+    {
+        $account = $this->account(1);
+        $package = $this->packageWithService('Mobile', 'AIRTIME');
+        $product = $this->createMock(CommunicationProduct::class);
+        $product->method('getExternalRef')->willReturn('ref-dtone');
+
+        // Misma especificidad (ambas comodín total) — debe respetarse el
+        // orden priority ASC, id ASC que ya trae el repositorio.
+        $first = $this->routeScope('CSQ', priority: 0, id: 1);
+        $second = $this->routeScope('DTONE', priority: 10, id: 2);
+
+        $this->routingRepo->method('findActiveRouteScopesForClient')->willReturn([$first, $second]);
+        $this->availabilityService->method('canDispatchTo')
+            ->willReturnCallback(fn ($provider) => $provider !== 'CSQ');
+        $this->productRepository->method('findMatchingDestination')->willReturn([$product]);
+
+        $selected = $this->resolver->select($account, $package);
+
+        $this->assertSame(CommunicationProviderEnum::DTONE, $selected->provider);
+    }
+
+    // ---- Fallback provider (nuevo) ----
+
+    public function testFallbackProviderIsTriedAfterItsOwnPrimaryProvider(): void
+    {
+        $account = $this->account(1);
+        $package = $this->package();
+        $product = $this->createMock(CommunicationProduct::class);
+        $product->method('getExternalRef')->willReturn('ref-fallback');
+
+        $this->routingRepo->method('findActiveRouteScopesForClient')
+            ->willReturn([$this->routeScope('CSQ', fallbackProvider: 'DTONE')]);
+        $this->availabilityService->method('canDispatchTo')
+            ->willReturnCallback(fn ($provider) => $provider !== 'CSQ');
+        $this->productRepository->method('findMatchingDestination')->willReturn([$product]);
+
+        $selected = $this->resolver->select($account, $package);
+
+        $this->assertSame(CommunicationProviderEnum::DTONE, $selected->provider);
+    }
+
+    public function testFallbackProviderDuplicatedAsAnotherRowsPrimaryIsNotTriedTwice(): void
+    {
+        $account = $this->account(1);
+        $package = $this->package();
+        $product = $this->createMock(CommunicationProduct::class);
+        $product->method('getExternalRef')->willReturn('ref-dtone');
+
+        // CSQ→DTONE como fallback, y DTONE también aparece como primario de
+        // otra fila — DTONE debe intentarse una sola vez.
+        $this->routingRepo->method('findActiveRouteScopesForClient')
+            ->willReturn([
+                $this->routeScope('CSQ', fallbackProvider: 'DTONE', priority: 0, id: 1),
+                $this->routeScope('DTONE', priority: 10, id: 2),
+            ]);
+        $callCount = 0;
+        $this->availabilityService->method('canDispatchTo')
+            ->willReturnCallback(function ($provider) use (&$callCount) {
+                $callCount++;
+
+                return $provider !== 'CSQ';
+            });
+        $this->productRepository->method('findMatchingDestination')->willReturn([$product]);
+
+        $selected = $this->resolver->select($account, $package);
+
+        $this->assertSame(CommunicationProviderEnum::DTONE, $selected->provider);
+        // CSQ, luego DTONE — nunca una tercera llamada repitiendo DTONE.
+        $this->assertSame(2, $callCount);
+    }
+
+    public function testSelectExcludingSkipsAnAlreadyTriedProviderAndReturnsNullInsteadOfThrowing(): void
+    {
+        $account = $this->account(1);
+        $package = $this->package();
+
+        $this->routingRepo->method('findActiveRouteScopesForClient')->willReturn([$this->routeScope('CSQ')]);
+        $this->availabilityService->method('canDispatchTo')->willReturn(true);
+
+        $selected = $this->resolver->selectExcluding($account, $package, null, [CommunicationProviderEnum::CSQ]);
+
+        $this->assertNull($selected);
+    }
+
+    public function testSelectExcludingFindsTheFallbackWhenThePrimaryIsExcluded(): void
+    {
+        $account = $this->account(1);
+        $package = $this->package();
+        $product = $this->createMock(CommunicationProduct::class);
+        $product->method('getExternalRef')->willReturn('ref-fallback');
+
+        $this->routingRepo->method('findActiveRouteScopesForClient')
+            ->willReturn([$this->routeScope('CSQ', fallbackProvider: 'DTONE')]);
+        $this->availabilityService->method('canDispatchTo')->willReturn(true);
+        $this->productRepository->method('findMatchingDestination')->willReturn([$product]);
+
+        $selected = $this->resolver->selectExcluding($account, $package, null, [CommunicationProviderEnum::CSQ]);
+
+        $this->assertNotNull($selected);
+        $this->assertSame(CommunicationProviderEnum::DTONE, $selected->provider);
     }
 }

--- a/tests/Provider/TransactionStatusTest.php
+++ b/tests/Provider/TransactionStatusTest.php
@@ -175,6 +175,85 @@ class TransactionStatusTest extends TestCase
         $this->assertSame(['count' => 1], $envelope['retry']);
     }
 
+    // ---- carryRetryBlock / failoverFromOf ----
+
+    /**
+     * fromDispatch()/fromStatus() arman un sobre nuevo desde cero — sin
+     * carryRetryBlock(), un segundo intento de despacho perdería el
+     * marcador de failover del intento anterior y el "un solo salto por
+     * venta" de SaleProviderFailoverService dejaría de cumplirse.
+     */
+    public function testCarryRetryBlockPreservesThePreviousRetryBlockWhenTheNewEnvelopeHasNone(): void
+    {
+        $previous = TransactionStatus::withRetry(
+            TransactionStatus::fromDispatch(new ProviderDispatchResult(outcome: ProviderOutcomeEnum::REJECTED), 'CSQ'),
+            ProviderOutcomeEnum::RETRYABLE,
+            'INTERNAL_PROVIDER_FAILOVER',
+            'Provider rejected',
+            ['failoverFrom' => 'CSQ', 'failoverTo' => 'DTONE'],
+        );
+
+        $new = TransactionStatus::fromDispatch(new ProviderDispatchResult(outcome: ProviderOutcomeEnum::REJECTED), 'DTONE');
+        $carried = TransactionStatus::carryRetryBlock($previous, $new);
+
+        $this->assertSame(['failoverFrom' => 'CSQ', 'failoverTo' => 'DTONE'], $carried['retry']);
+        // El resto del sobre nuevo (provider, outcome) no se toca.
+        $this->assertSame('DTONE', $carried['provider']);
+    }
+
+    public function testCarryRetryBlockDoesNotOverwriteARetryBlockAlreadyPresentInTheNewEnvelope(): void
+    {
+        $previous = TransactionStatus::withRetry(
+            TransactionStatus::fromDispatch(new ProviderDispatchResult(outcome: ProviderOutcomeEnum::REJECTED), 'CSQ'),
+            ProviderOutcomeEnum::RETRYABLE,
+            'INTERNAL_PROVIDER_FAILOVER',
+            'Provider rejected',
+            ['failoverFrom' => 'CSQ', 'failoverTo' => 'DTONE'],
+        );
+
+        $new = TransactionStatus::withRetry(
+            TransactionStatus::fromDispatch(new ProviderDispatchResult(outcome: ProviderOutcomeEnum::RETRYABLE), 'DTONE'),
+            ProviderOutcomeEnum::RETRYABLE,
+            'INTERNAL_GATEWAY_NOT_FOUND_RETRY',
+            null,
+            ['count' => 1],
+        );
+
+        $carried = TransactionStatus::carryRetryBlock($previous, $new);
+
+        $this->assertSame(['count' => 1], $carried['retry']);
+    }
+
+    public function testCarryRetryBlockIsANoOpWhenNeitherEnvelopeHasARetryBlock(): void
+    {
+        $previous = TransactionStatus::fromDispatch(new ProviderDispatchResult(outcome: ProviderOutcomeEnum::ACCEPTED), 'CSQ');
+        $new = TransactionStatus::fromDispatch(new ProviderDispatchResult(outcome: ProviderOutcomeEnum::ACCEPTED), 'CSQ');
+
+        $carried = TransactionStatus::carryRetryBlock($previous, $new);
+
+        $this->assertArrayNotHasKey('retry', $carried);
+    }
+
+    public function testFailoverFromOfReturnsNullWithoutARetryBlock(): void
+    {
+        $status = TransactionStatus::fromDispatch(new ProviderDispatchResult(outcome: ProviderOutcomeEnum::ACCEPTED), 'CSQ');
+
+        $this->assertNull(TransactionStatus::failoverFromOf($status));
+    }
+
+    public function testFailoverFromOfReadsTheMarker(): void
+    {
+        $status = TransactionStatus::withRetry(
+            TransactionStatus::fromDispatch(new ProviderDispatchResult(outcome: ProviderOutcomeEnum::REJECTED), 'CSQ'),
+            ProviderOutcomeEnum::RETRYABLE,
+            'INTERNAL_PROVIDER_FAILOVER',
+            'Provider rejected',
+            ['failoverFrom' => 'CSQ', 'failoverTo' => 'DTONE'],
+        );
+
+        $this->assertSame('CSQ', TransactionStatus::failoverFromOf($status));
+    }
+
     // ---- lectura: isV2 / rawOf / outcomeOf ----
 
     public function testIsV2IsFalseForEmptyArray(): void

--- a/tests/Service/CommunicationSaleServiceCsqCompletedDispatchTest.php
+++ b/tests/Service/CommunicationSaleServiceCsqCompletedDispatchTest.php
@@ -133,6 +133,7 @@ class CommunicationSaleServiceCsqCompletedDispatchTest extends TestCase
             $this->packageCatalogResolver,
             $this->createMock(\App\Provider\ProviderDispatchResolver::class),
             $this->createMock(\App\Provider\PromotionProviderDispatchResolver::class),
+            $this->createMock(\App\Service\Provider\SaleProviderFailoverService::class),
         );
 
         $this->saleRecharge = $this->buildPendingCsqRecharge();

--- a/tests/Service/CommunicationSaleServiceFailoverTest.php
+++ b/tests/Service/CommunicationSaleServiceFailoverTest.php
@@ -2,15 +2,17 @@
 
 namespace App\Tests\Service;
 
+use App\DTO\AccountBalanceDto;
 use App\Entity\Account;
 use App\Entity\Client;
 use App\Entity\CommunicationPackage;
 use App\Entity\CommunicationSaleRecharge;
 use App\Entity\Environment;
 use App\Enums\CommunicationStateEnum;
-use App\Provider\DTOne\DTOneCommunicationProvider;
-use App\Provider\DTOne\DTOneHttpClient;
-use App\Provider\DTOne\DTOneStatusMapper;
+use App\Message\SaleRechargeMessage;
+use App\Provider\Csq\CsqCommunicationProvider;
+use App\Provider\Csq\CsqHttpClient;
+use App\Provider\Csq\CsqStatusMapper;
 use App\Provider\ProviderContextFactory;
 use App\Provider\ProviderRegistry;
 use App\Provider\ProviderResolver;
@@ -27,7 +29,7 @@ use App\Service\Pricing\PackageCatalogResolver;
 use App\Service\Pricing\PackageOfferSourceEnum;
 use App\Service\Pricing\ResolvedPackageOffer;
 use App\Service\Provider\ProviderAvailabilityService;
-use App\DTO\AccountBalanceDto;
+use App\Service\Provider\SaleProviderFailoverService;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -38,6 +40,7 @@ use Psr\Log\NullLogger;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -45,20 +48,23 @@ use Symfony\Component\Serializer\SerializerInterface;
 /**
  * @covers \App\Service\CommunicationSaleService::invokeRechargeCommunication
  *
- * Documentado por DTOne (https://developers.dtone.com/reference/sandbox):
- * su sandbox simula el resultado según los ÚLTIMOS 3 DÍGITOS del número de
- * destino ("100"/"200"/"300" = COMPLETED sin PIN), no un número dummy fijo
- * como ETECSA/CSQ — por eso aquí se reemplaza solo el sufijo, conservando
- * el resto del número real del cliente.
+ * Cuando el proveedor rechaza una recarga (REJECTED, no UNKNOWN — ver
+ * ProviderOutcomeEnum), CommunicationSaleService intenta el proveedor
+ * secundario vía SaleProviderFailoverService ANTES de resolver la venta
+ * como REJECTED — mismo escenario de CommunicationSaleServiceCsqCompletedDispatchTest::testDoesNotCreateBalanceWhenCsqRejectsTheAmount(),
+ * pero con el failover activado.
  */
-class CommunicationSaleServiceDTOnePhoneSwapTest extends TestCase
+class CommunicationSaleServiceFailoverTest extends TestCase
 {
     private EntityManagerInterface&MockObject $em;
     private Connection&MockObject $connection;
     private BalanceService&MockObject $balanceService;
+    private HistoricalSaleService&MockObject $historicalSaleService;
     private ProviderAvailabilityService&MockObject $availabilityService;
-    private DTOneHttpClient&MockObject $dtoneClient;
+    private CsqHttpClient&MockObject $csqClient;
     private PackageCatalogResolver&MockObject $packageCatalogResolver;
+    private SaleProviderFailoverService&MockObject $failoverService;
+    private MessageBusInterface&MockObject $messageBus;
     private CommunicationSaleService $service;
     private CommunicationSaleRecharge $saleRecharge;
 
@@ -74,17 +80,22 @@ class CommunicationSaleServiceDTOnePhoneSwapTest extends TestCase
 
         $security = $this->createMock(Security::class);
         $parameters = $this->createMock(ParameterBagInterface::class);
+        $parameters->method('get')->willReturnMap([
+            ['app.csqPhoneNumber', '53500000'],
+        ]);
         $mailer = $this->createMock(MailerInterface::class);
         $logger = $this->createMock(LoggerInterface::class);
         $passwordHasher = $this->createMock(UserPasswordHasherInterface::class);
+        $environmentRepository = $this->createMock(EnvironmentRepository::class);
         $sysConfigRepo = $this->createMock(SysConfigRepository::class);
         $serializer = $this->createMock(SerializerInterface::class);
-        $messageBus = $this->createMock(MessageBusInterface::class);
-        $historicalSaleService = $this->createMock(HistoricalSaleService::class);
+        $this->messageBus = $this->createMock(MessageBusInterface::class);
+        $this->historicalSaleService = $this->createMock(HistoricalSaleService::class);
         $this->balanceService = $this->createMock(BalanceService::class);
         $notificationCenter = $this->createMock(NotificationCenterService::class);
         $this->availabilityService = $this->createMock(ProviderAvailabilityService::class);
         $configureSequence = $this->createMock(ConfigureSequenceService::class);
+        $this->failoverService = $this->createMock(SaleProviderFailoverService::class);
 
         $this->packageCatalogResolver = $this->createMock(PackageCatalogResolver::class);
 
@@ -92,9 +103,9 @@ class CommunicationSaleServiceDTOnePhoneSwapTest extends TestCase
         $providerResolver = new ProviderResolver($sysConfigRepo, $routingRepo, new NullLogger());
         $providerContextFactory = new ProviderContextFactory($providerResolver);
 
-        $this->dtoneClient = $this->createMock(DTOneHttpClient::class);
-        $dtoneProvider = new DTOneCommunicationProvider($this->dtoneClient, new DTOneStatusMapper(), new NullLogger());
-        $providerRegistry = new ProviderRegistry([$dtoneProvider]);
+        $this->csqClient = $this->createMock(CsqHttpClient::class);
+        $csqProvider = new CsqCommunicationProvider($this->csqClient, new CsqStatusMapper(), new NullLogger());
+        $providerRegistry = new ProviderRegistry([$csqProvider]);
 
         $this->service = new CommunicationSaleService(
             $this->em,
@@ -103,24 +114,25 @@ class CommunicationSaleServiceDTOnePhoneSwapTest extends TestCase
             $mailer,
             $logger,
             $passwordHasher,
-            $this->createMock(EnvironmentRepository::class),
+            $environmentRepository,
             $sysConfigRepo,
             $serializer,
             $providerRegistry,
             $providerResolver,
             $providerContextFactory,
             $configureSequence,
-            $messageBus,
-            $historicalSaleService,
+            $this->messageBus,
+            $this->historicalSaleService,
             $this->balanceService,
             $notificationCenter,
             $this->availabilityService,
             $this->packageCatalogResolver,
             $this->createMock(\App\Provider\ProviderDispatchResolver::class),
             $this->createMock(\App\Provider\PromotionProviderDispatchResolver::class),
-            $this->createMock(\App\Service\Provider\SaleProviderFailoverService::class),
+            $this->failoverService,
         );
 
+        $this->saleRecharge = $this->buildPendingCsqRecharge();
     }
 
     private function assignId(object $entity, int $id): void
@@ -130,7 +142,7 @@ class CommunicationSaleServiceDTOnePhoneSwapTest extends TestCase
         $property->setValue($entity, $id);
     }
 
-    private function buildPendingDtoneRecharge(string $phoneNumber): CommunicationSaleRecharge
+    private function buildPendingCsqRecharge(): CommunicationSaleRecharge
     {
         $client = $this->createMock(Client::class);
         $client->method('getId')->willReturn(1);
@@ -154,13 +166,13 @@ class CommunicationSaleServiceDTOnePhoneSwapTest extends TestCase
         $recharge = new CommunicationSaleRecharge();
         $recharge->setPackageId(1);
         $recharge->setTenant($account);
-        $recharge->setProvider('DTONE');
+        $recharge->setProvider('CSQ');
         $recharge->setCatalogPackage($catalogPackage);
-        $recharge->setDispatchExternalRef('35718');
-        $recharge->setDestinationAmount(250.0);
+        $recharge->setDispatchExternalRef('7951-2200');
+        $recharge->setDestinationAmount(2200.0);
         $recharge->setDestinationCurrency('CUP');
-        $recharge->setTransactionId('2608110100042');
-        $recharge->setPhoneNumber($phoneNumber);
+        $recharge->setTransactionId('2608100100042');
+        $recharge->setPhoneNumber('53500000');
         $recharge->setState(CommunicationStateEnum::PENDING);
         $recharge->setStateProcess('SENDING');
         $this->assignId($recharge, 555);
@@ -179,49 +191,62 @@ class CommunicationSaleServiceDTOnePhoneSwapTest extends TestCase
         return $recharge;
     }
 
-    private function acceptedDtoneResponse(): array
+    private function stubCsqRejection(): void
     {
-        return [
-            'id' => 999888,
-            'status' => ['class' => ['id' => 1, 'message' => 'ACCEPTED'], 'id' => 10001, 'message' => 'ACCEPTED'],
-        ];
+        // Mismo payload de rechazo real que CommunicationSaleServiceCsqCompletedDispatchTest::testDoesNotCreateBalanceWhenCsqRejectsTheAmount().
+        $this->csqClient->method('purchase')->willReturn([
+            'rc' => -1,
+            'items' => [[
+                'finalstatus' => -1,
+                'resultcode' => '927',
+                'resultmessage' => 'Importe incorrecto para la ruta 993',
+            ]],
+        ]);
+
+        $balance = new AccountBalanceDto('USD', 1000.0);
+        $this->balanceService->method('balance')->willReturn($balance);
+        $this->connection->method('executeStatement')->willReturn(1);
     }
 
-    public function testReplacesOnlyTheLastThreeDigitsWithDTOneCompletedSuffixWhenPhoneEndsInSixty(): void
+    public function testPromotesToTheFallbackProviderAndReenqueuesInsteadOfRejecting(): void
     {
-        $this->saleRecharge = $this->buildPendingDtoneRecharge('5356085160');
         $this->availabilityService->method('canDispatchTo')->willReturn(true);
-        $this->balanceService->method('balance')->willReturn(new AccountBalanceDto('USD', 1000.0));
-        $this->connection->method('executeStatement')->willReturn(1);
+        $this->stubCsqRejection();
 
-        $this->dtoneClient->expects($this->once())
-            ->method('createTransaction')
-            ->with(
-                $this->anything(),
-                $this->anything(),
-                $this->callback(fn (array $body) => ($body['credit_party_identifier']['mobile_number'] ?? null) === '+5356085100'),
-            )
-            ->willReturn($this->acceptedDtoneResponse());
+        // El failover service muta la venta él mismo (comportamiento real
+        // documentado en su propio test suite) — aquí solo se verifica que
+        // CommunicationSaleService reacciona a `true` reencolando en vez de
+        // marcar REJECTED.
+        $this->failoverService->method('promoteToFallback')
+            ->willReturnCallback(function ($sale) {
+                $sale->setProvider('DTONE');
+
+                return true;
+            });
+
+        $this->messageBus->expects($this->once())
+            ->method('dispatch')
+            ->with($this->callback(fn ($message) => $message instanceof SaleRechargeMessage))
+            ->willReturn(new Envelope(new SaleRechargeMessage(555)));
 
         $this->service->invokeRechargeCommunication(555);
+
+        $this->assertNotSame(CommunicationStateEnum::REJECTED, $this->saleRecharge->getState());
+        $this->assertSame('DTONE', $this->saleRecharge->getProvider());
     }
 
-    public function testKeepsTheRealPhoneNumberWhenItDoesNotEndInSixty(): void
+    public function testFallsBackToRejectedWhenNoFallbackCandidateIsAvailable(): void
     {
-        $this->saleRecharge = $this->buildPendingDtoneRecharge('5356085136');
         $this->availabilityService->method('canDispatchTo')->willReturn(true);
-        $this->balanceService->method('balance')->willReturn(new AccountBalanceDto('USD', 1000.0));
-        $this->connection->method('executeStatement')->willReturn(1);
+        $this->stubCsqRejection();
 
-        $this->dtoneClient->expects($this->once())
-            ->method('createTransaction')
-            ->with(
-                $this->anything(),
-                $this->anything(),
-                $this->callback(fn (array $body) => ($body['credit_party_identifier']['mobile_number'] ?? null) === '+5356085136'),
-            )
-            ->willReturn($this->acceptedDtoneResponse());
+        $this->failoverService->method('promoteToFallback')->willReturn(false);
+
+        $this->messageBus->expects($this->never())->method('dispatch');
 
         $this->service->invokeRechargeCommunication(555);
+
+        $this->assertSame(CommunicationStateEnum::REJECTED, $this->saleRecharge->getState());
+        $this->assertSame('CSQ', $this->saleRecharge->getProvider());
     }
 }

--- a/tests/Service/CommunicationSaleServicePromotionDispatchTest.php
+++ b/tests/Service/CommunicationSaleServicePromotionDispatchTest.php
@@ -119,6 +119,7 @@ class CommunicationSaleServicePromotionDispatchTest extends TestCase
             $this->packageCatalogResolver,
             $this->createMock(\App\Provider\ProviderDispatchResolver::class),
             $this->createMock(\App\Provider\PromotionProviderDispatchResolver::class),
+            $this->createMock(\App\Service\Provider\SaleProviderFailoverService::class),
         );
 
         $this->saleRecharge = $this->buildPendingPromotionRecharge();

--- a/tests/Service/CommunicationSaleServiceTransactionStatusTest.php
+++ b/tests/Service/CommunicationSaleServiceTransactionStatusTest.php
@@ -134,6 +134,7 @@ class CommunicationSaleServiceTransactionStatusTest extends TestCase
             $this->packageCatalogResolver,
             $this->createMock(\App\Provider\ProviderDispatchResolver::class),
             $this->createMock(\App\Provider\PromotionProviderDispatchResolver::class),
+            $this->createMock(\App\Service\Provider\SaleProviderFailoverService::class),
         );
 
         $this->saleRecharge = $this->buildPendingCsqRecharge();

--- a/tests/Service/CommunicationSaleServiceV2AdmissionTest.php
+++ b/tests/Service/CommunicationSaleServiceV2AdmissionTest.php
@@ -116,6 +116,7 @@ class CommunicationSaleServiceV2AdmissionTest extends TestCase
             $this->packageCatalogResolver,
             $this->dispatchResolver,
             $this->promotionDispatchResolver,
+            $this->createMock(\App\Service\Provider\SaleProviderFailoverService::class),
         );
     }
 

--- a/tests/Service/CommunicationSaleServiceV2AsyncDispatchTest.php
+++ b/tests/Service/CommunicationSaleServiceV2AsyncDispatchTest.php
@@ -125,6 +125,7 @@ class CommunicationSaleServiceV2AsyncDispatchTest extends TestCase
             $this->packageCatalogResolver,
             $dispatchResolver,
             $this->createMock(\App\Provider\PromotionProviderDispatchResolver::class),
+            $this->createMock(\App\Service\Provider\SaleProviderFailoverService::class),
         );
 
         $this->saleRecharge = $this->buildPendingV2CsqRecharge();

--- a/tests/Service/Provider/SaleProviderFailoverServiceTest.php
+++ b/tests/Service/Provider/SaleProviderFailoverServiceTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace App\Tests\Service\Provider;
+
+use App\Entity\Account;
+use App\Entity\CommunicationPackage;
+use App\Entity\CommunicationProduct;
+use App\Entity\CommunicationSalePackage;
+use App\Entity\CommunicationSaleRecharge;
+use App\Enums\CommunicationProviderEnum;
+use App\Provider\ProviderDispatchResolver;
+use App\Provider\SelectedDispatch;
+use App\Repository\SysConfigRepository;
+use App\Service\HistoricalSaleService;
+use App\Service\Provider\SaleProviderFailoverService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \App\Service\Provider\SaleProviderFailoverService
+ */
+class SaleProviderFailoverServiceTest extends TestCase
+{
+    private ProviderDispatchResolver&MockObject $dispatchResolver;
+    private SysConfigRepository&MockObject $sysConfigRepo;
+    private HistoricalSaleService&MockObject $historicalSaleService;
+    private SaleProviderFailoverService $service;
+
+    protected function setUp(): void
+    {
+        $this->dispatchResolver = $this->createMock(ProviderDispatchResolver::class);
+        $this->sysConfigRepo = $this->createMock(SysConfigRepository::class);
+        $this->historicalSaleService = $this->createMock(HistoricalSaleService::class);
+
+        $this->service = new SaleProviderFailoverService(
+            $this->dispatchResolver,
+            $this->sysConfigRepo,
+            $this->historicalSaleService,
+        );
+
+        // Kill switch en '1' por defecto salvo que el test lo apague.
+        $this->sysConfigRepo->method('findCachedValue')
+            ->willReturnCallback(fn (string $key) => $key === SaleProviderFailoverService::FAILOVER_ENABLED_KEY ? '1' : null);
+    }
+
+    private function assignId(object $entity, int $id): void
+    {
+        $property = new \ReflectionProperty($entity, 'id');
+        $property->setAccessible(true);
+        $property->setValue($entity, $id);
+    }
+
+    private function rechargeSale(string $provider = 'CSQ', array $transactionStatus = []): CommunicationSaleRecharge
+    {
+        $account = $this->createMock(Account::class);
+        $package = new CommunicationPackage();
+
+        $sale = new CommunicationSaleRecharge();
+        $this->assignId($sale, 1);
+        $sale->setTenant($account);
+        $sale->setCatalogPackage($package);
+        $sale->setProvider($provider);
+        $sale->setTransactionStatus($transactionStatus);
+
+        return $sale;
+    }
+
+    public function testPromotesToTheFallbackProviderWhenOneIsAvailable(): void
+    {
+        $sale = $this->rechargeSale('CSQ');
+        $product = $this->createMock(CommunicationProduct::class);
+        $selected = new SelectedDispatch(CommunicationProviderEnum::DTONE, $product, 'ref-fallback');
+
+        $this->dispatchResolver->expects($this->once())
+            ->method('selectExcluding')
+            ->with($this->anything(), $this->anything(), 'recharge', [CommunicationProviderEnum::CSQ])
+            ->willReturn($selected);
+        $this->historicalSaleService->expects($this->once())->method('createHistoricalCommunication');
+
+        $promoted = $this->service->promoteToFallback($sale, 'Provider rejected the recharge');
+
+        $this->assertTrue($promoted);
+        $this->assertSame('DTONE', $sale->getProvider());
+        $this->assertSame('ref-fallback', $sale->getDispatchExternalRef());
+        $this->assertSame('Created', $sale->getStateProcess());
+        $this->assertSame('CSQ', $sale->getTransactionStatus()['retry']['failoverFrom']);
+        $this->assertSame('DTONE', $sale->getTransactionStatus()['retry']['failoverTo']);
+    }
+
+    public function testDoesNotPromoteWhenNoFallbackCandidateIsAvailable(): void
+    {
+        $sale = $this->rechargeSale('CSQ');
+
+        $this->dispatchResolver->method('selectExcluding')->willReturn(null);
+        $this->historicalSaleService->expects($this->never())->method('createHistoricalCommunication');
+
+        $promoted = $this->service->promoteToFallback($sale, 'Provider rejected the recharge');
+
+        $this->assertFalse($promoted);
+        $this->assertSame('CSQ', $sale->getProvider());
+    }
+
+    public function testDoesNotPromoteTwiceForTheSameSale(): void
+    {
+        $sale = $this->rechargeSale('CSQ', ['retry' => ['failoverFrom' => 'ETECSA', 'failoverTo' => 'CSQ']]);
+
+        $this->dispatchResolver->expects($this->never())->method('selectExcluding');
+
+        $promoted = $this->service->promoteToFallback($sale, 'Provider rejected the recharge again');
+
+        $this->assertFalse($promoted);
+    }
+
+    public function testRespectsTheKillSwitch(): void
+    {
+        $this->sysConfigRepo = $this->createMock(SysConfigRepository::class);
+        $this->sysConfigRepo->method('findCachedValue')
+            ->willReturnCallback(fn (string $key) => $key === SaleProviderFailoverService::FAILOVER_ENABLED_KEY ? '0' : null);
+        $this->service = new SaleProviderFailoverService($this->dispatchResolver, $this->sysConfigRepo, $this->historicalSaleService);
+
+        $sale = $this->rechargeSale('CSQ');
+        $this->dispatchResolver->expects($this->never())->method('selectExcluding');
+
+        $promoted = $this->service->promoteToFallback($sale, 'Provider rejected the recharge');
+
+        $this->assertFalse($promoted);
+    }
+
+    public function testDoesNotPromoteWithoutACatalogPackageSnapshot(): void
+    {
+        $account = $this->createMock(Account::class);
+        $sale = new CommunicationSaleRecharge();
+        $sale->setTenant($account);
+        $sale->setProvider('CSQ');
+
+        $this->dispatchResolver->expects($this->never())->method('selectExcluding');
+
+        $this->assertFalse($this->service->promoteToFallback($sale, 'reason'));
+    }
+
+    public function testUsesSaleTypeSaleForPackageSales(): void
+    {
+        $account = $this->createMock(Account::class);
+        $package = new CommunicationPackage();
+        $sale = new CommunicationSalePackage();
+        $this->assignId($sale, 2);
+        $sale->setTenant($account);
+        $sale->setCatalogPackage($package);
+        $sale->setProvider('CSQ');
+
+        $product = $this->createMock(CommunicationProduct::class);
+        $selected = new SelectedDispatch(CommunicationProviderEnum::DTONE, $product, 'ref-fallback');
+
+        $this->dispatchResolver->expects($this->once())
+            ->method('selectExcluding')
+            ->with($this->anything(), $this->anything(), 'sale', [CommunicationProviderEnum::CSQ])
+            ->willReturn($selected);
+
+        $this->assertTrue($this->service->promoteToFallback($sale, 'reason'));
+    }
+}

--- a/tests/Service/ProviderRoutingAdminServiceTest.php
+++ b/tests/Service/ProviderRoutingAdminServiceTest.php
@@ -239,6 +239,48 @@ class ProviderRoutingAdminServiceTest extends TestCase
         $this->assertSame('AWS Malta a DTOne', $routing->getNotes());
     }
 
+    public function testCreatePersistsTheServiceCategoryAndDerivesServiceKey(): void
+    {
+        $client = $this->createMock(Client::class);
+        $client->method('getId')->willReturn(1);
+        $this->stubClientAndFreeScope($client);
+        $this->security->method('getUser')->willReturn(null);
+
+        $routing = $this->service->create(new CreateProviderRoutingDto(
+            clientId: 1,
+            provider: 'DTONE',
+            serviceName: 'Mobile',
+            subserviceName: 'AIRTIME',
+        ));
+
+        $this->assertSame('Mobile', $routing->getServiceName());
+        $this->assertSame('AIRTIME', $routing->getSubserviceName());
+        $this->assertSame('Mobile|AIRTIME', $routing->getServiceKey());
+    }
+
+    /**
+     * Dos filas activas del mismo cliente/entorno/tipo de venta pueden
+     * coexistir si son de categorías distintas — assertScopeIsFree() ahora
+     * filtra también por serviceKey, así que la query de "¿existe otra
+     * fila?" con una categoría distinta debe volver vacía.
+     */
+    public function testCreateAllowsTwoActiveRowsForTheSameScopeWithDifferentCategories(): void
+    {
+        $client = $this->createMock(Client::class);
+        $client->method('getId')->willReturn(1);
+        $this->stubClientAndFreeScope($client);
+        $this->security->method('getUser')->willReturn(null);
+
+        $routing = $this->service->create(new CreateProviderRoutingDto(
+            clientId: 1,
+            provider: 'DTONE',
+            serviceName: 'Utilities',
+            subserviceName: 'INTERNET',
+        ));
+
+        $this->assertSame('Utilities|INTERNET', $routing->getServiceKey());
+    }
+
     // ---- gate de habilitación (assertProviderIsEnabled) ----
 
     /**
@@ -518,6 +560,67 @@ class ProviderRoutingAdminServiceTest extends TestCase
         $this->expectExceptionMessage('Ya existe un enrutado activo');
 
         $this->service->update($routing, new UpdateProviderRoutingDto(saleType: 'recharge'));
+    }
+
+    public function testUpdateChangesTheServiceCategoryAndRevalidatesScope(): void
+    {
+        $client = $this->createMock(Client::class);
+        $client->method('getId')->willReturn(1);
+
+        $routing = new ClientProviderRouting();
+        $routing->setClient($client);
+        $routing->setProvider('ETECSA');
+
+        $this->stubScopeQuery(null);
+
+        $updated = $this->service->update($routing, new UpdateProviderRoutingDto(serviceName: 'Mobile', subserviceName: 'AIRTIME'));
+
+        $this->assertSame('Mobile', $updated->getServiceName());
+        $this->assertSame('AIRTIME', $updated->getSubserviceName());
+        $this->assertSame('Mobile|AIRTIME', $updated->getServiceKey());
+    }
+
+    /**
+     * '' es la convención de "volver a comodín" (null = no tocar) — ver
+     * docblock de UpdateProviderRoutingDto.
+     */
+    public function testUpdateWithEmptyStringClearsTheServiceCategoryBackToWildcard(): void
+    {
+        $client = $this->createMock(Client::class);
+        $client->method('getId')->willReturn(1);
+
+        $routing = new ClientProviderRouting();
+        $routing->setClient($client);
+        $routing->setProvider('ETECSA');
+        $routing->setServiceCategory('Mobile', 'AIRTIME');
+
+        $this->stubScopeQuery(null);
+
+        $updated = $this->service->update($routing, new UpdateProviderRoutingDto(serviceName: ''));
+
+        $this->assertNull($updated->getServiceName());
+        $this->assertNull($updated->getSubserviceName());
+        $this->assertSame('|', $updated->getServiceKey());
+    }
+
+    public function testUpdateWithoutTouchingCategoryPreservesTheExistingOne(): void
+    {
+        $client = $this->createMock(Client::class);
+        $client->method('getId')->willReturn(1);
+
+        $routing = new ClientProviderRouting();
+        $routing->setClient($client);
+        $routing->setProvider('ETECSA');
+        $routing->setServiceCategory('Mobile', 'AIRTIME');
+
+        $this->stubScopeQuery(null);
+
+        // scopeTouched se activa por saleType, no por categoría — la
+        // categoría existente debe sobrevivir intacta.
+        $updated = $this->service->update($routing, new UpdateProviderRoutingDto(saleType: 'recharge'));
+
+        $this->assertSame('Mobile', $updated->getServiceName());
+        $this->assertSame('AIRTIME', $updated->getSubserviceName());
     }
 
     // ---- toggle ----


### PR DESCRIPTION
## Resumen

- `ClientProviderRouting` gana `serviceName`/`subserviceName` (mismo vocabulario que `CommunicationPackage`/`CommunicationContract`, vía `ServiceCategoryKey`) — una regla de enrutado ahora puede acotarse a una categoría del catálogo, no solo a cliente/entorno/tipo de venta.
- `ProviderDispatchResolver` deja de ignorar `environment`/`saleType` de cada fila (bug preexistente): ahora filtra por scope completo y prueba la regla más específica primero.
- `fallbackProvider` (existía desde Fase 2, nunca usado) pasa a leerse: se prueba tras el principal en la selección inicial, y `SaleProviderFailoverService` reintenta automáticamente cuando el principal responde con un **rechazo determinista** — nunca tras un timeout/error de transporte (`UNKNOWN`), para no arriesgar doble cobro.
- Migración `Version20260828120000`: añade `service_name`/`subservice_name`/`service_key` y amplía `uniq_cpr_scope` con `service_key` (`NULLS NOT DISTINCT`, sin backfill — filas existentes quedan como comodín).

## ⚠️ Antes de desplegar a producción

Respetar `environment`/`saleType` en el despacho **cambia el comportamiento de filas ya existentes**: una fila hoy activa acotada a TEST deja de participar en el despacho de PROD. Hay que revisar el contenido real de `client_provider_routing` en producción antes de este release.

## Test plan
- [x] `php bin/phpunit --no-coverage` — 1096 tests, verde (incluye Postgres real para los funcionales)
- [x] `vendor/bin/phpstan analyse` — sin errores
- [ ] Confirmar con el usuario el contenido de `client_provider_routing` en prod antes de desplegar (ver aviso arriba)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UGZSuxX18gJ4N9XUmvmadS