### PR TITLE
feat(promotions): vincula paquetes de promoción a productos por proveedor

### DIFF
--- a/src/Controller/DashboardPromotionController.php
+++ b/src/Controller/DashboardPromotionController.php
@@ -15,6 +15,7 @@ use App\OpenApi\Attribute\DashboardEndpoint;
 use App\Repository\CommunicationPromotionsRepository;
 use App\Service\CommunicationPromotionService;
 use App\Service\Pricing\CommunicationContractService;
+use App\Service\Pricing\CommunicationPackageBindingService;
 use App\Service\Pricing\CommunicationPromotionBindingService;
 use App\Service\Pricing\CommunicationPromotionEquivalenceService;
 use App\Service\Pricing\PromotionEquivalenceResult;
@@ -36,6 +37,7 @@ class DashboardPromotionController extends AbstractController
         private readonly NormalizerInterface $serializer,
         private readonly CommunicationPromotionService $promotionService,
         private readonly CommunicationPromotionBindingService $bindingService,
+        private readonly CommunicationPackageBindingService $packageBindingService,
         private readonly CommunicationPromotionEquivalenceService $equivalenceService,
         private readonly CommunicationContractService $contractService,
     ) {
@@ -200,6 +202,32 @@ class DashboardPromotionController extends AbstractController
         $this->em->flush();
 
         return $this->json(['deleted' => true]);
+    }
+
+    #[Route('/{id}/packages', name: 'dashboard_promotions_packages_list', methods: ['GET'])]
+    #[DashboardEndpoint(summary: 'Paquetes generados por una promoción V2 con su cobertura por proveedor', tag: 'Promotions')]
+    public function listPackages(int $id): JsonResponse
+    {
+        $promotion = $this->repository->find($id);
+        if ($promotion === null) {
+            return $this->json(['error' => ['message' => 'Promotion not found']], Response::HTTP_NOT_FOUND);
+        }
+
+        $rows = $this->packageBindingService->listPromotionPackageBindings($promotion);
+
+        return $this->json(array_map(fn (array $row) => [
+            'packageId' => $row['package']->getId(),
+            'name' => $row['package']->getName(),
+            'destinationAmount' => $row['package']->getDestinationAmount(),
+            'destinationCurrency' => $row['package']->getDestinationCurrency(),
+            'bindings' => array_map(fn (array $b) => [
+                'provider' => $b['provider'],
+                'productId' => $b['product']->getId(),
+                'externalRef' => $b['product']->getExternalRef(),
+                'description' => $b['product']->getDescription(),
+            ], $row['bindings']),
+            'missingProviders' => $row['missingProviders'],
+        ], $rows));
     }
 
     #[Route('/{id}/bindings', name: 'dashboard_promotions_bindings_list', methods: ['GET'])]

--- a/src/DTO/UpdatePromotionDto.php
+++ b/src/DTO/UpdatePromotionDto.php
@@ -75,6 +75,39 @@ class UpdatePromotionDto implements IInput
 
     protected ?string $priority;
 
+    /**
+     * Solo V2 — mismo "{monto}" que CreatePromotionV2Dto::$packageNameTemplate,
+     * renderizado por CommunicationPromotionService::updatePackageMetadata()
+     * contra el destinationAmount propio de cada paquete generado.
+     */
+    #[Assert\Length(max: 255)]
+    protected ?string $packageNameTemplate;
+
+    #[Assert\Length(max: 255)]
+    protected ?string $packageDescriptionTemplate;
+
+    protected ?array $tags;
+
+    protected ?array $service;
+
+    #[Assert\PositiveOrZero]
+    protected ?int $displayOrder;
+
+    /**
+     * El rango de una promoción V2 (montos, salto, moneda) define QUÉ
+     * paquetes existen — cambiarlo después de creada invalidaría los
+     * vínculos por proveedor ya hechos sobre los paquetes actuales. No son
+     * editables: si llegan, update() rechaza explícitamente en vez de
+     * ignorarlos en silencio (ver PROMOTION_V2_RANGE_IMMUTABLE).
+     */
+    protected ?float $amountFrom;
+
+    protected ?float $amountTo;
+
+    protected ?float $amountStep;
+
+    protected ?string $destinationCurrency;
+
     public function __construct(
         ?string $name = null,
         ?string $description = null,
@@ -88,6 +121,15 @@ class UpdatePromotionDto implements IInput
         ?int $productId = null,
         ?int $environmentId = null,
         ?string $priority = null,
+        ?string $packageNameTemplate = null,
+        ?string $packageDescriptionTemplate = null,
+        ?array $tags = null,
+        ?array $service = null,
+        ?int $displayOrder = null,
+        ?float $amountFrom = null,
+        ?float $amountTo = null,
+        ?float $amountStep = null,
+        ?string $destinationCurrency = null,
     ) {
         $this->name = $name;
         $this->description = $description;
@@ -101,6 +143,15 @@ class UpdatePromotionDto implements IInput
         $this->productId = $productId;
         $this->environmentId = $environmentId;
         $this->priority = $priority;
+        $this->packageNameTemplate = $packageNameTemplate;
+        $this->packageDescriptionTemplate = $packageDescriptionTemplate;
+        $this->tags = $tags;
+        $this->service = $service;
+        $this->displayOrder = $displayOrder;
+        $this->amountFrom = $amountFrom;
+        $this->amountTo = $amountTo;
+        $this->amountStep = $amountStep;
+        $this->destinationCurrency = $destinationCurrency;
     }
 
     #[Assert\Callback]
@@ -150,4 +201,31 @@ class UpdatePromotionDto implements IInput
 
     public function getPriority(): ?string { return $this->priority; }
     public function setPriority(?string $v): void { $this->priority = $v; }
+
+    public function getPackageNameTemplate(): ?string { return $this->packageNameTemplate; }
+    public function setPackageNameTemplate(?string $v): void { $this->packageNameTemplate = $v; }
+
+    public function getPackageDescriptionTemplate(): ?string { return $this->packageDescriptionTemplate; }
+    public function setPackageDescriptionTemplate(?string $v): void { $this->packageDescriptionTemplate = $v; }
+
+    public function getTags(): ?array { return $this->tags; }
+    public function setTags(?array $v): void { $this->tags = $v; }
+
+    public function getService(): ?array { return $this->service; }
+    public function setService(?array $v): void { $this->service = $v; }
+
+    public function getDisplayOrder(): ?int { return $this->displayOrder; }
+    public function setDisplayOrder(?int $v): void { $this->displayOrder = $v; }
+
+    public function getAmountFrom(): ?float { return $this->amountFrom; }
+    public function setAmountFrom(?float $v): void { $this->amountFrom = $v; }
+
+    public function getAmountTo(): ?float { return $this->amountTo; }
+    public function setAmountTo(?float $v): void { $this->amountTo = $v; }
+
+    public function getAmountStep(): ?float { return $this->amountStep; }
+    public function setAmountStep(?float $v): void { $this->amountStep = $v; }
+
+    public function getDestinationCurrency(): ?string { return $this->destinationCurrency; }
+    public function setDestinationCurrency(?string $v): void { $this->destinationCurrency = $v; }
 }

--- a/src/Service/CommunicationPromotionService.php
+++ b/src/Service/CommunicationPromotionService.php
@@ -307,16 +307,27 @@ class CommunicationPromotionService extends CommonService
      */
     public function update(CommunicationPromotions $promotion, UpdatePromotionDto $dto): CommunicationPromotions
     {
-        // Falla ANTES de mutar nada — evita el caso raro de mandar
-        // productId+benefits en la misma petición, donde setProduct() más
-        // abajo cambiaría isV2() a mitad del método.
-        if ($dto->getBenefits() !== null && !$promotion->isV2()) {
-            throw new MyCurrentException(
-                'PROMOTION_BENEFITS_NOT_APPLICABLE',
-                'Esta promoción no es V2 — los beneficios se editan con terms, no benefits',
-                400,
-            );
+        // El rango [amountFrom, amountTo, amountStep] + destinationCurrency
+        // define qué CommunicationPackage existen — cambiarlo después de
+        // crear la promoción invalidaría los vínculos por proveedor ya
+        // hechos sobre los paquetes actuales. Se rechaza explícito en vez
+        // de ignorarlo en silencio.
+        foreach (['amountFrom', 'amountTo', 'amountStep', 'destinationCurrency'] as $field) {
+            $getter = 'get' . ucfirst($field);
+            if ($dto->$getter() !== null) {
+                throw new MyCurrentException(
+                    'PROMOTION_V2_RANGE_IMMUTABLE',
+                    "El rango de una promoción V2 no es editable ({$field})",
+                    400,
+                );
+            }
         }
+
+        $hasPackageMetadata = $dto->getPackageNameTemplate() !== null
+            || $dto->getPackageDescriptionTemplate() !== null
+            || $dto->getTags() !== null
+            || $dto->getService() !== null
+            || $dto->getDisplayOrder() !== null;
 
         if ($dto->getName() !== null) {
             $promotion->setName($dto->getName());
@@ -387,16 +398,64 @@ class CommunicationPromotionService extends CommonService
             $this->updatePackageBenefits($promotion, $dto->getBenefits());
         }
 
+        if ($hasPackageMetadata) {
+            $this->updatePackageMetadata(
+                $promotion,
+                $dto->getPackageNameTemplate(),
+                $dto->getPackageDescriptionTemplate(),
+                $dto->getTags(),
+                $dto->getService(),
+                $dto->getDisplayOrder(),
+            );
+        }
+
         return $promotion;
     }
 
     /**
-     * Beneficios "plantilla" de una promoción V2 — se toman de un
+     * Propaga name/description (renderizados por monto vía
+     * packageNameTemplate/packageDescriptionTemplate, mismo "{monto}" que
+     * CreatePromotionV2Dto), tags, service y displayOrder a TODOS los
+     * CommunicationPackage vinculados a esta promoción — reutiliza
+     * CommunicationPackageAdminService::update() por paquete, así que
+     * incluye su misma guarda de categoría bloqueada
+     * (COMMUNICATION_PACKAGE_CATEGORY_LOCKED) al tocar `service`.
+     *
+     * @return int cantidad de paquetes actualizados
+     */
+    public function updatePackageMetadata(
+        CommunicationPromotions $promotion,
+        ?string $nameTemplate,
+        ?string $descriptionTemplate,
+        ?array $tags,
+        ?array $service,
+        ?int $displayOrder,
+    ): int {
+        $packages = $this->packageRepository->findByPromotion($promotion);
+        foreach ($packages as $package) {
+            $amount = (float) $package->getDestinationAmount();
+            $this->packageAdminService->update($package, new UpdateCommunicationPackageDto(
+                name: $nameTemplate !== null ? $this->packageAdminService->renderTemplate($nameTemplate, $amount) : null,
+                description: $descriptionTemplate !== null ? $this->packageAdminService->renderTemplate($descriptionTemplate, $amount) : null,
+                displayOrder: $displayOrder,
+                tags: $tags,
+                service: $service,
+            ));
+        }
+
+        return count($packages);
+    }
+
+    /**
+     * Beneficios "plantilla" de una promoción — se toman de un
      * CommunicationPackage cualquiera vinculado (todos comparten el mismo
      * array salvo lo que CommunicationPackageAdminService::
      * applyCreditBenefitDefaults() recalcula por paquete, ver
      * updatePackageBenefits()). Vacío si la promoción todavía no tiene
-     * paquetes vinculados, o si es V1 (esa usa getTerms(), no esto).
+     * ningún CommunicationPackage vinculado — el dashboard ya no distingue
+     * "V1"/"V2" al editar: toda promoción usa esta misma pestaña de
+     * beneficios, y una promoción sin paquetes generados simplemente no
+     * tiene nada que mostrar acá.
      *
      * @return list<array<string, mixed>>
      */
@@ -415,22 +474,14 @@ class CommunicationPromotionService extends CommonService
      * amount.base contra el destinationAmount propio de cada uno, igual que
      * al crear el batch original (createV2()): un mismo array "plantilla"
      * produce el texto/monto correcto en cada paquete pese a tener montos
-     * de destino distintos.
+     * de destino distintos. No-op seguro (0 paquetes actualizados) para una
+     * promoción sin ningún CommunicationPackage vinculado — el dashboard ya
+     * no distingue "V1"/"V2" al editar, así que esto nunca debe fallar.
      *
      * @return int cantidad de paquetes actualizados
-     *
-     * @throws MyCurrentException si la promoción no es V2
      */
     public function updatePackageBenefits(CommunicationPromotions $promotion, array $benefits): int
     {
-        if (!$promotion->isV2()) {
-            throw new MyCurrentException(
-                'PROMOTION_BENEFITS_NOT_APPLICABLE',
-                'Esta promoción no es V2 — los beneficios se editan con terms, no benefits',
-                400,
-            );
-        }
-
         $packages = $this->packageRepository->findByPromotion($promotion);
         foreach ($packages as $package) {
             $this->packageAdminService->update($package, new UpdateCommunicationPackageDto(benefits: $benefits));

--- a/src/Service/Pricing/CommunicationPackageAdminService.php
+++ b/src/Service/Pricing/CommunicationPackageAdminService.php
@@ -139,7 +139,13 @@ class CommunicationPackageAdminService
         return $packages;
     }
 
-    private function renderTemplate(string $template, float $amount): string
+    /**
+     * Expuesto (no solo uso interno de createBatch()) para que
+     * CommunicationPromotionService::updatePackageMetadata() pueda
+     * re-renderizar name/description contra el destinationAmount propio de
+     * cada paquete YA existente al editar una promoción V2.
+     */
+    public function renderTemplate(string $template, float $amount): string
     {
         return str_replace('{monto}', self::formatAmount($amount), $template);
     }

--- a/src/Service/Pricing/CommunicationPackageBindingService.php
+++ b/src/Service/Pricing/CommunicationPackageBindingService.php
@@ -5,10 +5,12 @@ namespace App\Service\Pricing;
 use App\Entity\CommunicationPackage;
 use App\Entity\CommunicationPackageProviderProduct;
 use App\Entity\CommunicationProduct;
+use App\Entity\CommunicationPromotions;
 use App\Entity\Environment;
 use App\Exception\MyCurrentException;
 use App\Provider\ProviderRegistry;
 use App\Repository\CommunicationPackageProviderProductRepository;
+use App\Repository\CommunicationPackageRepository;
 use App\Repository\CommunicationProductRepository;
 use Doctrine\ORM\EntityManagerInterface;
 
@@ -26,6 +28,7 @@ class CommunicationPackageBindingService
         private readonly EntityManagerInterface $em,
         private readonly CommunicationPackageProviderProductRepository $bindingRepo,
         private readonly CommunicationProductRepository $productRepository,
+        private readonly CommunicationPackageRepository $packageRepository,
         private readonly ProviderRegistry $providerRegistry,
     ) {
     }
@@ -70,6 +73,40 @@ class CommunicationPackageBindingService
                 'boundProduct' => $bindingsByProvider[$provider] ?? null,
                 'candidates' => $candidates,
                 'autoMatched' => $autoMatched,
+            ];
+        }
+
+        return $rows;
+    }
+
+    /**
+     * Cobertura por proveedor de todos los paquetes generados por una
+     * promoción V2 — el tab "Proveedores" del flujo de promociones se apoya
+     * en esto para mostrar de una vez qué paquetes quedan sin despachar por
+     * qué proveedor (ver ProviderDispatchResolver::findDispatchableProduct(),
+     * que nunca hace auto-match para un paquete de promoción). No incluye
+     * candidatos — esta lista es de resumen; los candidatos por paquete se
+     * piden bajo demanda con listBindings().
+     *
+     * @return list<array{package: CommunicationPackage, bindings: list<array{provider: string, product: CommunicationProduct}>, missingProviders: list<string>}>
+     */
+    public function listPromotionPackageBindings(CommunicationPromotions $promotion): array
+    {
+        $registeredProviders = array_map(static fn ($p) => $p->value, $this->providerRegistry->registered());
+
+        $rows = [];
+        foreach ($this->packageRepository->findByPromotion($promotion) as $package) {
+            $bindings = [];
+            $boundProviders = [];
+            foreach ($this->bindingRepo->findAllForPackage($package) as $binding) {
+                $bindings[] = ['provider' => $binding->getProvider(), 'product' => $binding->getProduct()];
+                $boundProviders[] = $binding->getProvider();
+            }
+
+            $rows[] = [
+                'package' => $package,
+                'bindings' => $bindings,
+                'missingProviders' => array_values(array_diff($registeredProviders, $boundProviders)),
             ];
         }
 

--- a/tests/Controller/DashboardPromotionControllerTest.php
+++ b/tests/Controller/DashboardPromotionControllerTest.php
@@ -15,6 +15,7 @@ use App\Repository\CommunicationPromotionsRepository;
 use App\Service\CommunicationPromotionService;
 use App\Service\CreatePromotionV2Result;
 use App\Service\Pricing\CommunicationContractService;
+use App\Service\Pricing\CommunicationPackageBindingService;
 use App\Service\Pricing\CommunicationPromotionBindingService;
 use App\Service\Pricing\CommunicationPromotionEquivalenceService;
 use App\Service\Pricing\PromotionEquivalenceResult;
@@ -36,6 +37,7 @@ class DashboardPromotionControllerTest extends TestCase
 {
     private CommunicationPromotionsRepository&MockObject $repository;
     private CommunicationPromotionBindingService&MockObject $bindingService;
+    private CommunicationPackageBindingService&MockObject $packageBindingService;
     private CommunicationPromotionService&MockObject $promotionService;
     private CommunicationPromotionEquivalenceService&MockObject $equivalenceService;
     private CommunicationContractService&MockObject $contractService;
@@ -46,6 +48,7 @@ class DashboardPromotionControllerTest extends TestCase
     {
         $this->repository = $this->createMock(CommunicationPromotionsRepository::class);
         $this->bindingService = $this->createMock(CommunicationPromotionBindingService::class);
+        $this->packageBindingService = $this->createMock(CommunicationPackageBindingService::class);
         $this->promotionService = $this->createMock(CommunicationPromotionService::class);
         $this->equivalenceService = $this->createMock(CommunicationPromotionEquivalenceService::class);
         $this->contractService = $this->createMock(CommunicationContractService::class);
@@ -58,6 +61,7 @@ class DashboardPromotionControllerTest extends TestCase
             $this->serializer,
             $this->promotionService,
             $this->bindingService,
+            $this->packageBindingService,
             $this->equivalenceService,
             $this->contractService,
         );
@@ -182,6 +186,60 @@ class DashboardPromotionControllerTest extends TestCase
 
         $data = json_decode($response->getContent(), true);
         $this->assertTrue($data['deleted']);
+    }
+
+    public function testListPackagesReturnsNotFoundWhenPromotionDoesNotExist(): void
+    {
+        $this->repository->method('find')->willReturn(null);
+
+        $response = $this->controller->listPackages(999);
+
+        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+    }
+
+    public function testListPackagesReturnsOneRowPerPackageWithMissingProviders(): void
+    {
+        $promotion = new CommunicationPromotions();
+        $this->repository->method('find')->willReturn($promotion);
+
+        $package = $this->createMock(CommunicationPackage::class);
+        $package->method('getId')->willReturn(42);
+        $package->method('getName')->willReturn('Cubacel 500 CUP');
+        $package->method('getDestinationAmount')->willReturn(500.0);
+        $package->method('getDestinationCurrency')->willReturn('CUP');
+
+        $this->packageBindingService->method('listPromotionPackageBindings')->with($promotion)->willReturn([
+            [
+                'package' => $package,
+                'bindings' => [['provider' => 'CSQ', 'product' => $this->product()]],
+                'missingProviders' => ['DTONE', 'ETECSA'],
+            ],
+        ]);
+
+        $response = $this->controller->listPackages(1);
+
+        $data = json_decode($response->getContent(), true);
+        $this->assertCount(1, $data);
+        $this->assertSame(42, $data[0]['packageId']);
+        $this->assertSame('Cubacel 500 CUP', $data[0]['name']);
+        $this->assertEquals(500.0, $data[0]['destinationAmount']);
+        $this->assertSame('CUP', $data[0]['destinationCurrency']);
+        $this->assertCount(1, $data[0]['bindings']);
+        $this->assertSame('CSQ', $data[0]['bindings'][0]['provider']);
+        $this->assertSame(1, $data[0]['bindings'][0]['productId']);
+        $this->assertSame('ref-1', $data[0]['bindings'][0]['externalRef']);
+        $this->assertSame(['DTONE', 'ETECSA'], $data[0]['missingProviders']);
+    }
+
+    public function testListPackagesReturnsEmptyArrayWhenPromotionHasNoPackages(): void
+    {
+        $promotion = new CommunicationPromotions();
+        $this->repository->method('find')->willReturn($promotion);
+        $this->packageBindingService->method('listPromotionPackageBindings')->willReturn([]);
+
+        $response = $this->controller->listPackages(1);
+
+        $this->assertSame([], json_decode($response->getContent(), true));
     }
 
     private function v2Dto(): CreatePromotionV2Dto

--- a/tests/Functional/Controller/DashboardPromotionControllerBenefitsFunctionalTest.php
+++ b/tests/Functional/Controller/DashboardPromotionControllerBenefitsFunctionalTest.php
@@ -9,6 +9,7 @@ use App\Repository\CommunicationPackageRepository;
 use App\Repository\CommunicationPromotionsRepository;
 use App\Service\CommunicationPromotionService;
 use App\Service\Pricing\CommunicationContractService;
+use App\Service\Pricing\CommunicationPackageBindingService;
 use App\Service\Pricing\CommunicationPromotionBindingService;
 use App\Service\Pricing\CommunicationPromotionEquivalenceService;
 use App\Tests\Functional\Provider\ProviderFunctionalTestCase;
@@ -38,6 +39,7 @@ class DashboardPromotionControllerBenefitsFunctionalTest extends ProviderFunctio
             self::getContainer()->get(NormalizerInterface::class),
             self::getContainer()->get(CommunicationPromotionService::class),
             self::getContainer()->get(CommunicationPromotionBindingService::class),
+            self::getContainer()->get(CommunicationPackageBindingService::class),
             self::getContainer()->get(CommunicationPromotionEquivalenceService::class),
             self::getContainer()->get(CommunicationContractService::class),
         );
@@ -272,6 +274,76 @@ class DashboardPromotionControllerBenefitsFunctionalTest extends ProviderFunctio
         $this->assertCount(2, $packages);
         foreach ($packages as $package) {
             $this->assertSame(['quantity' => 15, 'unit' => 'DAYS'], $package->getValidity());
+        }
+    }
+
+    /**
+     * Round-trip completo del tab "Proveedores": crear promoción V2 (3
+     * paquetes) → editar packageNameTemplate/tags/displayOrder → releer con
+     * GET /promotions/{id}/packages y confirmar que cada paquete se
+     * renombró contra SU PROPIO destinationAmount (no un valor fijo) y que,
+     * sin ningún vínculo por proveedor todavía, missingProviders lista
+     * TODOS los proveedores registrados.
+     */
+    public function testListPackagesReflectsRenamedPackagesAndAllProvidersMissingBeforeAnyBinding(): void
+    {
+        $environment = $this->createEnvironment();
+
+        /** @var CommunicationPromotionService $promotionService */
+        $promotionService = self::getContainer()->get(CommunicationPromotionService::class);
+        $result = $promotionService->createV2(new CreatePromotionV2Dto(
+            name: 'Tab proveedores',
+            description: 'Tab proveedores',
+            packageNameTemplate: 'Promo {monto}',
+            packageDescriptionTemplate: 'Promo {monto}',
+            startAt: (new \DateTimeImmutable('-1 day'))->format('c'),
+            endAt: (new \DateTimeImmutable('+5 days'))->format('c'),
+            environmentId: $environment->getId(),
+            destinationCurrency: 'CUP',
+            // 3 paquetes: 100, 200, 300 CUP.
+            amountFrom: 100.0,
+            amountTo: 300.0,
+            amountStep: 100.0,
+        ));
+        $promotionId = $result->promotion->getId();
+        $this->em->clear();
+
+        $updateResponse = $this->controller()->update($promotionId, new UpdatePromotionDto(
+            packageNameTemplate: 'Cubacel {monto} CUP',
+            tags: ['BUNDLE'],
+            displayOrder: 3,
+        ));
+        $this->assertSame(200, $updateResponse->getStatusCode());
+        $this->em->clear();
+
+        $response = $this->controller()->listPackages($promotionId);
+        $this->assertSame(200, $response->getStatusCode());
+        $data = json_decode($response->getContent(), true);
+
+        $this->assertCount(3, $data);
+        usort($data, fn ($a, $b) => $a['destinationAmount'] <=> $b['destinationAmount']);
+        $this->assertSame(['Cubacel 100 CUP', 'Cubacel 200 CUP', 'Cubacel 300 CUP'], array_column($data, 'name'));
+
+        $registeredProviders = array_map(
+            static fn ($p) => $p->value,
+            self::getContainer()->get(\App\Provider\ProviderRegistry::class)->registered(),
+        );
+        foreach ($data as $row) {
+            $this->assertSame([], $row['bindings']);
+            $this->assertEqualsCanonicalizing($registeredProviders, $row['missingProviders']);
+        }
+
+        $this->em->clear();
+        /** @var CommunicationPackageRepository $packageRepository */
+        $packageRepository = self::getContainer()->get(CommunicationPackageRepository::class);
+        $packages = $packageRepository->createQueryBuilder('p')
+            ->andWhere('p.promotion = :promo')
+            ->setParameter('promo', $promotionId)
+            ->getQuery()
+            ->getResult();
+        foreach ($packages as $package) {
+            $this->assertSame(['BUNDLE'], $package->getTags());
+            $this->assertSame(3, $package->getDisplayOrder());
         }
     }
 }

--- a/tests/Provider/Etecsa/EtecsaCommunicationProviderTest.php
+++ b/tests/Provider/Etecsa/EtecsaCommunicationProviderTest.php
@@ -14,10 +14,14 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
+ * @covers \App\Provider\Etecsa\EtecsaCommunicationProvider::fetchProducts
  * @covers \App\Provider\Etecsa\EtecsaCommunicationProvider::fetchPromotionProducts
  *
- * Cubre solo fetchPromotionProducts() (Fase 5C) — ETECSA no tiene concepto
- * de "promoción" propio, delega en fetchProducts() sin filtrar.
+ * fetchPromotionProducts() (Fase 5C) delega en fetchProducts() sin filtrar
+ * — ETECSA no tiene concepto de "promoción" propio. Los casos de
+ * fetchProducts() de abajo cierran el hueco de cobertura directa que tenía
+ * este proveedor frente a CSQ/DTOne (que sí prueban productTypeRaw,
+ * wholesalePrice, validFrom/validTo y el guard de items sin Id).
  */
 class EtecsaCommunicationProviderTest extends TestCase
 {
@@ -55,5 +59,79 @@ class EtecsaCommunicationProviderTest extends TestCase
         $this->assertSame('100', $products[0]->externalId);
         // Producto de monto flexible — igual que fetchProducts() normal.
         $this->assertNull($products[0]->destinationAmount);
+    }
+
+    public function testFetchProductsMapsTypeWholesalePriceAndValidityWindow(): void
+    {
+        $environment = $this->createMock(Environment::class);
+        $this->environmentRepository->method('find')->with(4)->willReturn($environment);
+
+        $this->client->method('listPackages')->with($environment)->willReturn([
+            [
+                'Id' => 200,
+                'Description' => 'Recarga Cubacel',
+                'PackageType' => 'RECHARGE',
+                'Price' => 150.5,
+                'Enabled' => true,
+                'InitialDate' => '2026-08-18T00:00:00+00:00',
+                'FinalDate' => '2026-08-25T23:59:00+00:00',
+            ],
+        ]);
+
+        $context = new ProviderContext(provider: CommunicationProviderEnum::ETECSA, environmentType: 'TEST', environmentId: 4);
+        $products = iterator_to_array($this->provider->fetchProducts($context));
+
+        $this->assertCount(1, $products);
+        $product = $products[0];
+        $this->assertSame('200', $product->externalId);
+        $this->assertSame('Recarga Cubacel', $product->name);
+        $this->assertSame('Recarga Cubacel', $product->description);
+        $this->assertSame('RECHARGE', $product->productTypeRaw);
+        $this->assertSame(150.5, $product->wholesalePrice);
+        $this->assertTrue($product->enabled);
+        $this->assertEquals(new \DateTimeImmutable('2026-08-18T00:00:00+00:00'), $product->validFrom);
+        $this->assertEquals(new \DateTimeImmutable('2026-08-25T23:59:00+00:00'), $product->validTo);
+        $this->assertTrue($product->isMobileOrInternetService);
+        $this->assertSame(['name' => 'MOBILE', 'subservice' => ['name' => 'AIRTIME']], $product->service);
+    }
+
+    public function testFetchProductsDefaultsDisabledAndUnboundedValidityWhenFieldsAreMissing(): void
+    {
+        $environment = $this->createMock(Environment::class);
+        $this->environmentRepository->method('find')->with(4)->willReturn($environment);
+
+        // Sin Enabled/InitialDate/FinalDate/PackageType/Price — el mapeo no
+        // debe romper, solo caer a sus defaults (false/null/''/0.0).
+        $this->client->method('listPackages')->with($environment)->willReturn([
+            ['Id' => 300, 'Description' => 'Sin metadata extra'],
+        ]);
+
+        $context = new ProviderContext(provider: CommunicationProviderEnum::ETECSA, environmentType: 'TEST', environmentId: 4);
+        $products = iterator_to_array($this->provider->fetchProducts($context));
+
+        $this->assertCount(1, $products);
+        $product = $products[0];
+        $this->assertSame('', $product->productTypeRaw);
+        $this->assertSame(0.0, $product->wholesalePrice);
+        $this->assertFalse($product->enabled);
+        $this->assertNull($product->validFrom);
+        $this->assertNull($product->validTo);
+    }
+
+    public function testFetchProductsSkipsItemsWithoutId(): void
+    {
+        $environment = $this->createMock(Environment::class);
+        $this->environmentRepository->method('find')->with(4)->willReturn($environment);
+
+        $this->client->method('listPackages')->with($environment)->willReturn([
+            ['Description' => 'Sin Id, debe ignorarse'],
+            ['Id' => 400, 'Description' => 'Con Id, sí se mapea'],
+        ]);
+
+        $context = new ProviderContext(provider: CommunicationProviderEnum::ETECSA, environmentType: 'TEST', environmentId: 4);
+        $products = iterator_to_array($this->provider->fetchProducts($context));
+
+        $this->assertCount(1, $products);
+        $this->assertSame('400', $products[0]->externalId);
     }
 }

--- a/tests/Service/CommunicationPromotionServiceV2Test.php
+++ b/tests/Service/CommunicationPromotionServiceV2Test.php
@@ -269,22 +269,124 @@ class CommunicationPromotionServiceV2Test extends TestCase
         $this->assertSame(3, $count);
     }
 
-    public function testUpdatePackageBenefitsThrowsForAV1Promotion(): void
+    /**
+     * El dashboard ya no distingue "V1"/"V2" al editar — una promoción sin
+     * ningún CommunicationPackage vinculado (ej. una promoción legacy,
+     * product != null) simplemente no tiene nada que actualizar: no-op
+     * seguro, nunca un error.
+     */
+    public function testUpdatePackageBenefitsIsANoOpForAPromotionWithoutLinkedPackages(): void
     {
-        // Una promoción V1 tiene product != null (isV2() = product === null)
-        // — createV2()/dto() de este test solo generan V2, así que se
-        // construye directo con reflection en vez de un DTO legacy.
         $promotion = new CommunicationPromotions();
         $reflection = new \ReflectionProperty(CommunicationPromotions::class, 'product');
         $reflection->setAccessible(true);
         $reflection->setValue($promotion, $this->createMock(\App\Entity\CommunicationProduct::class));
+        $this->packageRepository->method('findByPromotion')->with($promotion)->willReturn([]);
 
         $this->packageAdminService->expects($this->never())->method('update');
 
-        $this->expectException(MyCurrentException::class);
-        $this->expectExceptionMessage('Esta promoción no es V2 — los beneficios se editan con terms, no benefits');
+        $count = $this->service->updatePackageBenefits($promotion, [['type' => 'CREDITS']]);
 
-        $this->service->updatePackageBenefits($promotion, [['type' => 'CREDITS']]);
+        $this->assertSame(0, $count);
+    }
+
+    /**
+     * Round-trip de los campos V2 de UpdatePromotionDto (cargar → editar →
+     * volver a leer) — el test que faltaba en el bug de 2026-08-27 (ver
+     * CLAUDE.md regla 12): packageNameTemplate/packageDescriptionTemplate
+     * se renderizan por paquete contra su propio destinationAmount, igual
+     * que al crear el batch original.
+     */
+    public function testUpdatePropagatesNameAndDescriptionTemplatesRenderedPerPackage(): void
+    {
+        $promotion = $this->v2Promotion();
+        $package500 = (new CommunicationPackage())->setDestinationAmount(500.0);
+        $package1000 = (new CommunicationPackage())->setDestinationAmount(1000.0);
+        $this->packageRepository->method('findByPromotion')->with($promotion)->willReturn([$package500, $package1000]);
+        $this->packageAdminService->method('renderTemplate')
+            ->willReturnCallback(fn (string $template, float $amount) => str_replace('{monto}', (string) (int) $amount, $template));
+
+        $calls = [];
+        $this->packageAdminService->expects($this->exactly(2))
+            ->method('update')
+            ->willReturnCallback(function ($package, UpdateCommunicationPackageDto $dto) use (&$calls) {
+                $calls[] = [$dto->getName(), $dto->getDescription()];
+
+                return $package;
+            });
+
+        $dto = new \App\DTO\UpdatePromotionDto(packageNameTemplate: 'Cubacel {monto} CUP', packageDescriptionTemplate: 'Recarga {monto} CUP');
+        $this->service->update($promotion, $dto);
+
+        $this->assertSame([
+            ['Cubacel 500 CUP', 'Recarga 500 CUP'],
+            ['Cubacel 1000 CUP', 'Recarga 1000 CUP'],
+        ], $calls);
+    }
+
+    public function testUpdatePropagatesTagsServiceAndDisplayOrderToEveryLinkedPackage(): void
+    {
+        $promotion = $this->v2Promotion();
+        $packages = [new CommunicationPackage(), new CommunicationPackage()];
+        $this->packageRepository->method('findByPromotion')->with($promotion)->willReturn($packages);
+
+        $this->packageAdminService->expects($this->exactly(2))
+            ->method('update')
+            ->with(
+                $this->isInstanceOf(CommunicationPackage::class),
+                $this->callback(fn (UpdateCommunicationPackageDto $dto) => $dto->getTags() === ['DATA']
+                    && $dto->getService() === ['name' => 'Mobile', 'subservice' => ['name' => 'DATA']]
+                    && $dto->getDisplayOrder() === 5)
+            );
+
+        $dto = new \App\DTO\UpdatePromotionDto(
+            tags: ['DATA'],
+            service: ['name' => 'Mobile', 'subservice' => ['name' => 'DATA']],
+            displayOrder: 5,
+        );
+        $this->service->update($promotion, $dto);
+    }
+
+    public function testUpdateMetadataFieldsIsANoOpForAPromotionWithoutLinkedPackages(): void
+    {
+        $promotion = new CommunicationPromotions();
+        $reflection = new \ReflectionProperty(CommunicationPromotions::class, 'product');
+        $reflection->setAccessible(true);
+        $reflection->setValue($promotion, $this->createMock(\App\Entity\CommunicationProduct::class));
+        $this->packageRepository->method('findByPromotion')->with($promotion)->willReturn([]);
+
+        $this->packageAdminService->expects($this->never())->method('update');
+
+        $result = $this->service->update($promotion, new \App\DTO\UpdatePromotionDto(tags: ['DATA']));
+
+        $this->assertSame($promotion, $result);
+    }
+
+    /**
+     * El rango [amountFrom, amountTo, amountStep] + destinationCurrency
+     * define qué paquetes existen — cambiarlo tras crear la promoción
+     * invalidaría los vínculos por proveedor ya hechos. No se ignora en
+     * silencio (ese es justo el patrón de pérdida de datos que motivó la
+     * regla de TDD, ver CLAUDE.md): se rechaza con 400 explícito.
+     */
+    public function testUpdateRejectsRangeFieldsAsImmutable(): void
+    {
+        $promotion = $this->v2Promotion();
+        $this->em->expects($this->never())->method('flush');
+
+        $this->expectException(MyCurrentException::class);
+        $this->expectExceptionMessage('rango');
+
+        $this->service->update($promotion, new \App\DTO\UpdatePromotionDto(amountFrom: 600.0));
+    }
+
+    public function testUpdateRejectsDestinationCurrencyAsImmutable(): void
+    {
+        $promotion = $this->v2Promotion();
+
+        $this->expectException(MyCurrentException::class);
+
+        $this->service->update($promotion, new \App\DTO\UpdatePromotionDto(destinationCurrency: 'USD'));
     }
 
     private function v2Promotion(): CommunicationPromotions

--- a/tests/Service/Pricing/CommunicationPackageBindingServiceTest.php
+++ b/tests/Service/Pricing/CommunicationPackageBindingServiceTest.php
@@ -5,11 +5,13 @@ namespace App\Tests\Service\Pricing;
 use App\Entity\CommunicationPackage;
 use App\Entity\CommunicationPackageProviderProduct;
 use App\Entity\CommunicationProduct;
+use App\Entity\CommunicationPromotions;
 use App\Enums\CommunicationProviderEnum;
 use App\Exception\MyCurrentException;
 use App\Provider\Contract\CommunicationProviderInterface;
 use App\Provider\ProviderRegistry;
 use App\Repository\CommunicationPackageProviderProductRepository;
+use App\Repository\CommunicationPackageRepository;
 use App\Repository\CommunicationProductRepository;
 use App\Service\Pricing\CommunicationPackageBindingService;
 use Doctrine\ORM\EntityManagerInterface;
@@ -29,6 +31,7 @@ class CommunicationPackageBindingServiceTest extends TestCase
     private EntityManagerInterface&MockObject $em;
     private CommunicationPackageProviderProductRepository&MockObject $bindingRepo;
     private CommunicationProductRepository&MockObject $productRepository;
+    private CommunicationPackageRepository&MockObject $packageRepository;
     private CommunicationPackageBindingService $service;
 
     protected function setUp(): void
@@ -36,11 +39,13 @@ class CommunicationPackageBindingServiceTest extends TestCase
         $this->em = $this->createMock(EntityManagerInterface::class);
         $this->bindingRepo = $this->createMock(CommunicationPackageProviderProductRepository::class);
         $this->productRepository = $this->createMock(CommunicationProductRepository::class);
+        $this->packageRepository = $this->createMock(CommunicationPackageRepository::class);
 
         $this->service = new CommunicationPackageBindingService(
             $this->em,
             $this->bindingRepo,
             $this->productRepository,
+            $this->packageRepository,
             $this->providerRegistry([CommunicationProviderEnum::ETECSA, CommunicationProviderEnum::CSQ]),
         );
     }
@@ -202,5 +207,49 @@ class CommunicationPackageBindingServiceTest extends TestCase
         $this->em->expects($this->never())->method('flush');
 
         $this->service->removeBinding($package, 'CSQ');
+    }
+
+    public function testListPromotionPackageBindingsReturnsOneRowPerPackageWithMissingProviders(): void
+    {
+        $promotion = $this->createMock(CommunicationPromotions::class);
+        $package = $this->package();
+        $this->packageRepository->method('findByPromotion')->with($promotion)->willReturn([$package]);
+
+        $product = $this->createMock(CommunicationProduct::class);
+        $binding = $this->createMock(CommunicationPackageProviderProduct::class);
+        $binding->method('getProvider')->willReturn('CSQ');
+        $binding->method('getProduct')->willReturn($product);
+        $this->bindingRepo->method('findAllForPackage')->with($package)->willReturn([$binding]);
+
+        $rows = $this->service->listPromotionPackageBindings($promotion);
+
+        $this->assertCount(1, $rows);
+        $this->assertSame($package, $rows[0]['package']);
+        $this->assertSame([['provider' => 'CSQ', 'product' => $product]], $rows[0]['bindings']);
+        // El registro de setUp() tiene ETECSA y CSQ — solo CSQ está vinculado.
+        $this->assertSame(['ETECSA'], $rows[0]['missingProviders']);
+    }
+
+    public function testListPromotionPackageBindingsMarksAllProvidersMissingWhenPackageHasNoBindings(): void
+    {
+        $promotion = $this->createMock(CommunicationPromotions::class);
+        $package = $this->package();
+        $this->packageRepository->method('findByPromotion')->willReturn([$package]);
+        $this->bindingRepo->method('findAllForPackage')->willReturn([]);
+
+        $rows = $this->service->listPromotionPackageBindings($promotion);
+
+        $this->assertSame([], $rows[0]['bindings']);
+        $this->assertSame(['ETECSA', 'CSQ'], $rows[0]['missingProviders']);
+    }
+
+    public function testListPromotionPackageBindingsReturnsEmptyArrayWhenPromotionHasNoPackages(): void
+    {
+        $promotion = $this->createMock(CommunicationPromotions::class);
+        $this->packageRepository->method('findByPromotion')->willReturn([]);
+
+        $rows = $this->service->listPromotionPackageBindings($promotion);
+
+        $this->assertSame([], $rows);
     }
 }


### PR DESCRIPTION
## Summary
- Nuevo endpoint `GET /promotions/{id}/packages`: cobertura por proveedor de los paquetes generados por una promoción V2 (qué proveedores tienen producto vinculado y cuáles faltan).
- `UpdatePromotionDto` acepta `packageNameTemplate`/`packageDescriptionTemplate`/`tags`/`service`/`displayOrder` y rechaza cambios al rango de montos (inmutable tras crear la promoción).
- `CommunicationPromotionService::update()` ya no distingue el origen de la promoción para aceptar `benefits`/metadata de paquete — una promoción sin paquetes generados simplemente no tiene nada que actualizar (no-op seguro), en vez de un error 400.
- Cierra el hueco de cobertura directa de `EtecsaCommunicationProvider::fetchProducts()`.

## Test plan
- [x] `php bin/phpunit --no-coverage` — 1159/1159 en verde
- [x] `vendor/bin/phpstan analyse` — sin errores
- [x] Round-trip verificado contra Postgres real (crear promoción V2 → editar metadata de paquete → releer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)