### PR TITLE
Release: recarga de Nauta usa el identificador de destino correcto

### DIFF
--- a/migrations/Version20260831080000.php
+++ b/migrations/Version20260831080000.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Añade communication_product.required_identifier_fields (JSON) —
+ * identificador(es) de destino que el proveedor exige para despachar ESE
+ * producto: DTOne confirmó contra su sandbox real (2026-08-31) que Nauta
+ * WIFI Recharge exige `account_number` (cuenta Nauta), Nauta PLUS exige
+ * `mobile_number` y Nauta Hogar Plus exige AMBOS a la vez — mismo
+ * `service`/`subservice` (Utilities/Internet o Landline) para los tres, así
+ * que no se puede derivar de ahí. Ver ProviderProductDto::$requiredIdentifierFields
+ * para el formato (lista de opciones OR, cada una una lista de campos AND) y
+ * App\Entity\CommunicationProduct::$requiredIdentifierFields. Default '[]'
+ * por compatibilidad con filas históricas — se interpreta como "exigir solo
+ * phoneNumber" (comportamiento anterior a este fix).
+ */
+final class Version20260831080000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Añade communication_product.required_identifier_fields (JSON, default vacío)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE communication_product ADD COLUMN IF NOT EXISTS required_identifier_fields JSON NOT NULL DEFAULT '[]'");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE communication_product DROP COLUMN IF EXISTS required_identifier_fields');
+    }
+}

--- a/migrations/Version20260831081500.php
+++ b/migrations/Version20260831081500.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Añade communication_sale_info.account_identifier — identificador de
+ * destino tipo cuenta (p.ej. "usuario@nauta.com.cu"), distinto de
+ * phone_number, para productos que lo exigen (Nauta WIFI Recharge exige
+ * SOLO este; Nauta Hogar Plus exige este Y phone_number a la vez —
+ * confirmado contra el sandbox real de DTOne el 2026-08-31, ver
+ * App\Entity\CommunicationProduct::$requiredIdentifierFields). Ver
+ * App\Entity\CommunicationSaleRecharge::$accountIdentifier.
+ */
+final class Version20260831081500 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Añade communication_sale_info.account_identifier (identificador de destino tipo cuenta, p.ej. Nauta)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE communication_sale_info ADD COLUMN IF NOT EXISTS account_identifier VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE communication_sale_info DROP COLUMN IF EXISTS account_identifier');
+    }
+}

--- a/src/Controller/DashboardCommunicationPackagesController.php
+++ b/src/Controller/DashboardCommunicationPackagesController.php
@@ -398,6 +398,7 @@ class DashboardCommunicationPackagesController extends AbstractController
             'description' => $product->getDescription(),
             'wholesalePrice' => $product->getPrice() ?? 0.0,
             'priceCurrency' => $product->getPriceCurrency(),
+            'requiredIdentifierFields' => $product->getRequiredIdentifierFields(),
         ];
     }
 }

--- a/src/Controller/DashboardPromotionController.php
+++ b/src/Controller/DashboardPromotionController.php
@@ -282,6 +282,7 @@ class DashboardPromotionController extends AbstractController
             'description' => $product->getDescription(),
             'wholesalePrice' => $product->getPrice() ?? 0.0,
             'priceCurrency' => $product->getPriceCurrency(),
+            'requiredIdentifierFields' => $product->getRequiredIdentifierFields(),
         ];
     }
 

--- a/src/DTO/Out/PackageCoverageItemOutDto.php
+++ b/src/DTO/Out/PackageCoverageItemOutDto.php
@@ -14,4 +14,14 @@ final class PackageCoverageItemOutDto
     public ?string $description = null;
     public float $wholesalePrice;
     public ?string $priceCurrency = null;
+    /**
+     * Identificador(es) de destino que este producto exige (ver
+     * App\Entity\CommunicationProduct::$requiredIdentifierFields) — lista
+     * de opciones OR, cada una una lista de campos AND, en vocabulario
+     * neutral ('phoneNumber' | 'accountIdentifier'). `[]` = sin declarar
+     * (comportamiento histórico, solo phoneNumber).
+     *
+     * @var list<list<string>>
+     */
+    public array $requiredIdentifierFields = [];
 }

--- a/src/DTO/ReserveRecharge.php
+++ b/src/DTO/ReserveRecharge.php
@@ -29,10 +29,9 @@ final class ReserveRecharge
             required: true,
             default: '5350499847'
         )]
-        #[Assert\NotBlank]
         #[Assert\Length(min: 8, max: 10)]
         #[Groups(['comSales:create'])]
-        readonly string $phoneNumber,
+        readonly ?string $phoneNumber,
         #[ApiProperty(
             description: 'The promotion id in current system, take the information from /communication/promotions',
             required: true
@@ -55,15 +54,31 @@ final class ReserveRecharge
         )]
         #[Groups(['comSales:read', 'comSales:create'])]
         #[Assert\NotBlank]
-        readonly string $clientTransactionId
+        readonly string $clientTransactionId,
+        /**
+         * Identificador de destino tipo cuenta (no un número de teléfono) —
+         * p.ej. la cuenta Nauta para Nauta WIFI Recharge. Ninguno de los dos
+         * (este ni phoneNumber) es #[Assert\NotBlank]: cuál es obligatorio
+         * depende del producto, se valida en CommunicationSaleService::
+         * assertRecipientIdentifierSatisfied() al admitir la reserva.
+         */
+        #[ApiProperty(description: 'Account-type recipient identifier (e.g. Nauta account) for products that require it instead of, or in addition to, phoneNumber')]
+        #[Assert\Length(max: 255)]
+        #[Groups(['comSales:create'])]
+        readonly ?string $accountIdentifier = null,
     )
     {
 
     }
 
-    public function getPhoneNumber(): string
+    public function getPhoneNumber(): ?string
     {
         return $this->phoneNumber;
+    }
+
+    public function getAccountIdentifier(): ?string
+    {
+        return $this->accountIdentifier;
     }
 
     public function getPromotionId(): int

--- a/src/Entity/CommunicationProduct.php
+++ b/src/Entity/CommunicationProduct.php
@@ -133,6 +133,18 @@ class CommunicationProduct
     #[Groups(['product:read'])]
     private array $service = [];
 
+    /**
+     * Identificador(es) de destino que el proveedor exige para despachar
+     * este producto — viene de ProviderProductDto::$requiredIdentifierFields
+     * (ver su docblock para el formato y el porqué). `[]` = sin declarar,
+     * comportamiento histórico (solo phoneNumber).
+     *
+     * @var list<list<string>>
+     */
+    #[ORM\Column(type: Types::JSON)]
+    #[Groups(['product:read'])]
+    private array $requiredIdentifierFields = [];
+
     public function __construct()
     {
         $this->createdAt = new \DateTimeImmutable('now');
@@ -369,6 +381,24 @@ class CommunicationProduct
     public function setPriceCurrency(?string $priceCurrency): static
     {
         $this->priceCurrency = $priceCurrency;
+
+        return $this;
+    }
+
+    /**
+     * @return list<list<string>>
+     */
+    public function getRequiredIdentifierFields(): array
+    {
+        return $this->requiredIdentifierFields;
+    }
+
+    /**
+     * @param list<list<string>> $requiredIdentifierFields
+     */
+    public function setRequiredIdentifierFields(array $requiredIdentifierFields): static
+    {
+        $this->requiredIdentifierFields = $requiredIdentifierFields;
 
         return $this;
     }

--- a/src/Entity/CommunicationSaleRecharge.php
+++ b/src/Entity/CommunicationSaleRecharge.php
@@ -39,20 +39,44 @@ class CommunicationSaleRecharge extends CommunicationSaleInfo
         required: true,
         example: 'XXXXXXXXXX'
     )]
-    #[Assert\NotBlank]
     #[Assert\Length(min: 8, max: 10)]
     #[Groups(['comSales:read', 'comSales:create', 'sale:list', 'sale:detail'])]
-    private string $phoneNumber;
+    private ?string $phoneNumber = null;
 
+    /**
+     * Identificador de destino tipo cuenta (no un número de teléfono) —
+     * p.ej. la cuenta Nauta ("usuario@nauta.com.cu") para Nauta WIFI
+     * Recharge. Cuál de los dos (o ambos) exige el producto elegido lo
+     * valida CommunicationSaleService::assertRecipientIdentifierSatisfied()
+     * contra CommunicationProduct::$requiredIdentifierFields al admitir la
+     * venta — ninguno de los dos es #[Assert\NotBlank] aquí porque cuál es
+     * obligatorio depende del producto, no es una regla fija del DTO.
+     */
+    #[ORM\Column(length: 255, nullable: true)]
+    #[Assert\Length(max: 255)]
+    #[Groups(['comSales:read', 'comSales:create', 'sale:list', 'sale:detail'])]
+    private ?string $accountIdentifier = null;
 
-    public function getPhoneNumber(): string
+    public function getPhoneNumber(): ?string
     {
         return $this->phoneNumber;
     }
 
-    public function setPhoneNumber(string $phoneNumber): static
+    public function setPhoneNumber(?string $phoneNumber): static
     {
         $this->phoneNumber = $phoneNumber;
+
+        return $this;
+    }
+
+    public function getAccountIdentifier(): ?string
+    {
+        return $this->accountIdentifier;
+    }
+
+    public function setAccountIdentifier(?string $accountIdentifier): static
+    {
+        $this->accountIdentifier = $accountIdentifier;
 
         return $this;
     }

--- a/src/Provider/Contract/ProviderProductDto.php
+++ b/src/Provider/Contract/ProviderProductDto.php
@@ -51,6 +51,23 @@ final readonly class ProviderProductDto
          * @var array{name?: string, subservice?: array{name?: string}}
          */
         public array $service,
+        /**
+         * Identificador(es) de destino que el proveedor exige para
+         * despachar ESTE producto — no siempre es un número de teléfono
+         * (ver docs/dtone-product-types.md y CommunicationSaleService::
+         * assertRecipientIdentifierSatisfied()). Lista de opciones
+         * alternativas (OR), cada una una lista de campos que deben venir
+         * TODOS juntos (AND), usando el vocabulario neutral de
+         * CommunicationSaleRecharge: 'phoneNumber' | 'accountIdentifier'.
+         * `[]` significa "el proveedor no lo declara" — se interpreta como
+         * el comportamiento histórico (exigir solo phoneNumber). Cada
+         * adaptador traduce el vocabulario propio del proveedor aquí
+         * (DTOne: mobile_number/account_number — ver
+         * DTOneCommunicationProvider::mapRequiredIdentifierFields()).
+         *
+         * @var list<list<string>>
+         */
+        public array $requiredIdentifierFields = [],
     ) {
     }
 }

--- a/src/Provider/Contract/RechargeRequest.php
+++ b/src/Provider/Contract/RechargeRequest.php
@@ -12,12 +12,20 @@ final readonly class RechargeRequest
      */
     public function __construct(
         public string $transactionId,
-        public string $phoneNumber,
+        public ?string $phoneNumber,
         public string $productExternalId,
         public float $destinationAmount,
         public string $destinationUnit,
         public ?float $sendAmount = null,
         public array $metadata = [],
+        /**
+         * Identificador de destino tipo cuenta (no un número de teléfono) —
+         * p.ej. la cuenta Nauta para Nauta WIFI Recharge. Ver
+         * CommunicationProduct::$requiredIdentifierFields: algunos
+         * productos exigen SOLO este, otros SOLO phoneNumber, y algunos
+         * (Nauta Hogar Plus) exigen ambos a la vez.
+         */
+        public ?string $accountIdentifier = null,
     ) {
     }
 }

--- a/src/Provider/Csq/CsqCommunicationProvider.php
+++ b/src/Provider/Csq/CsqCommunicationProvider.php
@@ -252,6 +252,8 @@ final class CsqCommunicationProvider implements
                 continue;
             }
 
+            $requiredIdentifierFields = $this->resolveRequiredIdentifierFields($context, (int) $item['articleId']);
+
             $topupType = isset($item['topupType']) ? (string) $item['topupType'] : null;
             $serviceMap = self::TOPUP_TYPE_SERVICE_MAP[$topupType] ?? null;
             $destinationUnit = isset($item['destinationCurrency']) ? (string) $item['destinationCurrency'] : null;
@@ -291,6 +293,7 @@ final class CsqCommunicationProvider implements
                         'name' => $serviceMap['service'],
                         'subservice' => ['name' => $serviceMap['subservice']],
                     ] : [],
+                    requiredIdentifierFields: $requiredIdentifierFields,
                 );
             }
         }
@@ -309,6 +312,68 @@ final class CsqCommunicationProvider implements
     public function fetchPromotionProducts(ProviderContext $context, PromotionCatalogQuery $query): iterable
     {
         return $this->fetchProducts($context);
+    }
+
+    /**
+     * GET /pre-paid/recharge/parameters/{terminal}/{articleId} es la única
+     * señal que CSQ da para distinguir un destino tipo cuenta de uno tipo
+     * teléfono — confirmado en vivo el 2026-08-31: el campo siempre se
+     * llama "account" (nunca cambia), pero `parameters[].labels.en` sí
+     * revela la semántica real ("Nauta email" para 7855 vs "Phone Number"
+     * para 7854 Cubacel). No hay heurística de topupType posible: Nauta CUP
+     * y Cubacel comparten el mismo `field`. Se consulta UNA vez por
+     * articleId (antes de expandir a N CommunicationProduct por
+     * denominación) — best-effort: un fallo de este endpoint puntual (o una
+     * label no reconocida) no debe tumbar el sync completo, solo deja el
+     * producto sin requiredIdentifierFields declarado (comportamiento
+     * histórico: exigir solo phoneNumber).
+     *
+     * @return list<list<string>>
+     */
+    private function resolveRequiredIdentifierFields(ProviderContext $context, int $articleId): array
+    {
+        try {
+            $response = $this->client->getParameters($context, $articleId);
+        } catch (MyCurrentException $e) {
+            $this->csqLogger->warning('CSQ catálogo: no se pudo consultar /pre-paid/recharge/parameters, se usa el comportamiento histórico (phoneNumber).', [
+                'articleId' => $articleId,
+                'environmentId' => $context->environmentId,
+                'error' => $e->getMessage(),
+            ]);
+
+            return [];
+        }
+
+        $fields = [];
+        foreach ((array) ($response['parameters'] ?? []) as $parameter) {
+            $field = $this->mapParameterLabelToNeutralField(is_array($parameter) ? $parameter : []);
+            if ($field !== null) {
+                $fields[] = $field;
+            }
+        }
+
+        return $fields === [] ? [] : [$fields];
+    }
+
+    /**
+     * @param array<string, mixed> $parameter
+     */
+    private function mapParameterLabelToNeutralField(array $parameter): ?string
+    {
+        $label = strtolower((string) ($parameter['labels']['en'] ?? ''));
+        if ($label === '') {
+            return null;
+        }
+
+        if (str_contains($label, 'email') || str_contains($label, 'account')) {
+            return 'accountIdentifier';
+        }
+
+        if (str_contains($label, 'phone') || str_contains($label, 'mobile') || str_contains($label, 'number')) {
+            return 'phoneNumber';
+        }
+
+        return null;
     }
 
     /**
@@ -402,7 +467,15 @@ final class CsqCommunicationProvider implements
                 $context,
                 $articleId,
                 $this->deriveLocalReference($request->transactionId),
-                $request->phoneNumber,
+                // El campo "account" de CSQ es el mismo nombre para ambos
+                // casos (nunca cambia — ver CsqHttpClient::purchase()), pero
+                // su contenido esperado sí varía por producto: cuenta Nauta
+                // para Nauta CUP, número de teléfono para Cubacel/etc. —
+                // CommunicationSaleService solo puebla accountIdentifier
+                // cuando el producto lo exige (ver
+                // CommunicationProduct::$requiredIdentifierFields), así que
+                // basta con preferirlo sobre phoneNumber cuando venga.
+                $request->accountIdentifier ?? $request->phoneNumber,
                 (int) round($destinationAmount * 100),
             );
         } catch (MyCurrentException $e) {

--- a/src/Provider/Csq/CsqHttpClient.php
+++ b/src/Provider/Csq/CsqHttpClient.php
@@ -163,6 +163,28 @@ class CsqHttpClient
         return $this->request($context, 'GET', '/external-point-of-sale/by-file/balances');
     }
 
+    /**
+     * GET /pre-paid/recharge/parameters/{terminalId}/{operatorId} —
+     * describe el/los parámetro(s) de destino que Purchase espera para ESE
+     * artículo. `field` es siempre "account" (nunca cambia — ver purchase()),
+     * pero `labels` sí revela la semántica real: confirmado en vivo el
+     * 2026-08-31, Nauta CUP (7855) trae `{"en": "Nauta email"}` mientras
+     * Cubacel (7854) trae `{"en": "Phone Number"}` — es la única señal que
+     * CSQ da para distinguir "cuenta" de "número de teléfono" (ver
+     * CsqCommunicationProvider::resolveRequiredIdentifierFields()). OJO:
+     * `dynamic` de esta respuesta NO describe fielmente qué exige Purchase
+     * (ver docblock de purchase()) — este método solo se usa para los
+     * `labels`, no para decidir dynamicProductId/receiverEmail/documentNumber.
+     *
+     * @return array<string, mixed>
+     */
+    public function getParameters(ProviderContext $context, int $articleId): array
+    {
+        $terminal = $this->requireTerminal($context);
+
+        return $this->request($context, 'GET', "/pre-paid/recharge/parameters/{$terminal}/{$articleId}");
+    }
+
     private function requireTerminal(ProviderContext $context): int
     {
         $credentials = $this->credentialsResolver->get(CommunicationProviderEnum::CSQ, $context->environmentType);

--- a/src/Provider/DTOne/DTOneCommunicationProvider.php
+++ b/src/Provider/DTOne/DTOneCommunicationProvider.php
@@ -94,6 +94,20 @@ final class DTOneCommunicationProvider implements
      */
     private const COUNTRY_CALLING_CODE = '53';
 
+    /**
+     * Traduce el vocabulario de `credit_party_identifier` de DTOne al
+     * vocabulario neutral de CommunicationSaleRecharge/RechargeRequest.
+     * Confirmado contra el sandbox real el 2026-08-31: `account_number` es
+     * la cuenta Nauta (no un número de teléfono) para Nauta WIFI Recharge —
+     * ver docs/dtone-product-types.md. Cualquier campo de DTOne que no esté
+     * aquí (p.ej. `email`, `iban`, otros no vistos todavía) se descarta en
+     * mapRequiredIdentifierFields() en vez de inventar un mapeo.
+     */
+    private const IDENTIFIER_FIELD_MAP = [
+        'mobile_number' => 'phoneNumber',
+        'account_number' => 'accountIdentifier',
+    ];
+
     public function __construct(
         private readonly DTOneHttpClient $client,
         private readonly DTOneStatusMapper $statusMapper,
@@ -134,7 +148,7 @@ final class DTOneCommunicationProvider implements
 
     public function recharge(ProviderContext $context, RechargeRequest $request): ProviderDispatchResult
     {
-        $body = $this->buildTransactionBody($request->transactionId, $request->productExternalId, $request->phoneNumber);
+        $body = $this->buildTransactionBody($request->transactionId, $request->productExternalId, $request->phoneNumber, $request->accountIdentifier);
 
         try {
             $raw = $this->client->createTransaction($context, $request->transactionId, $body);
@@ -152,7 +166,11 @@ final class DTOneCommunicationProvider implements
 
     public function sellPackage(ProviderContext $context, PackageSaleRequest $request): ProviderDispatchResult
     {
-        $body = $this->buildTransactionBody($request->transactionId, $request->productExternalId, $request->phoneNumber);
+        // PackageSaleRequest no lleva accountIdentifier: los productos que
+        // hoy pasan por sellPackage() (PIN_PURCHASE, gift cards) nunca
+        // exigen cuenta Nauta — ver el docblock de la clase. Si algún día
+        // hace falta, se añade igual que en RechargeRequest.
+        $body = $this->buildTransactionBody($request->transactionId, $request->productExternalId, $request->phoneNumber, null);
 
         try {
             $raw = $this->client->createTransaction($context, $request->transactionId, $body);
@@ -310,8 +328,48 @@ final class DTOneCommunicationProvider implements
                     'name' => $service,
                     'subservice' => $subservice !== null ? ['name' => $subservice] : null,
                 ], static fn ($v) => $v !== null),
+                requiredIdentifierFields: $this->mapRequiredIdentifierFields($item['required_credit_party_identifier_fields'] ?? null),
             );
         }
+    }
+
+    /**
+     * required_credit_party_identifier_fields de DTOne es una lista de
+     * opciones alternativas (OR), cada una una lista de campos que deben
+     * venir todos juntos (AND) — confirmado contra el sandbox real el
+     * 2026-08-31 con Nauta Hogar Plus (`[["mobile_number","account_number"]]`,
+     * ambos a la vez). Se traduce cada campo con IDENTIFIER_FIELD_MAP; un
+     * campo no reconocido se descarta (nunca se inventa un mapeo), y si eso
+     * deja una opción vacía, la opción entera se descarta.
+     *
+     * @param mixed $raw
+     * @return list<list<string>>
+     */
+    private function mapRequiredIdentifierFields(mixed $raw): array
+    {
+        if (!is_array($raw)) {
+            return [];
+        }
+
+        $options = [];
+        foreach ($raw as $option) {
+            if (!is_array($option)) {
+                continue;
+            }
+
+            $mapped = [];
+            foreach ($option as $field) {
+                if (is_string($field) && isset(self::IDENTIFIER_FIELD_MAP[$field])) {
+                    $mapped[] = self::IDENTIFIER_FIELD_MAP[$field];
+                }
+            }
+
+            if ($mapped !== []) {
+                $options[] = $mapped;
+            }
+        }
+
+        return $options;
     }
 
     /**
@@ -393,7 +451,7 @@ final class DTOneCommunicationProvider implements
     /**
      * @return array<string, mixed>
      */
-    private function buildTransactionBody(string $transactionId, string $productExternalId, ?string $phoneNumber): array
+    private function buildTransactionBody(string $transactionId, string $productExternalId, ?string $phoneNumber, ?string $accountIdentifier): array
     {
         $body = [
             'external_id' => $transactionId,
@@ -401,8 +459,21 @@ final class DTOneCommunicationProvider implements
             'auto_confirm' => true,
         ];
 
+        // Se manda cualquiera de los dos que venga informado — cuál(es)
+        // hacía falta ya lo decidió CommunicationSaleService contra
+        // CommunicationProduct::$requiredIdentifierFields antes de admitir
+        // la venta (ver assertRecipientIdentifierSatisfied()); aquí solo se
+        // traduce al vocabulario de DTOne. Nauta Hogar Plus exige ambos a
+        // la vez — confirmado contra el sandbox real el 2026-08-31.
+        $identifier = [];
         if ($phoneNumber !== null) {
-            $body['credit_party_identifier'] = ['mobile_number' => $this->toE164Cuba($phoneNumber)];
+            $identifier['mobile_number'] = $this->toE164Cuba($phoneNumber);
+        }
+        if ($accountIdentifier !== null) {
+            $identifier['account_number'] = $accountIdentifier;
+        }
+        if ($identifier !== []) {
+            $body['credit_party_identifier'] = $identifier;
         }
 
         return $body;

--- a/src/Service/CommunicationSaleService.php
+++ b/src/Service/CommunicationSaleService.php
@@ -10,6 +10,7 @@ use App\Entity\BalanceOperation;
 use App\Entity\CommunicationNationality;
 use App\Entity\CommunicationOffice;
 use App\Entity\CommunicationPackage;
+use App\Entity\CommunicationProduct;
 use App\Entity\CommunicationPromotions;
 use App\Entity\CommunicationSaleHistory;
 use App\Entity\CommunicationSaleInfo;
@@ -213,6 +214,7 @@ class CommunicationSaleService extends CommonService
         // promoción→producto (ver PromotionProviderDispatchResolver) y se
         // congela ANTES de construir la venta.
         $admission = $this->admitV2ForReserve($user, $catalogPackage, $promotion);
+        $this->assertRecipientIdentifierSatisfied($admission->dispatchProduct, $reserveDto->getPhoneNumber(), $reserveDto->getAccountIdentifier());
 
         $recharge = new CommunicationSaleRecharge();
         $recharge->setTenant($user);
@@ -222,6 +224,7 @@ class CommunicationSaleService extends CommonService
         $recharge->setPromotionId($reserveDto->getPromotionId());
         $recharge->setPackageId($reserveDto->getPackageId());
         $recharge->setPhoneNumber($reserveDto->getPhoneNumber());
+        $recharge->setAccountIdentifier($reserveDto->getAccountIdentifier());
         $recharge->setClientTransactionId($reserveDto->getClientTransactionId());
         $this->applyAdmission($recharge, $admission);
         $recharge->setPromotion($promotion);
@@ -294,6 +297,7 @@ class CommunicationSaleService extends CommonService
         // El proveedor es propiedad del producto, no de la cuenta — se
         // valida y se congela ANTES de construir la venta (ver admitV2()).
         $admission = $this->admitV2($user, $recharge->getPackageId(), 'recharge');
+        $this->assertRecipientIdentifierSatisfied($admission->dispatchProduct, $recharge->getPhoneNumber(), $recharge->getAccountIdentifier());
 
         $recharge->setTransactionId($transactionId);
         $this->applyAdmission($recharge, $admission);
@@ -470,10 +474,18 @@ class CommunicationSaleService extends CommonService
                 // cuenta de DTOne).
                 $provider = $this->providerResolver->resolveForSale($saleRecharge);
 
-                $phoneLength = strlen($saleRecharge->getPhoneNumber());
-                $checkPhone = substr($saleRecharge->getPhoneNumber(), $phoneLength - 2, $phoneLength);
+                // Productos tipo cuenta (Nauta WIFI Recharge exige SOLO
+                // accountIdentifier, no un número — ver
+                // CommunicationProduct::$requiredIdentifierFields) pueden
+                // no traer phoneNumber en absoluto: las sustituciones de
+                // sandbox de abajo son todas convenciones sobre el número
+                // de teléfono, así que se saltan por completo cuando no hay
+                // ninguno.
                 $phoneNumber = $saleRecharge->getPhoneNumber();
-                if ($environment->getType() === 'TEST' && $provider === CommunicationProviderEnum::ETECSA) {
+                $checkPhone = $phoneNumber !== null ? substr($phoneNumber, -2) : null;
+                if ($phoneNumber === null) {
+                    // nada que sustituir
+                } elseif ($environment->getType() === 'TEST' && $provider === CommunicationProviderEnum::ETECSA) {
                     $phoneNumber = $checkPhone === "60" ? $this->parameters->get(
                         'app.phoneNumber'
                     ) : $saleRecharge->getPhoneNumber();
@@ -508,6 +520,7 @@ class CommunicationSaleService extends CommonService
 
                 $body = [
                     'phoneNumber' => $phoneNumber,
+                    'accountIdentifier' => $saleRecharge->getAccountIdentifier(),
                     'productCode' => $productCode,
                     'productPrice' => round($destination->amount, 2),
                     'transactionId' => $saleRecharge->getTransactionId(),
@@ -522,6 +535,7 @@ class CommunicationSaleService extends CommonService
                     productExternalId: (string) $productCode,
                     destinationAmount: (float) $destination->amount,
                     destinationUnit: $saleRecharge->getCurrency() ?? 'CUP',
+                    accountIdentifier: $saleRecharge->getAccountIdentifier(),
                 );
 
                 $dispatchResult = $adapter->recharge($context, $request);
@@ -945,6 +959,56 @@ class CommunicationSaleService extends CommonService
             dispatchExternalRef: $dispatch->externalRef,
             destinationAmount: $package->getDestinationAmount(),
             destinationCurrency: $package->getDestinationCurrency(),
+        );
+    }
+
+    /**
+     * Rechaza de forma síncrona (en admisión, antes de persistir la venta)
+     * una recarga que no trae el/los identificador(es) de destino que el
+     * producto resuelto exige — ver CommunicationProduct::$requiredIdentifierFields.
+     * Confirmado contra el sandbox real de DTOne el 2026-08-31: Nauta WIFI
+     * Recharge exige SOLO accountIdentifier (cuenta Nauta, no un número de
+     * teléfono), Nauta PLUS exige SOLO phoneNumber, y Nauta Hogar Plus
+     * exige AMBOS a la vez — los tres con el MISMO service/subservice, así
+     * que no hay atajo de catálogo posible, hay que leer el campo real.
+     *
+     * `$product === null` o `requiredIdentifierFields === []` (producto sin
+     * declarar, todo el catálogo histórico) cae al comportamiento anterior
+     * a este fix: se exige solo phoneNumber.
+     *
+     * @throws MyCurrentException
+     */
+    private function assertRecipientIdentifierSatisfied(?CommunicationProduct $product, ?string $phoneNumber, ?string $accountIdentifier): void
+    {
+        $required = $product?->getRequiredIdentifierFields() ?? [];
+
+        if ($required === []) {
+            if ($phoneNumber === null || $phoneNumber === '') {
+                throw new MyCurrentException('COM_MISSING_RECIPIENT_IDENTIFIER', 'phoneNumber is required for this product', 400);
+            }
+
+            return;
+        }
+
+        $provided = [];
+        if ($phoneNumber !== null && $phoneNumber !== '') {
+            $provided['phoneNumber'] = true;
+        }
+        if ($accountIdentifier !== null && $accountIdentifier !== '') {
+            $provided['accountIdentifier'] = true;
+        }
+
+        foreach ($required as $option) {
+            if (array_diff($option, array_keys($provided)) === []) {
+                return;
+            }
+        }
+
+        $optionsDescription = implode(' OR ', array_map(static fn (array $option) => implode('+', $option), $required));
+        throw new MyCurrentException(
+            'COM_MISSING_RECIPIENT_IDENTIFIER',
+            "Missing required recipient identifier(s) for this product: {$optionsDescription}",
+            400,
         );
     }
 

--- a/src/Service/Pricing/CommunicationPackageAdminService.php
+++ b/src/Service/Pricing/CommunicationPackageAdminService.php
@@ -313,7 +313,7 @@ class CommunicationPackageAdminService
      * costo mayorista — evita publicar un paquete indespachable (ver
      * DashboardCommunicationPackagesController::coverage()).
      *
-     * @return list<array{provider: string, productId: int, externalRef: string, description: ?string, wholesalePrice: float, priceCurrency: ?string}>
+     * @return list<array{provider: string, productId: int, externalRef: string, description: ?string, wholesalePrice: float, priceCurrency: ?string, requiredIdentifierFields: list<list<string>>}>
      */
     public function coverage(CommunicationPackage $package, ?Environment $environment): array
     {
@@ -330,6 +330,7 @@ class CommunicationPackageAdminService
             'description' => $product->getDescription(),
             'wholesalePrice' => $product->getPrice() ?? 0.0,
             'priceCurrency' => $product->getPriceCurrency(),
+            'requiredIdentifierFields' => $product->getRequiredIdentifierFields(),
         ], $products);
     }
 }

--- a/src/Service/Provider/CommunicationCatalogSyncService.php
+++ b/src/Service/Provider/CommunicationCatalogSyncService.php
@@ -76,6 +76,7 @@ class CommunicationCatalogSyncService
             $entity->setIsMobileOrInternetService($item->isMobileOrInternetService);
             $entity->setBenefits($item->benefits);
             $entity->setService($item->service);
+            $entity->setRequiredIdentifierFields($item->requiredIdentifierFields);
             $entity->setPrice($item->wholesalePrice);
             $entity->setPriceCurrency($item->priceCurrency);
             $entity->setDestinationAmount($item->destinationAmount);

--- a/tests/Controller/DashboardCommunicationPackagesControllerTest.php
+++ b/tests/Controller/DashboardCommunicationPackagesControllerTest.php
@@ -260,6 +260,7 @@ class DashboardCommunicationPackagesControllerTest extends TestCase
         $product->method('getExternalRef')->willReturn('x');
         $product->method('getPrice')->willReturn(10.0);
         $product->method('getPriceCurrency')->willReturn('USD');
+        $product->method('getRequiredIdentifierFields')->willReturn([['accountIdentifier']]);
 
         return $product;
     }
@@ -295,6 +296,12 @@ class DashboardCommunicationPackagesControllerTest extends TestCase
         $this->assertCount(1, $data[1]['candidates']);
         $this->assertTrue($data[0]['autoMatched']);
         $this->assertFalse($data[1]['autoMatched']);
+        // requiredIdentifierFields (ver App\Entity\CommunicationProduct) viaja
+        // en la serialización — el admin necesita verlo al elegir el vínculo
+        // paquete->producto (ej. Nauta WIFI exige accountIdentifier, no un
+        // número de teléfono).
+        $this->assertSame([['accountIdentifier']], $data[0]['boundProduct']['requiredIdentifierFields']);
+        $this->assertSame([['accountIdentifier']], $data[1]['candidates'][0]['requiredIdentifierFields']);
     }
 
     public function testSetBindingReturnsNotFoundWhenPackageDoesNotExist(): void

--- a/tests/Controller/DashboardPromotionControllerTest.php
+++ b/tests/Controller/DashboardPromotionControllerTest.php
@@ -73,6 +73,7 @@ class DashboardPromotionControllerTest extends TestCase
         $product->method('getProvider')->willReturn('CSQ');
         $product->method('getId')->willReturn(1);
         $product->method('getExternalRef')->willReturn('ref-1');
+        $product->method('getRequiredIdentifierFields')->willReturn([['accountIdentifier']]);
 
         return $product;
     }
@@ -117,6 +118,11 @@ class DashboardPromotionControllerTest extends TestCase
         $this->assertSame('CSQ', $data[1]['provider']);
         $this->assertNull($data[1]['boundProduct']);
         $this->assertCount(1, $data[1]['candidates']);
+        // requiredIdentifierFields (ver App\Entity\CommunicationProduct) —
+        // mismo criterio que catalog/packages/{id}/bindings: el admin
+        // necesita ver qué identificador exige el producto al vincularlo.
+        $this->assertSame([['accountIdentifier']], $data[0]['boundProduct']['requiredIdentifierFields']);
+        $this->assertSame([['accountIdentifier']], $data[1]['candidates'][0]['requiredIdentifierFields']);
     }
 
     public function testSetBindingReturnsNotFoundWhenPromotionDoesNotExist(): void

--- a/tests/Provider/Csq/CsqCommunicationProviderCatalogTest.php
+++ b/tests/Provider/Csq/CsqCommunicationProviderCatalogTest.php
@@ -279,6 +279,130 @@ class CsqCommunicationProviderCatalogTest extends TestCase
         $this->assertSame(str_repeat('a', 255), $products[0]->description);
     }
 
+    /**
+     * Confirmado contra el sandbox real de CSQ el 2026-08-31: `/pre-paid/
+     * recharge/parameters/{terminal}/{articleId}` es la única señal que da
+     * CSQ para distinguir un destino tipo cuenta de uno tipo teléfono — el
+     * campo siempre se llama "account" (nunca cambia), pero `labels.en` sí
+     * revela la semántica real ("Nauta email" vs "Phone Number"). A
+     * diferencia de DTOne, no hay heurística de service/subservice posible
+     * aquí tampoco: hay que leer el campo real por artículo.
+     *
+     * @dataProvider parametersLabelProvider
+     */
+    public function testFetchProductsTranslatesParametersLabelToNeutralField(array $labels, array $expected): void
+    {
+        $this->client->method('getPortfolio')->willReturn($this->portfolio([
+            [
+                'articleId' => 7855,
+                'name' => 'Nauta CUP',
+                'countryId' => 192,
+                'topupType' => 'Data',
+                'amountType' => 'by_list',
+                'saleAmount' => ['from' => null, 'to' => null, 'step' => null, 'list' => [1000]],
+                'exchangeRate' => 22.0,
+                'saleCurrency' => 'USD',
+                'destinationCurrency' => 'CUP',
+            ],
+        ]));
+        $this->client->method('getParameters')->with($this->anything(), 7855)->willReturn([
+            'rc' => 0,
+            'parameters' => [['field' => 'account', 'labels' => $labels]],
+        ]);
+
+        $products = iterator_to_array($this->provider->fetchProducts($this->context()));
+
+        $this->assertCount(1, $products);
+        $this->assertSame($expected, $products[0]->requiredIdentifierFields);
+    }
+
+    /**
+     * @return iterable<string, array{array, list<list<string>>}>
+     */
+    public static function parametersLabelProvider(): iterable
+    {
+        yield 'Nauta email -> accountIdentifier' => [
+            ['en' => 'Nauta email', 'es' => 'Correo electronico de Nauta'],
+            [['accountIdentifier']],
+        ];
+        yield 'Phone Number -> phoneNumber' => [
+            ['en' => 'Phone Number', 'es' => 'Numero de telefono'],
+            [['phoneNumber']],
+        ];
+        yield 'label desconocida no se inventa' => [
+            ['en' => 'Something else entirely'],
+            [],
+        ];
+        yield 'sin labels en absoluto' => [
+            [],
+            [],
+        ];
+    }
+
+    /**
+     * Best-effort (mismo criterio que exchangeRate inválido u otros campos
+     * de catálogo): si /pre-paid/recharge/parameters falla, el producto NO
+     * se omite del catálogo — se sincroniza igual, sin requiredIdentifierFields
+     * declarado (comportamiento histórico: exigir solo phoneNumber). Un
+     * proveedor caído en ESE endpoint puntual no debe tumbar todo el sync.
+     */
+    public function testFetchProductsFallsBackToLegacyWhenGetParametersFails(): void
+    {
+        $this->client->method('getPortfolio')->willReturn($this->portfolio([
+            [
+                'articleId' => 7855,
+                'name' => 'Nauta CUP',
+                'countryId' => 192,
+                'topupType' => 'Data',
+                'amountType' => 'by_list',
+                'saleAmount' => ['from' => null, 'to' => null, 'step' => null, 'list' => [1000]],
+                'exchangeRate' => 22.0,
+                'saleCurrency' => 'USD',
+                'destinationCurrency' => 'CUP',
+            ],
+        ]));
+        $this->client->method('getParameters')->willThrowException(
+            new \App\Exception\MyCurrentException('CSQ_REQUEST_FAILED', 'timeout', 502),
+        );
+
+        $products = iterator_to_array($this->provider->fetchProducts($this->context()));
+
+        $this->assertCount(1, $products);
+        $this->assertSame([], $products[0]->requiredIdentifierFields);
+    }
+
+    /**
+     * getParameters() se consulta UNA vez por articleId, no una vez por
+     * denominación generada — evita N llamadas redundantes cuando un
+     * articleId by_range se expande a decenas de CommunicationProduct.
+     */
+    public function testFetchProductsCallsGetParametersOncePerArticleIdNotPerDenomination(): void
+    {
+        $this->client->method('getPortfolio')->willReturn($this->portfolio([
+            [
+                'articleId' => 7951,
+                'name' => 'Cubacel Pack Combos',
+                'countryId' => 192,
+                'topupType' => 'Bundles',
+                'amountType' => 'by_list',
+                'saleAmount' => ['from' => null, 'to' => null, 'step' => null, 'list' => [2200, 3300, 4400]],
+                'exchangeRate' => 22.0,
+                'saleCurrency' => 'USD',
+                'destinationCurrency' => 'CUP',
+            ],
+        ]));
+        $this->client->expects($this->once())->method('getParameters')->willReturn([
+            'rc' => 0,
+            'parameters' => [['field' => 'account', 'labels' => ['en' => 'Phone Number']]],
+        ]);
+
+        $products = iterator_to_array($this->provider->fetchProducts($this->context()));
+
+        $this->assertCount(3, $products);
+        $this->assertSame([['phoneNumber']], $products[0]->requiredIdentifierFields);
+        $this->assertSame([['phoneNumber']], $products[2]->requiredIdentifierFields);
+    }
+
     public function testEmptyPortfolioYieldsNoProducts(): void
     {
         $this->client->method('getPortfolio')->willReturn([]);

--- a/tests/Provider/Csq/CsqCommunicationProviderRechargeTest.php
+++ b/tests/Provider/Csq/CsqCommunicationProviderRechargeTest.php
@@ -70,6 +70,33 @@ class CsqCommunicationProviderRechargeTest extends TestCase
         $this->assertSame('X1', $result->providerReference);
     }
 
+    /**
+     * Nauta CUP (7855) exige la cuenta Nauta ("Nauta email"), no un número
+     * de teléfono — confirmado contra el sandbox real de CSQ el 2026-08-31
+     * (GET /pre-paid/recharge/parameters). CommunicationSaleService solo
+     * puebla accountIdentifier cuando el producto lo exige (ver
+     * CommunicationProduct::$requiredIdentifierFields), así que aquí basta
+     * con preferirlo sobre phoneNumber cuando venga presente.
+     */
+    public function testRechargeSendsAccountIdentifierAsAccountWhenPresent(): void
+    {
+        $this->client->expects($this->once())
+            ->method('purchase')
+            ->with($this->anything(), 7855, $this->anything(), 'usuario@nauta.com.cu', $this->anything())
+            ->willReturn(['rc' => 0, 'items' => [['resultcode' => '10', 'resultmessage' => 'OK', 'supplierreference' => 'X2']]]);
+
+        $request = new RechargeRequest(
+            transactionId: '2608100100043',
+            phoneNumber: null,
+            productExternalId: '7855-1000',
+            destinationAmount: 1000.0,
+            destinationUnit: 'CUP',
+            accountIdentifier: 'usuario@nauta.com.cu',
+        );
+
+        $this->provider->recharge($this->context(), $request);
+    }
+
     public function testRechargeReturnsRejectedWithClearMessageOnMalformedExternalRef(): void
     {
         $this->client->expects($this->never())->method('purchase');

--- a/tests/Provider/Csq/CsqHttpClientTest.php
+++ b/tests/Provider/Csq/CsqHttpClientTest.php
@@ -290,4 +290,47 @@ class CsqHttpClientTest extends TestCase
 
         $client->purchase($this->context(), 7951, 100042, '53500000', 220000);
     }
+
+    // ---- getParameters ----
+
+    /**
+     * GET /pre-paid/recharge/parameters/{terminal}/{articleId} — confirmado
+     * en vivo el 2026-08-31: la respuesta trae `parameters[].labels` con la
+     * semántica real del campo "account" (siempre el mismo nombre de
+     * campo, ver purchase()) — p.ej. "Nauta email" para Nauta CUP (7855) vs
+     * "Phone Number" para Cubacel (7854). Es la única señal que CSQ da para
+     * distinguirlos, ver CsqCommunicationProvider::resolveRequiredIdentifierFields().
+     */
+    public function testGetParametersSendsDocumentedRequestAndDecodesBody(): void
+    {
+        $requestedUrl = null;
+        $payload = ['rc' => 0, 'message' => 'OK', 'dynamic' => false, 'dynamicField' => 'account', 'parameters' => [
+            ['field' => 'account', 'labels' => ['en' => 'Nauta email', 'es' => 'Correo electronico de Nauta']],
+        ]];
+
+        $httpClient = new MockHttpClient(function (string $method, string $url) use (&$requestedUrl, $payload) {
+            $requestedUrl = $url;
+            $this->assertSame('GET', $method);
+
+            return new MockResponse(json_encode($payload), ['http_code' => 200]);
+        });
+
+        $client = new CsqHttpClient($httpClient, $this->credentialsResolver(), new NullLogger());
+        $result = $client->getParameters($this->context(), 7855);
+
+        $this->assertSame('https://evsb.csqworld.com/pre-paid/recharge/parameters/173103/7855', $requestedUrl);
+        $this->assertSame($payload, $result);
+    }
+
+    public function testGetParametersWrapsTransportErrors(): void
+    {
+        $httpClient = new MockHttpClient(function () {
+            return new MockResponse('', ['http_code' => 503]);
+        });
+        $client = new CsqHttpClient($httpClient, $this->credentialsResolver(), new NullLogger());
+
+        $this->expectException(MyCurrentException::class);
+
+        $client->getParameters($this->context(), 7855);
+    }
 }

--- a/tests/Provider/DTOne/DTOneCommunicationProviderTest.php
+++ b/tests/Provider/DTOne/DTOneCommunicationProviderTest.php
@@ -79,6 +79,68 @@ class DTOneCommunicationProviderTest extends TestCase
     }
 
     /**
+     * Nauta WIFI Recharge exige `account_number` (cuenta Nauta), no un
+     * número de teléfono (confirmado contra el sandbox real el 2026-08-31)
+     * — se manda tal cual, sin pasar por toE164Cuba() (eso es solo para
+     * mobile_number).
+     */
+    public function testRechargeSendsAccountNumberWhenOnlyAccountIdentifierIsSet(): void
+    {
+        $this->client->expects($this->once())
+            ->method('createTransaction')
+            ->with(
+                $this->anything(),
+                'TX-nauta-wifi',
+                ['external_id' => 'TX-nauta-wifi', 'product_id' => 35835, 'auto_confirm' => true, 'credit_party_identifier' => ['account_number' => 'usuario@nauta.com.cu']],
+            )
+            ->willReturn(['id' => 'dtone-ref', 'status' => ['id' => 20000, 'message' => 'submitted', 'class' => ['id' => 5, 'message' => 'SUBMITTED']]]);
+
+        $request = new RechargeRequest(
+            transactionId: 'TX-nauta-wifi',
+            phoneNumber: null,
+            productExternalId: '35835',
+            destinationAmount: 250.0,
+            destinationUnit: 'CUP',
+            accountIdentifier: 'usuario@nauta.com.cu',
+        );
+
+        $this->provider->recharge($this->context(), $request);
+    }
+
+    /**
+     * Nauta Hogar Plus exige mobile_number Y account_number a la vez
+     * (confirmado contra el sandbox real el 2026-08-31, articleId 59021 y
+     * otros) — ambos deben viajar juntos en el mismo credit_party_identifier.
+     */
+    public function testRechargeSendsBothMobileNumberAndAccountNumberWhenBothAreSet(): void
+    {
+        $this->client->expects($this->once())
+            ->method('createTransaction')
+            ->with(
+                $this->anything(),
+                'TX-nauta-hogar',
+                [
+                    'external_id' => 'TX-nauta-hogar',
+                    'product_id' => 59021,
+                    'auto_confirm' => true,
+                    'credit_party_identifier' => ['mobile_number' => '+5355501234', 'account_number' => 'usuario@nauta.com.cu'],
+                ],
+            )
+            ->willReturn(['id' => 'dtone-ref', 'status' => ['id' => 20000, 'message' => 'submitted', 'class' => ['id' => 5, 'message' => 'SUBMITTED']]]);
+
+        $request = new RechargeRequest(
+            transactionId: 'TX-nauta-hogar',
+            phoneNumber: '55501234',
+            productExternalId: '59021',
+            destinationAmount: 480.0,
+            destinationUnit: 'CUP',
+            accountIdentifier: 'usuario@nauta.com.cu',
+        );
+
+        $this->provider->recharge($this->context(), $request);
+    }
+
+    /**
      * @dataProvider phoneNumberFormatProvider
      */
     public function testRechargeConvertsPhoneNumberToE164Cuba(string $inputPhoneNumber, string $expectedMobileNumber): void
@@ -291,6 +353,73 @@ class DTOneCommunicationProviderTest extends TestCase
         $products = iterator_to_array($this->provider->fetchProducts($this->context()));
 
         $this->assertSame($expected, $products[0]->isMobileOrInternetService);
+    }
+
+    /**
+     * Confirmado contra el sandbox real de DTOne el 2026-08-31:
+     * `required_credit_party_identifier_fields` es una lista de OPCIONES
+     * alternativas (OR), cada una una lista de campos que deben venir TODOS
+     * juntos (AND). Nauta WIFI Recharge (35835, Utilities/Internet) exige
+     * SOLO `account_number`; Nauta PLUS (57055/57056, el MISMO
+     * service/subservice) exige SOLO `mobile_number`; Nauta Hogar Plus
+     * (59021 y otros, Utilities/Landline) exige AMBOS a la vez — por eso
+     * service/subservice no sirve para derivar esto, hay que leer el campo
+     * real de DTOne y traducirlo al vocabulario neutral de
+     * CommunicationSaleRecharge (mobile_number->phoneNumber,
+     * account_number->accountIdentifier).
+     *
+     * @dataProvider requiredCreditPartyIdentifierFieldsProvider
+     */
+    public function testFetchProductsTranslatesRequiredCreditPartyIdentifierFields(
+        ?array $rawRequiredFields,
+        array $expectedNeutralFields
+    ): void {
+        $item = [
+            'id' => 35835,
+            'name' => 'Nauta Cuba 250 CUP',
+            'type' => 'FIXED_VALUE_RECHARGE',
+            'destination' => ['amount' => 250, 'unit' => 'CUP'],
+            'prices' => ['wholesale' => ['amount' => 9.97, 'unit' => 'EUR']],
+        ];
+        if ($rawRequiredFields !== null) {
+            $item['required_credit_party_identifier_fields'] = $rawRequiredFields;
+        }
+
+        $this->client->method('iterateProducts')->willReturn((function () use ($item) {
+            yield $item;
+        })());
+
+        $products = iterator_to_array($this->provider->fetchProducts($this->context()));
+
+        $this->assertSame($expectedNeutralFields, $products[0]->requiredIdentifierFields);
+    }
+
+    /**
+     * @return iterable<string, array{?array, list<list<string>>}>
+     */
+    public static function requiredCreditPartyIdentifierFieldsProvider(): iterable
+    {
+        yield 'Nauta WIFI Recharge: solo account_number -> accountIdentifier' => [
+            [['account_number']],
+            [['accountIdentifier']],
+        ];
+        yield 'Nauta PLUS: solo mobile_number -> phoneNumber' => [
+            [['mobile_number']],
+            [['phoneNumber']],
+        ];
+        yield 'Nauta Hogar Plus: ambos juntos en la misma opción' => [
+            [['mobile_number', 'account_number']],
+            [['phoneNumber', 'accountIdentifier']],
+        ];
+        yield 'Cubacel (control): solo mobile_number' => [
+            [['mobile_number']],
+            [['phoneNumber']],
+        ];
+        yield 'sin el campo en absoluto (gift cards, etc.)' => [null, []];
+        yield 'campo desconocido de DTOne se descarta, no se inventa' => [
+            [['iban']],
+            [],
+        ];
     }
 
     public function testFetchProductsPreservesServiceShapeForClientPackageCreation(): void

--- a/tests/Service/CommunicationSaleServiceAccountIdentifierDispatchTest.php
+++ b/tests/Service/CommunicationSaleServiceAccountIdentifierDispatchTest.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Entity\Account;
+use App\Entity\Client;
+use App\Entity\CommunicationPackage;
+use App\Entity\CommunicationSaleRecharge;
+use App\Entity\Environment;
+use App\Enums\CommunicationStateEnum;
+use App\Provider\DTOne\DTOneCommunicationProvider;
+use App\Provider\DTOne\DTOneHttpClient;
+use App\Provider\DTOne\DTOneStatusMapper;
+use App\Provider\ProviderContextFactory;
+use App\Provider\ProviderRegistry;
+use App\Provider\ProviderResolver;
+use App\Repository\ClientProviderRoutingRepository;
+use App\Repository\CommunicationSaleRechargeRepository;
+use App\Repository\EnvironmentRepository;
+use App\Repository\SysConfigRepository;
+use App\Service\BalanceService;
+use App\Service\CommunicationSaleService;
+use App\Service\ConfigureSequenceService;
+use App\Service\HistoricalSaleService;
+use App\Service\NotificationCenterService;
+use App\Service\Pricing\PackageCatalogResolver;
+use App\Service\Pricing\PackageOfferSourceEnum;
+use App\Service\Pricing\ResolvedPackageOffer;
+use App\Service\Provider\ProviderAvailabilityService;
+use App\DTO\AccountBalanceDto;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * @covers \App\Service\CommunicationSaleService::invokeRechargeCommunication
+ *
+ * Nauta WIFI Recharge (DTOne) exige SOLO accountIdentifier (cuenta Nauta,
+ * no un número de teléfono) — confirmado contra el sandbox real el
+ * 2026-08-31. invokeRechargeCommunication() debe poder despachar una venta
+ * así sin phoneNumber en absoluto (antes de este fix, strlen(null) sobre
+ * phoneNumber habría fallado — ver el docblock de la clase para la lógica
+ * de sustitución de sandbox, que solo aplica cuando SÍ hay phoneNumber).
+ */
+class CommunicationSaleServiceAccountIdentifierDispatchTest extends TestCase
+{
+    private EntityManagerInterface&MockObject $em;
+    private Connection&MockObject $connection;
+    private BalanceService&MockObject $balanceService;
+    private ProviderAvailabilityService&MockObject $availabilityService;
+    private DTOneHttpClient&MockObject $dtoneClient;
+    private PackageCatalogResolver&MockObject $packageCatalogResolver;
+    private CommunicationSaleService $service;
+
+    protected function setUp(): void
+    {
+        $this->em = $this->createMock(EntityManagerInterface::class);
+        $this->connection = $this->createMock(Connection::class);
+        $this->em->method('getConnection')->willReturn($this->connection);
+
+        $classMetadata = $this->createMock(ClassMetadata::class);
+        $classMetadata->method('getTableName')->willReturn('communication_sale_info');
+        $this->em->method('getClassMetadata')->willReturn($classMetadata);
+
+        $security = $this->createMock(Security::class);
+        $parameters = $this->createMock(ParameterBagInterface::class);
+        $mailer = $this->createMock(MailerInterface::class);
+        $logger = $this->createMock(LoggerInterface::class);
+        $passwordHasher = $this->createMock(UserPasswordHasherInterface::class);
+        $sysConfigRepo = $this->createMock(SysConfigRepository::class);
+        $serializer = $this->createMock(SerializerInterface::class);
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $historicalSaleService = $this->createMock(HistoricalSaleService::class);
+        $this->balanceService = $this->createMock(BalanceService::class);
+        $notificationCenter = $this->createMock(NotificationCenterService::class);
+        $this->availabilityService = $this->createMock(ProviderAvailabilityService::class);
+        $configureSequence = $this->createMock(ConfigureSequenceService::class);
+
+        $this->packageCatalogResolver = $this->createMock(PackageCatalogResolver::class);
+
+        $routingRepo = $this->createMock(ClientProviderRoutingRepository::class);
+        $providerResolver = new ProviderResolver($sysConfigRepo, $routingRepo, new NullLogger());
+        $providerContextFactory = new ProviderContextFactory($providerResolver);
+
+        $this->dtoneClient = $this->createMock(DTOneHttpClient::class);
+        $dtoneProvider = new DTOneCommunicationProvider($this->dtoneClient, new DTOneStatusMapper(), new NullLogger());
+        $providerRegistry = new ProviderRegistry([$dtoneProvider]);
+
+        $this->service = new CommunicationSaleService(
+            $this->em,
+            $security,
+            $parameters,
+            $mailer,
+            $logger,
+            $passwordHasher,
+            $this->createMock(EnvironmentRepository::class),
+            $sysConfigRepo,
+            $serializer,
+            $providerRegistry,
+            $providerResolver,
+            $providerContextFactory,
+            $configureSequence,
+            $messageBus,
+            $historicalSaleService,
+            $this->balanceService,
+            $notificationCenter,
+            $this->availabilityService,
+            $this->packageCatalogResolver,
+            $this->createMock(\App\Provider\ProviderDispatchResolver::class),
+            $this->createMock(\App\Provider\PromotionProviderDispatchResolver::class),
+            $this->createMock(\App\Service\Provider\SaleProviderFailoverService::class),
+        );
+    }
+
+    private function assignId(object $entity, int $id): void
+    {
+        $property = new \ReflectionProperty($entity, 'id');
+        $property->setAccessible(true);
+        $property->setValue($entity, $id);
+    }
+
+    private function buildPendingDtoneRecharge(?string $phoneNumber, ?string $accountIdentifier): CommunicationSaleRecharge
+    {
+        $client = $this->createMock(Client::class);
+        $client->method('getId')->willReturn(1);
+
+        $environment = $this->createMock(Environment::class);
+        $environment->method('getId')->willReturn(10);
+        $environment->method('getType')->willReturn('TEST');
+
+        $account = $this->createMock(Account::class);
+        $account->method('getClient')->willReturn($client);
+        $account->method('getEnvironment')->willReturn($environment);
+        $account->method('getId')->willReturn(99);
+
+        $catalogPackage = $this->createMock(CommunicationPackage::class);
+        $catalogPackage->method('getId')->willReturn(1);
+
+        $this->packageCatalogResolver->method('offerFor')->with($catalogPackage, $account)->willReturn(
+            new ResolvedPackageOffer($catalogPackage, 100.0, 'USD', PackageOfferSourceEnum::PRODUCT_MAX),
+        );
+
+        $recharge = new CommunicationSaleRecharge();
+        $recharge->setPackageId(1);
+        $recharge->setTenant($account);
+        $recharge->setProvider('DTONE');
+        $recharge->setCatalogPackage($catalogPackage);
+        $recharge->setDispatchExternalRef('35835');
+        $recharge->setDestinationAmount(250.0);
+        $recharge->setDestinationCurrency('CUP');
+        $recharge->setTransactionId('2608110100042');
+        $recharge->setPhoneNumber($phoneNumber);
+        $recharge->setAccountIdentifier($accountIdentifier);
+        $recharge->setState(CommunicationStateEnum::PENDING);
+        $recharge->setStateProcess('SENDING');
+        $this->assignId($recharge, 555);
+
+        $saleRepo = $this->createMock(CommunicationSaleRechargeRepository::class);
+        $saleRepo->method('find')->with(555)->willReturn($recharge);
+
+        $environmentRepo = $this->createMock(EnvironmentRepository::class);
+        $environmentRepo->method('find')->with(10)->willReturn($environment);
+
+        $this->em->method('getRepository')->willReturnMap([
+            [CommunicationSaleRecharge::class, $saleRepo],
+            [Environment::class, $environmentRepo],
+        ]);
+
+        return $recharge;
+    }
+
+    private function acceptedDtoneResponse(): array
+    {
+        return [
+            'id' => 999888,
+            'status' => ['class' => ['id' => 1, 'message' => 'ACCEPTED'], 'id' => 10001, 'message' => 'ACCEPTED'],
+        ];
+    }
+
+    public function testDispatchesWithOnlyAccountIdentifierWhenPhoneNumberIsAbsent(): void
+    {
+        $this->buildPendingDtoneRecharge(null, 'usuario@nauta.com.cu');
+        $this->availabilityService->method('canDispatchTo')->willReturn(true);
+        $this->balanceService->method('balance')->willReturn(new AccountBalanceDto('USD', 1000.0));
+        $this->connection->method('executeStatement')->willReturn(1);
+
+        $this->dtoneClient->expects($this->once())
+            ->method('createTransaction')
+            ->with(
+                $this->anything(),
+                $this->anything(),
+                $this->callback(fn (array $body) => $body['credit_party_identifier'] === ['account_number' => 'usuario@nauta.com.cu']),
+            )
+            ->willReturn($this->acceptedDtoneResponse());
+
+        $this->service->invokeRechargeCommunication(555);
+    }
+
+    public function testDispatchesWithBothIdentifiersWhenBothArePresentAndAppliesDtoneSandboxSwapOnlyToPhone(): void
+    {
+        $this->buildPendingDtoneRecharge('5356085160', 'usuario@nauta.com.cu');
+        $this->availabilityService->method('canDispatchTo')->willReturn(true);
+        $this->balanceService->method('balance')->willReturn(new AccountBalanceDto('USD', 1000.0));
+        $this->connection->method('executeStatement')->willReturn(1);
+
+        $this->dtoneClient->expects($this->once())
+            ->method('createTransaction')
+            ->with(
+                $this->anything(),
+                $this->anything(),
+                $this->callback(fn (array $body) => $body['credit_party_identifier'] === [
+                    'mobile_number' => '+5356085100',
+                    'account_number' => 'usuario@nauta.com.cu',
+                ]),
+            )
+            ->willReturn($this->acceptedDtoneResponse());
+
+        $this->service->invokeRechargeCommunication(555);
+    }
+}

--- a/tests/Service/CommunicationSaleServiceRecipientIdentifierValidationTest.php
+++ b/tests/Service/CommunicationSaleServiceRecipientIdentifierValidationTest.php
@@ -1,0 +1,287 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Entity\Account;
+use App\Entity\Client;
+use App\Entity\CommunicationPackage;
+use App\Entity\CommunicationProduct;
+use App\Entity\CommunicationSaleRecharge;
+use App\Entity\Environment;
+use App\Enums\CommunicationProviderEnum;
+use App\Exception\MyCurrentException;
+use App\Provider\ProviderContextFactory;
+use App\Provider\ProviderDispatchResolver;
+use App\Provider\ProviderRegistry;
+use App\Provider\ProviderResolver;
+use App\Provider\SelectedDispatch;
+use App\Repository\ClientProviderRoutingRepository;
+use App\Repository\EnvironmentRepository;
+use App\Repository\SysConfigRepository;
+use App\Service\BalanceService;
+use App\Service\CommunicationSaleService;
+use App\Service\ConfigureSequenceService;
+use App\Service\HistoricalSaleService;
+use App\Service\NotificationCenterService;
+use App\Service\Pricing\PackageCatalogResolver;
+use App\Service\Pricing\PackageOfferSourceEnum;
+use App\Service\Pricing\ResolvedPackageOffer;
+use App\Service\Provider\ProviderAvailabilityService;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * @covers \App\Service\CommunicationSaleService::processRecharge
+ *
+ * Cubre la validación síncrona (en admisión, antes de persistir la venta)
+ * de qué identificador(es) de destino exige el producto resuelto — ver
+ * CommunicationProduct::$requiredIdentifierFields. Confirmado contra el
+ * sandbox real de DTOne el 2026-08-31: Nauta WIFI Recharge exige SOLO
+ * accountIdentifier, Nauta PLUS SOLO phoneNumber, y Nauta Hogar Plus AMBOS
+ * a la vez — todos con el MISMO service/subservice, así que el chequeo
+ * tiene que ser contra requiredIdentifierFields, no contra ningún atajo de
+ * catálogo. Rechazar aquí, de forma síncrona, evita que una venta admitida
+ * sin el dato correcto quede fallando en silencio en el worker async (ver
+ * CommunicationSaleServiceAccountIdentifierDispatchTest para el lado del
+ * despacho).
+ */
+class CommunicationSaleServiceRecipientIdentifierValidationTest extends TestCase
+{
+    private EntityManagerInterface&MockObject $em;
+    private Security&MockObject $security;
+    private BalanceService&MockObject $balanceService;
+    private PackageCatalogResolver&MockObject $packageCatalogResolver;
+    private ProviderDispatchResolver&MockObject $dispatchResolver;
+    private CommunicationSaleService $service;
+
+    protected function setUp(): void
+    {
+        $this->em = $this->createMock(EntityManagerInterface::class);
+        $this->security = $this->createMock(Security::class);
+        $sysConfigRepo = $this->createMock(SysConfigRepository::class);
+        $this->balanceService = $this->createMock(BalanceService::class);
+        $availabilityService = $this->createMock(ProviderAvailabilityService::class);
+        $this->packageCatalogResolver = $this->createMock(PackageCatalogResolver::class);
+        $this->dispatchResolver = $this->createMock(ProviderDispatchResolver::class);
+        $promotionDispatchResolver = $this->createMock(\App\Provider\PromotionProviderDispatchResolver::class);
+
+        $parameters = $this->createMock(ParameterBagInterface::class);
+        $mailer = $this->createMock(MailerInterface::class);
+        $logger = $this->createMock(LoggerInterface::class);
+        $passwordHasher = $this->createMock(UserPasswordHasherInterface::class);
+        $environmentRepository = $this->createMock(EnvironmentRepository::class);
+        $serializer = $this->createMock(SerializerInterface::class);
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $historicalSaleService = $this->createMock(HistoricalSaleService::class);
+        $notificationCenter = $this->createMock(NotificationCenterService::class);
+        $configureSequence = $this->createMock(ConfigureSequenceService::class);
+        $configureSequence->method('getLastSequence')->willReturn(1);
+
+        $routingRepo = $this->createMock(ClientProviderRoutingRepository::class);
+        $providerRegistry = new ProviderRegistry([]);
+        $providerResolver = new ProviderResolver($sysConfigRepo, $routingRepo, $this->createMock(LoggerInterface::class));
+        $providerContextFactory = new ProviderContextFactory($providerResolver);
+
+        $this->service = new CommunicationSaleService(
+            $this->em,
+            $this->security,
+            $parameters,
+            $mailer,
+            $logger,
+            $passwordHasher,
+            $environmentRepository,
+            $sysConfigRepo,
+            $serializer,
+            $providerRegistry,
+            $providerResolver,
+            $providerContextFactory,
+            $configureSequence,
+            $messageBus,
+            $historicalSaleService,
+            $this->balanceService,
+            $notificationCenter,
+            $availabilityService,
+            $this->packageCatalogResolver,
+            $this->dispatchResolver,
+            $promotionDispatchResolver,
+            $this->createMock(\App\Service\Provider\SaleProviderFailoverService::class),
+        );
+    }
+
+    private function account(): Account&MockObject
+    {
+        $client = $this->createMock(Client::class);
+        $client->method('getId')->willReturn(1);
+
+        $environment = $this->createMock(Environment::class);
+        $environment->method('getId')->willReturn(10);
+
+        $account = $this->createMock(Account::class);
+        $account->method('getClient')->willReturn($client);
+        $account->method('getEnvironment')->willReturn($environment);
+        $account->method('getId')->willReturn(99);
+
+        return $account;
+    }
+
+    private function catalogPackage(): CommunicationPackage
+    {
+        $package = (new CommunicationPackage())
+            ->setName('Nauta')
+            ->setDescription('Nauta')
+            ->setDestinationAmount(250.0)
+            ->setDestinationCurrency('CUP');
+
+        $property = new \ReflectionProperty($package, 'id');
+        $property->setAccessible(true);
+        $property->setValue($package, 42);
+
+        return $package;
+    }
+
+    /**
+     * @param list<list<string>> $requiredIdentifierFields
+     */
+    private function stubAdmission(array $requiredIdentifierFields): CommunicationPackage
+    {
+        $account = $this->account();
+        $this->security->method('getUser')->willReturn($account);
+
+        $package = $this->catalogPackage();
+        $repo = $this->createMock(EntityRepository::class);
+        $repo->method('find')->willReturn($package);
+        $this->em->method('getRepository')->willReturnMap([
+            [CommunicationPackage::class, $repo],
+        ]);
+
+        $product = $this->createMock(CommunicationProduct::class);
+        $product->method('getRequiredIdentifierFields')->willReturn($requiredIdentifierFields);
+
+        $this->packageCatalogResolver->method('offerForSale')
+            ->willReturn(new ResolvedPackageOffer($package, 9.97, 'USD', PackageOfferSourceEnum::PRODUCT_MAX));
+        $this->dispatchResolver->method('select')
+            ->willReturn(new SelectedDispatch(CommunicationProviderEnum::DTONE, $product, '35835'));
+        $this->balanceService->method('hasAvailableBalance')->willReturn(true);
+
+        return $package;
+    }
+
+    public function testAcceptsNautaWifiRechargeWithOnlyAccountIdentifier(): void
+    {
+        $this->stubAdmission([['accountIdentifier']]);
+
+        $recharge = new CommunicationSaleRecharge();
+        $recharge->setPackageId(42);
+        $recharge->setAccountIdentifier('usuario@nauta.com.cu');
+
+        $result = $this->service->processRecharge($recharge);
+
+        $this->assertSame('usuario@nauta.com.cu', $result->getAccountIdentifier());
+    }
+
+    public function testRejectsNautaWifiRechargeWithOnlyPhoneNumber(): void
+    {
+        $this->stubAdmission([['accountIdentifier']]);
+
+        $recharge = new CommunicationSaleRecharge();
+        $recharge->setPackageId(42);
+        $recharge->setPhoneNumber('55501234');
+
+        $this->expectException(MyCurrentException::class);
+
+        $this->service->processRecharge($recharge);
+    }
+
+    public function testAcceptsNautaPlusWithOnlyPhoneNumber(): void
+    {
+        $this->stubAdmission([['phoneNumber']]);
+
+        $recharge = new CommunicationSaleRecharge();
+        $recharge->setPackageId(42);
+        $recharge->setPhoneNumber('55501234');
+
+        $result = $this->service->processRecharge($recharge);
+
+        $this->assertSame('55501234', $result->getPhoneNumber());
+    }
+
+    public function testRejectsNautaHogarWithOnlyPhoneNumberWhenBothAreRequiredTogether(): void
+    {
+        $this->stubAdmission([['phoneNumber', 'accountIdentifier']]);
+
+        $recharge = new CommunicationSaleRecharge();
+        $recharge->setPackageId(42);
+        $recharge->setPhoneNumber('55501234');
+
+        $this->expectException(MyCurrentException::class);
+
+        $this->service->processRecharge($recharge);
+    }
+
+    public function testAcceptsNautaHogarWithBothFieldsWhenBothAreRequiredTogether(): void
+    {
+        $this->stubAdmission([['phoneNumber', 'accountIdentifier']]);
+
+        $recharge = new CommunicationSaleRecharge();
+        $recharge->setPackageId(42);
+        $recharge->setPhoneNumber('55501234');
+        $recharge->setAccountIdentifier('usuario@nauta.com.cu');
+
+        $result = $this->service->processRecharge($recharge);
+
+        $this->assertSame('55501234', $result->getPhoneNumber());
+        $this->assertSame('usuario@nauta.com.cu', $result->getAccountIdentifier());
+    }
+
+    public function testAcceptsEitherAlternativeWhenProductDeclaresMultipleOptions(): void
+    {
+        $this->stubAdmission([['phoneNumber'], ['accountIdentifier']]);
+
+        $recharge = new CommunicationSaleRecharge();
+        $recharge->setPackageId(42);
+        $recharge->setAccountIdentifier('usuario@nauta.com.cu');
+
+        $result = $this->service->processRecharge($recharge);
+
+        $this->assertSame('usuario@nauta.com.cu', $result->getAccountIdentifier());
+    }
+
+    /**
+     * Producto sin requiredIdentifierFields declarado (catálogo histórico,
+     * incluido ETECSA/Cubacel de siempre) — comportamiento anterior a este
+     * fix: se sigue exigiendo phoneNumber.
+     */
+    public function testLegacyProductWithNoDeclaredFieldsStillRequiresPhoneNumber(): void
+    {
+        $this->stubAdmission([]);
+
+        $recharge = new CommunicationSaleRecharge();
+        $recharge->setPackageId(42);
+
+        $this->expectException(MyCurrentException::class);
+
+        $this->service->processRecharge($recharge);
+    }
+
+    public function testLegacyProductWithNoDeclaredFieldsAcceptsPhoneNumber(): void
+    {
+        $this->stubAdmission([]);
+
+        $recharge = new CommunicationSaleRecharge();
+        $recharge->setPackageId(42);
+        $recharge->setPhoneNumber('55501234');
+
+        $result = $this->service->processRecharge($recharge);
+
+        $this->assertSame('55501234', $result->getPhoneNumber());
+    }
+}

--- a/tests/Service/CommunicationSaleServiceV2AdmissionTest.php
+++ b/tests/Service/CommunicationSaleServiceV2AdmissionTest.php
@@ -184,6 +184,7 @@ class CommunicationSaleServiceV2AdmissionTest extends TestCase
 
         $recharge = new CommunicationSaleRecharge();
         $recharge->setPackageId(42);
+        $recharge->setPhoneNumber('5550001234');
 
         $result = $this->service->processRecharge($recharge);
 

--- a/tests/Service/Pricing/CommunicationPackageAdminServiceTest.php
+++ b/tests/Service/Pricing/CommunicationPackageAdminServiceTest.php
@@ -309,6 +309,7 @@ class CommunicationPackageAdminServiceTest extends TestCase
         $product->method('getDescription')->willReturn('Cubacel');
         $product->method('getPrice')->willReturn(11.36);
         $product->method('getPriceCurrency')->willReturn('USD');
+        $product->method('getRequiredIdentifierFields')->willReturn([['phoneNumber', 'accountIdentifier']]);
 
         $environment = $this->createMock(Environment::class);
         $this->productRepository->expects($this->once())
@@ -325,6 +326,7 @@ class CommunicationPackageAdminServiceTest extends TestCase
             'description' => 'Cubacel',
             'wholesalePrice' => 11.36,
             'priceCurrency' => 'USD',
+            'requiredIdentifierFields' => [['phoneNumber', 'accountIdentifier']],
         ]], $coverage);
     }
 }

--- a/tests/Service/Provider/CommunicationCatalogSyncServiceTest.php
+++ b/tests/Service/Provider/CommunicationCatalogSyncServiceTest.php
@@ -42,7 +42,7 @@ class CommunicationCatalogSyncServiceTest extends TestCase
         return new CommunicationCatalogSyncService($this->em, $registry);
     }
 
-    private function fakeProduct(string $externalId, string $name = 'Combo', float $price = 10.0, bool $enabled = true): ProviderProductDto
+    private function fakeProduct(string $externalId, string $name = 'Combo', float $price = 10.0, bool $enabled = true, array $requiredIdentifierFields = []): ProviderProductDto
     {
         return new ProviderProductDto(
             externalId: $externalId,
@@ -62,6 +62,7 @@ class CommunicationCatalogSyncServiceTest extends TestCase
             raw: [],
             isMobileOrInternetService: true,
             service: ['name' => 'MOBILE', 'subservice' => ['name' => 'AIRTIME']],
+            requiredIdentifierFields: $requiredIdentifierFields,
         );
     }
 
@@ -183,6 +184,38 @@ class CommunicationCatalogSyncServiceTest extends TestCase
         $this->assertSame(12.5, $persisted->getPrice());
         $this->assertTrue($persisted->isEnabled());
         $this->assertSame($environment, $persisted->getEnvironment());
+    }
+
+    /**
+     * requiredIdentifierFields viaja tal cual del ProviderProductDto al
+     * CommunicationProduct persistido — es lo que
+     * CommunicationSaleService usa para saber qué identificador(es) de
+     * destino exigir en el momento de la venta (ver
+     * DTOneCommunicationProviderTest para cómo cada adaptador lo deriva
+     * del proveedor real).
+     */
+    public function testPersistsRequiredIdentifierFieldsFromDto(): void
+    {
+        $environment = $this->createMock(Environment::class);
+        $environment->method('getType')->willReturn('PROD');
+        $environment->method('getId')->willReturn(4);
+
+        $this->productRepo->method('findOneBy')->willReturn(null);
+
+        /** @var CommunicationProduct|null $persisted */
+        $persisted = null;
+        $this->em->method('persist')->willReturnCallback(function ($entity) use (&$persisted) {
+            $persisted = $entity;
+        });
+
+        $adapter = $this->etecsaAdapterReturning([
+            $this->fakeProduct('100', requiredIdentifierFields: [['accountIdentifier']]),
+        ]);
+        $service = $this->serviceWithAdapter($adapter);
+
+        $service->syncProducts(CommunicationProviderEnum::ETECSA, $environment);
+
+        $this->assertSame([['accountIdentifier']], $persisted->getRequiredIdentifierFields());
     }
 
     public function testNonNumericExternalIdFallsBackToZeroPackageId(): void


### PR DESCRIPTION
## Summary
- DTOne y CSQ confirmaron contra sandbox real que Nauta WIFI Recharge exige cuenta Nauta (`accountIdentifier`), Nauta PLUS exige número de teléfono, y Nauta Hogar Plus exige ambos a la vez — los tres comparten el mismo `service`/`subservice`, así que no se podía inferir del catálogo.
- `CommunicationProduct.requiredIdentifierFields` (nueva columna JSON) persiste, por producto, qué identificador(es) exige el proveedor real, en vocabulario neutral (`phoneNumber`/`accountIdentifier`). Poblado en el sync de catálogo de DTOne (traduce `mobile_number`/`account_number`) y CSQ (consulta `/pre-paid/recharge/parameters` por `articleId`).
- `RechargeRequest`, `CommunicationSaleRecharge` y `ReserveRecharge` aceptan `accountIdentifier`; `phoneNumber` pasa a opcional.
- `CommunicationSaleService` valida sincrónicamente en admisión (`400` claro si falta el identificador que el producto exige) y arma el payload de cada proveedor con lo que corresponda.
- Expuesto en `/catalog/packages/{id}/{bindings,coverage}` y `/promotions/{id}/bindings` para que el admin vea el requisito al vincular un producto (ver PR hermano en dashboard-cm).

## Test plan
- [x] TDD en cada capa (modelo, adaptadores DTOne/CSQ, validación de admisión, endpoints admin)
- [x] `php bin/phpunit --no-coverage` — 1144 tests en verde
- [x] `vendor/bin/phpstan analyse` — limpio
- [x] Verificado en vivo contra staging (venta real 5314: campo `accountIdentifier` viajó correctamente a DTOne y CSQ tras el failover; el rechazo final fue por saldo/ruta de Nauta en CSQ, no por el fix)

Ver PR hermano en dashboard-cm para la visibilidad del requisito en el dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpuoujmXjvtQPm1mz1x6Ax